### PR TITLE
Emit units-aware constructors in the struct generator

### DIFF
--- a/src/utils/generate_structs.jl
+++ b/src/utils/generate_structs.jl
@@ -41,12 +41,14 @@ end
 
 {{#needs_positional_constructor}}
 function {{constructor_func}}({{#parameters}}{{^internal_default}}{{name}}{{#default}}={{default}}{{/default}}, {{/internal_default}}{{/parameters}}){{{closing_constructor_text}}}
-    {{constructor_func}}({{#parameters}}{{^internal_default}}{{name}}, {{/internal_default}}{{/parameters}}{{#parameters}}{{#internal_default}}{{{internal_default}}}, {{/internal_default}}{{/parameters}})
+    {{#has_conversions}}_construction_fields = ({{#parameters}}{{^internal_default}}{{name}} = {{name}}, {{/internal_default}}{{/parameters}})
+    {{/has_conversions}}{{constructor_func}}({{#parameters}}{{^internal_default}}{{{constructor_value}}}, {{/internal_default}}{{/parameters}}{{#parameters}}{{#internal_default}}{{{internal_default}}}, {{/internal_default}}{{/parameters}})
 end
 {{/needs_positional_constructor}}
 
 function {{constructor_func}}(; {{#parameters}}{{name}}{{#kwarg_value}}{{{kwarg_value}}}{{/kwarg_value}}, {{/parameters}}){{{closing_constructor_text}}}
-    {{constructor_func}}({{#parameters}}{{name}}, {{/parameters}})
+    {{#has_conversions}}_construction_fields = ({{#parameters}}{{^internal_default}}{{name}} = {{name}}, {{/internal_default}}{{/parameters}})
+    {{/has_conversions}}{{constructor_func}}({{#parameters}}{{{constructor_value}}}, {{/parameters}})
 end
 
 {{#has_null_values}}
@@ -157,6 +159,23 @@ function generate_structs(directory, data::Vector; print_results = true)
             accessor_name = accessor_module * "get_" * param["name"]
             setter_name = accessor_module * "set_" * param["name"] * "!"
             conversion_unit = get(param, "conversion_unit", "nothing")
+            # `construct_value` (defined downstream) creates a temporary component.
+            # That way we can convert user input to DU via existing machinery:
+            # just call `get_foo!(temp, DU)`. raw float, no units attached -> assume DU. 
+            # `_construction_fields` collects user-provided conversion fields (base power).
+            param["constructor_value"] = if get(param, "needs_conversion", false)
+                string(
+                    "construct_value(",
+                    item["constructor_func"],
+                    ", _construction_fields, Val(:",
+                    param["name"],
+                    "), Val(",
+                    conversion_unit,
+                    "))",
+                )
+            else
+                param["name"]
+            end
             include_getter = !get(param, "exclude_getter", false)
             if include_getter
                 push!(
@@ -258,6 +277,10 @@ function generate_structs(directory, data::Vector; print_results = true)
         item["parameters"] = parameters
         item["accessors"] = accessors
         item["setters"] = setters
+        # Only structs with unit-bearing fields pay for the `_construction_fields`
+        # binding in their constructors.
+        item["has_conversions"] =
+            any(x -> get(x, "needs_conversion", false), parameters)
         # If all parameters have defaults then the positional constructor will
         # collide with the kwarg constructor.
         item["needs_positional_constructor"] = has_internal && has_non_default_values


### PR DESCRIPTION
Lets a component be constructed with unit-tagged values (`50.0u"MW"`, `0.5 * DU`) while it is detached from a system, per [PowerSystems.jl#1115](https://github.com/NREL-Sienna/PowerSystems.jl/issues/1115). Pairs with the PowerSystems.jl PR that implements the domain side.

Claude came up with a better solution than the one I suggested there: **create a temporary struct in the constructor, specifically so that we can convert user input to device base** using the existing infrastructure.

## What the template now emits

For every struct with at least one `needs_conversion` field, both generated constructors bind the arguments into a NamedTuple and route each unit-bearing field through a domain-provided hook:

```julia
function ThermalStandard(name, available, ..., base_power, ...)
    _construction_fields = (name = name, available = available, ..., base_power = base_power, )
    ThermalStandard(name, available, status, bus,
        construct_value(ThermalStandard, _construction_fields, Val(:active_power), Val(:mva)),
        ...)
end
```

`construct_value` then performs the conversion, via creating a temporary struct that has its conversion base as `base_power`. `construct_value` is resolved in the generating module, exactly like the `get_value` / `set_value` the accessors already emit. PowerSystems implements it.

Three details worth review:

- **The keyword constructor needed the same treatment, not just forwarding.** It passes `internal`, so it calls the default all-fields constructor rather than the positional one — emitting the conversion only in the positional constructor would silently skip the kwarg path.
- **Gated on a new per-item `has_conversions` flag**, so structs with no unit-bearing fields generate byte-identically to before. In PowerSystems only 39 of ~210 structs are affected.
- **`constructor_value` is precomputed per parameter in Julia** rather than expressed as nested Mustache sections, which keeps the template readable.

## Verification

- PowerSystems.jl full suite against this branch: **8165 pass, 0 fail**, including `test_generate_structs` (descriptor ↔ generated consistency) after regenerating all 40 affected files.
- Measured on real components: conversion costs ~5 ns and 0 bytes per field, and constructors stay fully type-inferred. Untagged and `MW`-tagged construction are indistinguishable; both are at or below the current baseline, which is dominated by `InfrastructureSystemsInternal()`'s uuid4.

  | | ns | allocs |
  |---|---|---|
  | `ThermalStandard` positional, untagged | 1154 | 6 |
  | `ThermalStandard` positional, `MW` | 1150 | 6 |
  | `ThermalStandard` kwarg, untagged | 1221 | 8 |

- The IS test suite fails at load on `test/optimization.jl:19` (`convert_output_to_natural_units` not defined in `IS.Optimization`). This is pre-existing on `IS4` — it fails identically with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)