### PR TITLE
Spell per-unit tags out for display; per-column table units

### DIFF
--- a/src/InfrastructureSystems.jl
+++ b/src/InfrastructureSystems.jl
@@ -160,7 +160,8 @@ using .RelativeUnits:
     SU,
     NU,
     display_units_arg,
-    unitful_variant
+    unitful_variant,
+    display_string
 # Names not exported from the submodule are pulled in explicitly so the
 # `IS._strip_units(...)` / `IS.convert_cost_coefficient(...)` call sites work.
 using .RelativeUnits: _strip_units, convert_cost_coefficient

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -8,7 +8,7 @@ Unit system for component data values.
 
 # Values
 - `SYSTEM_BASE`: Per-unit values on the system base power
-- `DEVICE_BASE`: Per-unit values on the device base power
+- `DEVICE_BASE`: Per-unit values on the component base power
 - `NATURAL_UNITS`: Values in natural units (e.g., MW, MVAR)
 """ UnitSystem
 

--- a/src/relative_units.jl
+++ b/src/relative_units.jl
@@ -1,7 +1,7 @@
 ###############################
 # Relative (per-unit) markers and RelativeQuantity wrapper.
 #
-# These types are domain-agnostic — they express "device base" / "system base"
+# These types are domain-agnostic — they express "component base" / "system base"
 # / "natural unit" without assuming any particular physical domain. Downstream
 # packages (e.g. PowerSystems) attach domain-specific meaning via categories
 # and conversions.
@@ -64,7 +64,7 @@ A quantity tagged with a per-unit marker.
 
 # Examples
 ```julia
-0.6 * DU  # 0.6 per-unit on device base
+0.6 * DU  # 0.6 per-unit on component base
 0.3 * SU  # 0.3 per-unit on system base
 ```
 """
@@ -245,7 +245,7 @@ Base.show(io::IO, ::NaturalUnit) = print(io, "NU")
     display_string(x) -> String
 
 Render `x` for human-facing display, spelling relative-unit tags out in full
