### PR TITLE
Let show_components override display units for Vector-form columns

### DIFF
--- a/src/InfrastructureSystems.jl
+++ b/src/InfrastructureSystems.jl
@@ -156,7 +156,8 @@ using .RelativeUnits:
     DU,
     SU,
     NU,
-    display_units_arg
+    display_units_arg,
+    unitful_variant
 # Names not exported from the submodule are pulled in explicitly so the
 # `IS._strip_units(...)` / `IS.convert_cost_coefficient(...)` call sites work.
 using .RelativeUnits: _strip_units, convert_cost_coefficient

--- a/src/relative_units.jl
+++ b/src/relative_units.jl
@@ -19,6 +19,7 @@ export DeviceBaseUnit, SystemBaseUnit, NaturalUnit
 export RelativeQuantity
 export DU, SU, NU
 export display_units_arg
+export unitful_variant
 
 """
 Supertype for all unit-system markers (relative and natural). Used as the
@@ -345,5 +346,26 @@ like `show_components` dispatch on the result to avoid runtime method
 introspection.
 """
 display_units_arg(_, ::Type) = missing
+
+"""
+    unitful_variant(f::Function)
+
+Resolve the unit-bearing companion of getter `f` — a function returning the
+same value but unit-tagged (a `RelativeQuantity` or a domain `Unitful.Quantity`)
+instead of a bare number — following the `\$(f)_unitful` naming convention the
+struct-generator template emits alongside every converted getter (see
+`generate_structs.jl`). Falls back to `f` itself when no such companion exists
+(hand-written getters that don't provide one). Display/tabular code should
+resolve through this trait rather than re-deriving the naming convention.
+"""
+function unitful_variant(f::Function)
+    name = Symbol(string(nameof(f)), "_unitful")
+    mod = parentmodule(f)
+    # `isdefined`, not `hasproperty`: the latter is backed by `propertynames`,
+    # which for a `Module` defaults to only its *exported* names, and a
+    # `_unitful` companion need not be exported to be a valid resolution
+    # target.
+    return isdefined(mod, name) ? getproperty(mod, name) : f
+end
 
 end # module RelativeUnits

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -79,9 +79,12 @@ end
 # of `(column, getter_func, arg)` tuples. The getter logic enables application of system
 # units in PowerSystems through its getter functions. Dict-form `additional_columns`
 # carry their own accessor closures, so there is nothing to resolve (returns `nothing`).
-_resolve_column_accessors(::Type, ::Dict) = nothing
+# `units`, when given, overrides every column's own `display_units_arg` trait — but
+# never forces a units argument onto a getter that doesn't accept one (`ismissing`
+# trait fields, e.g. `get_name`, are left as plain 1-arg calls).
+_resolve_column_accessors(::Type, ::Dict; units = nothing) = nothing
 
-function _resolve_column_accessors(component_type::Type, additional_columns::Vector)
+function _resolve_column_accessors(component_type::Type, additional_columns::Vector; units = nothing)
     parent = parentmodule(component_type)
     return map(additional_columns) do column
         getter_name = Symbol("get_$column")
