### PR TITLE
Fix broken @extref links breaking the docs build

### DIFF
--- a/docs/src/docs_best_practices/how-to/troubleshoot.md
+++ b/docs/src/docs_best_practices/how-to/troubleshoot.md
@@ -82,7 +82,7 @@ Pkg.add(["PowerSystems"]);
      2. Run the formatter once to format the rest of the file
      3. Add the text back in
      4. Add the `ignore` keyword argument with the file name to
-        [`JuliaFormatter.format`](@extref `JuliaFormatter.format-Tuple{Any}`) in `scripts/formatter/formatter_code.jl`
+        [`JuliaFormatter.format`](@extref JuliaFormatter.format) in `scripts/formatter/formatter_code.jl`
         to skip the file in the future:
 
 ```julia

--- a/docs/src/docs_best_practices/how-to/write_a_tutorial.md
+++ b/docs/src/docs_best_practices/how-to/write_a_tutorial.md
@@ -10,7 +10,7 @@ Sienna.
     the [difference between a tutorial and how-to guide](https://diataxis.fr/tutorials-how-to/)
     to refresh your memory and refer back throughout the process.
   - Look at an example: `PowerSystems.jl`'s
-    [Working with Time Series](https://sienna-platform.github.io/PowerSystems.jl/stable/tutorials/working_with_time_series/)
+    [Working with Time Series](@extref PowerSystems :doc:`tutorials/generated_working_with_time_series`)
 
 !!! warning
     
@@ -56,7 +56,7 @@ code blocks.
 !!! tip "Do"
     
     Display all code, starting from `using SomeSiennaPackage`. Example: See
-    [Working with Time Series](@extref tutorial_time_series).
+    [Working with Time Series](@extref PowerSystems :doc:`tutorials/generated_working_with_time_series`).
 
 !!! warning "Don't"
     


### PR DESCRIPTION
## Problem

The `Documentation` CI job has been failing on `main` since [run 27879924041](https://github.com/Sienna-Platform/InfrastructureSystems.jl/actions/runs/27879924041) (2026-06-20), and on every open PR branch as a result. Two `@extref` (DocumenterInterLinks) references no longer resolve against the upstream inventories, and `makedocs` treats `:external_cross_references` as fatal:

```
ERROR: LoadError: `makedocs` encountered an error [:external_cross_references] -- terminating build before rendering.
```

Because the failure happens in the external-link phase, the build terminates before rendering — nothing else in the CI log is a real signal.

## Cause and fix

| File | Was | Why it broke | Now |
| --- | --- | --- | --- |
| `docs_best_practices/how-to/troubleshoot.md` | ``@extref `JuliaFormatter.format-Tuple{Any}` `` | JuliaFormatter's inventory registers `format` as a `jl:function` with no signature suffix | `@extref JuliaFormatter.format` |
| `docs_best_practices/how-to/write_a_tutorial.md` | `@extref tutorial_time_series` | PowerSystems renamed the page (Literate-generated now), dropping the label | ``@extref PowerSystems :doc:`tutorials/generated_working_with_time_series` `` |

Also converts a hard-coded URL to that same PowerSystems tutorial (`write_a_tutorial.md:13`) into an `@extref`. It currently 404s for the same rename reason — Documenter doesn't linkcheck it, so it wasn't a build failure, just a dead link. `general_formatting.md` in this same guide tells authors to prefer `@extref` over hard-coded URLs.

## Verification

`julia --project=docs docs/make.jl` exits 0 with zero `cannot resolve external link` errors. Confirmed the rendered HTML points at live URLs:

- `https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/api/#JuliaFormatter.format`
- `https://sienna-platform.github.io/PowerSystems.jl/stable/tutorials/generated_working_with_time_series/`

Remaining build warnings (unbalanced `$` in `InfrastructureSystems.md`, the page-size warning) are pre-existing and non-fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)