-("0.6 p.u. in device base") where `show` prints the terse "0.6 DU". `DU`/`SU`
+("0.6 p.u. in component base") where `show` prints the terse "0.6 DU". `DU`/`SU`
 are convenient to type but are not standard terminology, so verbose output
 (e.g. a component's `text/plain` display) spells them out; terse contexts such
 as tabular cells keep the short tags.
@@ -263,7 +263,7 @@ display_string(q::RelativeQuantity) =
     string(_per_unit_string(q), " in ", _base_label(unit(q)))
 
 _per_unit_string(q::RelativeQuantity) = string(q.value, " p.u.")
-_base_label(::DeviceBaseUnit) = "device base"
+_base_label(::DeviceBaseUnit) = "component base"
 _base_label(::SystemBaseUnit) = "system base"
 
 function display_string(t::NamedTuple)

--- a/src/relative_units.jl
+++ b/src/relative_units.jl
@@ -20,6 +20,7 @@ export RelativeQuantity
 export DU, SU, NU
 export display_units_arg
 export unitful_variant
+export display_string
 
 """
 Supertype for all unit-system markers (relative and natural). Used as the
@@ -239,6 +240,57 @@ Base.show(io::IO, q::RelativeQuantity{T, SystemBaseUnit}) where {T} =
 Base.show(io::IO, ::DeviceBaseUnit) = print(io, "DU")
 Base.show(io::IO, ::SystemBaseUnit) = print(io, "SU")
 Base.show(io::IO, ::NaturalUnit) = print(io, "NU")
+
+"""
+    display_string(x) -> String
+
+Render `x` for human-facing display, spelling relative-unit tags out in full
+("0.6 p.u. in device base") where `show` prints the terse "0.6 DU". `DU`/`SU`
+are convenient to type but are not standard terminology, so verbose output
+(e.g. a component's `text/plain` display) spells them out; terse contexts such
+as tabular cells keep the short tags.
+
+Recurses into `NamedTuple`s so compound fields (e.g. `(min = …, max = …)`) are spelled
+out element-wise. When every element shares one per-unit base — the usual case for a
+compound field — the base is stated once after the tuple rather than repeated per
+element, which keeps the line readable:
+`(min = 0.0 p.u., max = 2.5 p.u.) in system base`.
+
+Anything else renders exactly as `print` would.
+"""
+display_string(x) = string(x)
+display_string(q::RelativeQuantity) =
+    string(_per_unit_string(q), " in ", _base_label(unit(q)))
+
+_per_unit_string(q::RelativeQuantity) = string(q.value, " p.u.")
+_base_label(::DeviceBaseUnit) = "device base"
+_base_label(::SystemBaseUnit) = "system base"
+
+function display_string(t::NamedTuple)
+    vals = values(t)
+    shared = _shared_relative_unit(vals)
+    isnothing(shared) || return string(
+        "(",
+        join(("$k = $(_per_unit_string(v))" for (k, v) in pairs(t)), ", "),
+        ") in ",
+        _base_label(shared),
+    )
+    return string(
+        "(",
+        join(("$k = $(display_string(v))" for (k, v) in pairs(t)), ", "),
+        ")",
+    )
+end
+
+# The single per-unit marker every value carries, or `nothing` if they are not all
+# `RelativeQuantity`s on one base (a mixed or empty tuple has no base to factor out).
+function _shared_relative_unit(vals::Tuple)
+    isempty(vals) && return nothing
+    first(vals) isa RelativeQuantity || return nothing
+    u = unit(first(vals))
+    all(v -> v isa RelativeQuantity && unit(v) === u, vals) || return nothing
+    return u
+end
 
 Base.zero(::Type{RelativeQuantity{T, U}}) where {T, U} = RelativeQuantity(zero(T), U())
 Base.one(::Type{RelativeQuantity{T, U}}) where {T, U} = RelativeQuantity(one(T), U())

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -88,7 +88,7 @@ _resolve_column_accessors(::Type, ::Dict; units = nothing) = nothing
 # Per-column units: `units` is either one unit applied to every column, or a
 # mapping from column name to that column's unit. A column missing from the
 # mapping keeps its own `display_units_arg` default rather than inheriting a
-# neighbour's unit.
+# neighbor's unit.
 _column_units(::Nothing, _, trait_arg) = trait_arg
 _column_units(units::AbstractDict, column, trait_arg) = get(units, column, trait_arg)
 _column_units(units::NamedTuple, column, trait_arg) =

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -79,10 +79,21 @@ end
 # of `(column, getter_func, arg)` tuples. The getter logic enables application of system
 # units in PowerSystems through its getter functions. Dict-form `additional_columns`
 # carry their own accessor closures, so there is nothing to resolve (returns `nothing`).
-# `units`, when given, overrides every column's own `display_units_arg` trait — but
-# never forces a units argument onto a getter that doesn't accept one (`ismissing`
-# trait fields, e.g. `get_name`, are left as plain 1-arg calls).
+# `units`, when given, overrides a column's own `display_units_arg` trait — either
+# uniformly (a single unit) or per column (a column→unit mapping) — but never forces
+# a units argument onto a getter that doesn't accept one (`ismissing` trait fields,
+# e.g. `get_name`, are left as plain 1-arg calls).
 _resolve_column_accessors(::Type, ::Dict; units = nothing) = nothing
+
+# Per-column units: `units` is either one unit applied to every column, or a
+# mapping from column name to that column's unit. A column missing from the
+# mapping keeps its own `display_units_arg` default rather than inheriting a
+# neighbour's unit.
+_column_units(::Nothing, _, trait_arg) = trait_arg
+_column_units(units::AbstractDict, column, trait_arg) = get(units, column, trait_arg)
+_column_units(units::NamedTuple, column, trait_arg) =
+    haskey(units, column) ? units[column] : trait_arg
+_column_units(units, _, _) = units
 
 function _resolve_column_accessors(
     component_type::Type,
@@ -102,7 +113,7 @@ function _resolve_column_accessors(
         end
         trait_arg = display_units_arg(getter_func, component_type)
         ismissing(trait_arg) && return (column, getter_func, missing)
-        arg = units === nothing ? trait_arg : units
+        arg = _column_units(units, column, trait_arg)
         # Route through the unit-tagged companion (e.g. `get_rating_unitful`)
         # so unit-converted columns print with an explicit unit suffix, not a
         # bare number.
@@ -134,8 +145,10 @@ end
 Vector-form `additional_columns` accepts `units` (e.g. `SU`, `DU`, or a
 domain-provided unit like `MW`) to force every unit-converted column to
 display in that unit system instead of each column's own `display_units_arg`
-default. Ignored for `Dict`-form `additional_columns`, whose closures compute
-their own values.
+default. To vary the unit by column, pass a mapping from column name to unit
+(an `AbstractDict` or `NamedTuple`, e.g. `Dict(:rating => MW, :active_power => SU)`);
+columns absent from the mapping keep their own default. Ignored for `Dict`-form
+`additional_columns`, whose closures compute their own values.
 """
 function show_components(
     io::IO,

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -86,6 +86,34 @@ end
     @test !isnothing(val2_pos) && !isnothing(val_pos)
     @test first(val2_pos) < first(val_pos)
 
+    # A column-to-unit mapping sets units per column; a column missing from the
+    # mapping keeps its own trait default rather than inheriting a neighbour's.
+    IS.show_components(
+        io,
+        sys.components,
+        IS.TestComponent,
+        [:val, :val2];
+        units = Dict(:val => IS.DU),
+    )
+    text = String(take!(io))
+    @test occursin("DU", text)
+    @test !occursin(r"\bSU\b", text)
+
+    IS.show_components(
+        io,
+        sys.components,
+        IS.TestComponent,
+        [:val];
+        units = Dict(:val2 => IS.DU),
+    )
+    text = String(take!(io))
+    @test occursin("SU", text)
+
+    # NamedTuple mappings work the same way.
+    IS.show_components(io, sys.components, IS.TestComponent, [:val]; units = (val = IS.DU,))
+    text = String(take!(io))
+    @test occursin("DU", text)
+
     # `units` is ignored (not an error) for Dict-form additional_columns.
     IS.show_components(
         io,

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -87,7 +87,7 @@ end
     @test first(val2_pos) < first(val_pos)
 
     # A column-to-unit mapping sets units per column; a column missing from the
-    # mapping keeps its own trait default rather than inheriting a neighbour's.
+    # mapping keeps its own trait default rather than inheriting a neighbor's.
     IS.show_components(
         io,
         sys.components,

--- a/test/test_relative_units.jl
+++ b/test/test_relative_units.jl
@@ -156,3 +156,21 @@ struct _FakeUnit <: IS.AbstractUnitSystem end
     @test_throws ArgumentError IS.convert_cost_coefficient(2.0, fake, IS.SU, 100.0, 50.0)
     @test_throws ArgumentError IS.convert_cost_coefficient(2.0, IS.DU, fake, 100.0, 50.0)
 end
+
+@testset "display_string spells per-unit tags out" begin
+    @test IS.display_string(0.6 * IS.DU) == "0.6 p.u. in device base"
+    @test IS.display_string(0.3 * IS.SU) == "0.3 p.u. in system base"
+    # Untagged values render exactly as `print` would.
+    @test IS.display_string(1.5) == "1.5"
+    @test IS.display_string(nothing) == "nothing"
+
+    # A compound field on one base states that base once, after the tuple.
+    @test IS.display_string((min = 0.0 * IS.SU, max = 2.5 * IS.SU)) ==
+          "(min = 0.0 p.u., max = 2.5 p.u.) in system base"
+    # Mixed bases have nothing to factor out, so each element is spelled out.
+    @test IS.display_string((min = 0.0 * IS.SU, max = 2.5 * IS.DU)) ==
+          "(min = 0.0 p.u. in system base, max = 2.5 p.u. in device base)"
+    # So does a tuple that is not all tagged.
+    @test IS.display_string((min = 0.0 * IS.SU, max = 2.5)) ==
+          "(min = 0.0 p.u. in system base, max = 2.5)"
+end

--- a/test/test_relative_units.jl
+++ b/test/test_relative_units.jl
@@ -158,7 +158,7 @@ struct _FakeUnit <: IS.AbstractUnitSystem end
 end
 
 @testset "display_string spells per-unit tags out" begin
-    @test IS.display_string(0.6 * IS.DU) == "0.6 p.u. in device base"
+    @test IS.display_string(0.6 * IS.DU) == "0.6 p.u. in component base"
     @test IS.display_string(0.3 * IS.SU) == "0.3 p.u. in system base"
     # Untagged values render exactly as `print` would.
     @test IS.display_string(1.5) == "1.5"
@@ -169,7 +169,7 @@ end
           "(min = 0.0 p.u., max = 2.5 p.u.) in system base"
     # Mixed bases have nothing to factor out, so each element is spelled out.
     @test IS.display_string((min = 0.0 * IS.SU, max = 2.5 * IS.DU)) ==
-          "(min = 0.0 p.u. in system base, max = 2.5 p.u. in device base)"
+          "(min = 0.0 p.u. in system base, max = 2.5 p.u. in component base)"
     # So does a tuple that is not all tagged.
     @test IS.display_string((min = 0.0 * IS.SU, max = 2.5)) ==
           "(min = 0.0 p.u. in system base, max = 2.5)"


### PR DESCRIPTION
## What changed

Two display-side changes that [PowerSystems.jl#1753](https://github.com/Sienna-Platform/PowerSystems.jl/issues/1753) needs. Paired with the PSY PR that consumes them.

- **`display_string(x)`** renders a value with its relative-unit tag spelled out instead of the terse `DU`/`SU`. Those are convenient shorthand but aren't standard terminology, so verbose output (a component's `text/plain` display) spells them out while terse contexts — the one-line `show`, table cells — keep the tags.

  ```
  0.6 * DU                          → "0.6 p.u. in device base"
  (min = 0.0 * SU, max = 2.5 * SU)  → "(min = 0.0 p.u., max = 2.5 p.u.) in system base"
  ```

  A compound field whose elements share one base states it once, after the tuple. Mixed or partially-tagged tuples have nothing to hoist, so they fall back to spelling each element out.

- **`show_components`' `units` kwarg** now accepts a column-to-unit mapping (`AbstractDict` or `NamedTuple`) as well as a single unit, so one table can show one column in natural units and another in device base. A column absent from the mapping keeps its own `display_units_arg` default rather than inheriting a neighbour's.

## How

`display_string` splits the old per-marker string into a value part and a base label, which is what lets the base be factored out of a `NamedTuple`. Column resolution moves the old `units === nothing ? trait_arg : units` ternary into a small `_column_units` dispatch, so the mapping forms are three methods rather than a branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)