@@ -90,12 +93,16 @@ function _resolve_column_accessors(component_type::Type, additional_columns::Vec
         else
             nothing
         end
-        arg = if getter_func === nothing
-            missing
-        else
-            display_units_arg(getter_func, component_type)
+        if getter_func === nothing
+            return (column, nothing, missing)
         end
-        (column, getter_func, arg)
+        trait_arg = display_units_arg(getter_func, component_type)
+        ismissing(trait_arg) && return (column, getter_func, missing)
+        arg = units === nothing ? trait_arg : units
+        # Route through the unit-tagged companion (e.g. `get_rating_unitful`)
+        # so unit-converted columns print with an explicit unit suffix, not a
+        # bare number.
+        (column, unitful_variant(getter_func), arg)
     end
 end
 
@@ -117,11 +124,21 @@ function _populate_column_value(component, column, getter_func, arg)
     return val
 end
 
+"""
+    show_components(io, components, component_type, additional_columns = []; units = nothing, kwargs...)
+
+Vector-form `additional_columns` accepts `units` (e.g. `SU`, `DU`, or a
+domain-provided unit like `MW`) to force every unit-converted column to
+display in that unit system instead of each column's own `display_units_arg`
+default. Ignored for `Dict`-form `additional_columns`, whose closures compute
+their own values.
+"""
 function show_components(
     io::IO,
     components::Components,
     component_type::Type{<:InfrastructureSystemsComponent},
     additional_columns::Union{Dict, Vector} = [];
+    units = nothing,
     kwargs...,
 )
     if !isconcretetype(component_type)
@@ -150,7 +167,8 @@ function show_components(
     data = Array{Any, 2}(undef, length(comps), length(column_labels))
 
     # Resolve each column's getter and units argument once, not per cell.
-    column_accessors = _resolve_column_accessors(component_type, additional_columns)
+    column_accessors =
+        _resolve_column_accessors(component_type, additional_columns; units = units)
 
     for (i, component) in enumerate(comps)
         data[i, 1] = get_name(component)

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -84,7 +84,11 @@ end
 # trait fields, e.g. `get_name`, are left as plain 1-arg calls).
 _resolve_column_accessors(::Type, ::Dict; units = nothing) = nothing
 
-function _resolve_column_accessors(component_type::Type, additional_columns::Vector; units = nothing)
+function _resolve_column_accessors(
+    component_type::Type,
+    additional_columns::Vector;
+    units = nothing,
+)
     parent = parentmodule(component_type)
     return map(additional_columns) do column
         getter_name = Symbol("get_$column")

--- a/src/utils/test.jl
+++ b/src/utils/test.jl
@@ -56,6 +56,14 @@ get_val(component::TestComponent) = component.val
 get_val(component::TestComponent, _) = component.val
 get_val2(component::TestComponent) = component.val2
 get_val2(component::TestComponent, _) = component.val2
+
+# Exercises the `display_units_arg`/`unitful_variant` machinery in
+# `show_components` tests without needing a domain-specific unit system:
+# `get_val_unitful` tags the bare `Int` with whatever units argument it was
+# called with instead of returning a bare number.
+InfrastructureSystems.display_units_arg(::typeof(get_val), ::Type{TestComponent}) = SU
+get_val_unitful(component::TestComponent, units) = "$(component.val) $(units)"
+export get_val, get_val_unitful
 supports_time_series(::TestComponent) = true
 supports_time_series(::AdditionalTestComponent) = true
 supports_time_series(::SimpleTestComponent) = false

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -60,6 +60,44 @@ end
     @test occursin("GeographicInfo", text)
 end
 
+@testset "Test show_components units resolution for Vector columns" begin
+    sys = create_system_data(; with_time_series = true, time_series_in_memory = true)
+    io = IOBuffer()
+
+    # No override: resolves the column's own `display_units_arg` trait (SU)
+    # through its `_unitful` companion, so the cell prints a unit suffix
+    # rather than a bare number.
+    IS.show_components(io, sys.components, IS.TestComponent, [:val])
+    text = String(take!(io))
+    @test occursin("SU", text)
+
+    # An explicit `units` override wins over the trait default.
+    IS.show_components(io, sys.components, IS.TestComponent, [:val]; units = IS.DU)
+    text = String(take!(io))
+    @test occursin("DU", text)
+    @test !occursin(r"\bSU\b", text)
+
+    # Column order is preserved (not alphabetized) for Vector-form columns,
+    # and `val2` (no units trait) is left as a bare, unsuffixed value.
+    IS.show_components(io, sys.components, IS.TestComponent, [:val2, :val])
+    text = String(take!(io))
+    val2_pos = findfirst("val2", text)
+    val_pos = findfirst(r"\bval\b", text)
+    @test !isnothing(val2_pos) && !isnothing(val_pos)
+    @test first(val2_pos) < first(val_pos)
+
+    # `units` is ignored (not an error) for Dict-form additional_columns.
+    IS.show_components(
+        io,
+        sys.components,
+        IS.TestComponent,
+        Dict("val" => x -> x.val * 10);
+        units = IS.DU,
+    )
+    text = String(take!(io))
+    @test occursin("val", text)
+end
+
 @testset "Test printing of internal" begin
     sys = create_system_data(;
         time_series_in_memory = true,


### PR DESCRIPTION
## Summary
- Adds an `IS.unitful_variant(f)` trait that resolves a getter's unit-tagged `_unitful` companion by the struct-generator's naming convention (falls back to `f` when no companion is registered).
- Threads an optional `units` kwarg through `show_components`/`_resolve_column_accessors` so callers can force every Vector-form column into one unit system instead of resolving each column's own `display_units_arg` default.
- Vector-form columns whose getter has a units trait now route through `unitful_variant` so cells print with an explicit unit suffix (e.g. `"5 SU"`), matching the Dict-form behavior domain packages already build with closures.

## Motivation
PowerSystems (psy6, see the units-management rework) needed a `show_components(sys, T, [:field, ...]; units = MW)` API that both (a) forces a caller-chosen unit system across all columns and (b) prints unit-tagged values, not bare numbers. Neither capability existed on IS's Vector-column path, so PSY reimplemented ~35 lines of `show_components`'s table-building logic (column labels, the `comps`/`data` loop, the `pretty_table` call) just to get them. This PR moves both capabilities into IS so PSY (and other domain packages) can go back to a thin forwarding wrapper.

## Test plan
- [x] `julia --project=test test/runtests.jl` (IS): 8672 tests, 0 failures
- [x] New `test/test_printing.jl` testset covers: trait-default resolution with unit suffix, explicit `units` override, Vector column order preservation, `units` silently ignored for Dict-form columns
- [x] Downstream (PowerSystems, pinned via `[sources]` to this branch): `test/runtests.jl test_printing` — 74 passed, 0 failed (1 unrelated pre-existing `PowerSystemCaseBuilder` data-build failure, reproduced identically against `IS4` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)