### PR TITLE
Draw component and supplemental attribute ids from one stream

### DIFF
--- a/src/component.jl
+++ b/src/component.jl
@@ -5,7 +5,7 @@ subsystem membership sets.
 """
 function assign_new_id_internal!(data, component::InfrastructureSystemsComponent)
     old_id = get_id(component)
-    new_id = get_next_component_id!(data)
+    new_id = get_next_id!(data)
     mgr = get_time_series_manager(component)
     if !isnothing(mgr)
         InfraStore.replace_owner!(

--- a/src/internal.jl
+++ b/src/internal.jl
@@ -35,7 +35,8 @@ Internal storage common to [`InfrastructureSystemsType`](@ref)s.
 
 Components and supplemental attributes are identified by an integer `id` assigned by the
 owning [`SystemData`](@ref) when they are attached (see [`get_id`](@ref)); it is
-[`UNASSIGNED_ID`](@ref) until then. Each instance also holds optional
+[`UNASSIGNED_ID`](@ref) until then. Both kinds draw from one id stream, so an id names
+exactly one object within a system. Each instance also holds optional
 [`SharedSystemReferences`](@ref) when attached to a system, optional unit metadata, and an
 optional user extension dictionary accessed through [`get_ext`](@ref).
 """

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -23,10 +23,9 @@ mutable struct SystemData <: ComponentContainer
     masked_components::Components
     "Maps the integer id of every attached component, regular and masked, to the component."
     component_ids::Dict{Int, <:InfrastructureSystemsComponent}
-    "Next integer id to assign to a component. Independent of the supplemental attribute id stream. Starts at 1."
-    next_component_id::Int
-    "Next integer id to assign to a supplemental attribute. Independent of the component id stream. Starts at 1."
-    next_supplemental_attribute_id::Int
+    "Next integer id to assign. Components and supplemental attributes draw from this one
+    stream, so an id identifies exactly one object of either kind. Starts at 1."
+    next_id::Int
     "User-defined subsystems. Components can be regular or masked."
     subsystems::Dict{String, Set{Int}}
     supplemental_attribute_manager::SupplementalAttributeManager
@@ -74,7 +73,6 @@ function SystemData(;
         masked_components,
         Dict{Int, InfrastructureSystemsComponent}(),
         1,
-        1,
         Dict{String, Set{Int}}(),
         supplemental_attribute_mgr,
         time_series_mgr,
@@ -86,8 +84,7 @@ end
 function SystemData(
     validation_descriptors,
     time_series_manager,
-    next_component_id,
-    next_supplemental_attribute_id,
+    next_id,
     subsystems,
     supplemental_attribute_manager,
     internal,
@@ -98,8 +95,7 @@ function SystemData(
         components,
         masked_components,
         Dict{Int, InfrastructureSystemsComponent}(),
-        next_component_id,
-        next_supplemental_attribute_id,
+        next_id,
         subsystems,
         supplemental_attribute_manager,
         time_series_manager,
@@ -109,21 +105,12 @@ function SystemData(
 end
 
 """
-Return the next integer id to assign to a component and advance the component counter.
+Return the next integer id and advance the counter. Components and supplemental attributes
+share this one stream.
 """
-function get_next_component_id!(data::SystemData)
-    id = data.next_component_id
-    data.next_component_id += 1
-    return id
-end
-
-"""
-Return the next integer id to assign to a supplemental attribute and advance the
-supplemental attribute counter.
-"""
-function get_next_supplemental_attribute_id!(data::SystemData)
-    id = data.next_supplemental_attribute_id
-    data.next_supplemental_attribute_id += 1
+function get_next_id!(data::SystemData)
+    id = data.next_id
+    data.next_id += 1
     return id
 end
 
@@ -340,12 +327,11 @@ function compare_values(
             # the components.
             continue
         end
-        if !compare_uuids && name in (:next_component_id, :next_supplemental_attribute_id)
-            # These counters are derived from the identities they hand out, so they only
-            # mean anything when the identities themselves are being compared. Reassigning
-            # ids (`assign_new_ids`) advances them past the originals while leaving the
-            # data identical — the same reason `id` itself is skipped unless
-            # `compare_uuids`.
+        if !compare_uuids && name == :next_id
+            # This counter is derived from the identities it hands out, so it only means
+            # anything when the identities themselves are being compared. Reassigning ids
+            # (`assign_new_ids`) advances it past the originals while leaving the data
+            # identical — the same reason `id` itself is skipped unless `compare_uuids`.
             continue
         end
         val_x = getproperty(x, name)
@@ -695,8 +681,7 @@ function to_dict(data::SystemData)
             (
             :components,
             :masked_components,
-            :next_component_id,
-            :next_supplemental_attribute_id,
+            :next_id,
             :subsystems,
             :supplemental_attribute_manager,
             :internal,
@@ -801,8 +786,16 @@ function deserialize(
         )
     end
     subsystems = Dict(k => Set(Int.(v)) for (k, v) in raw["subsystems"])
-    next_component_id = Int(get(raw, "next_component_id", 1))
-    next_supplemental_attribute_id = Int(get(raw, "next_supplemental_attribute_id", 1))
+    if !haskey(raw, "next_id")
+        throw(
+            DataFormatError(
+                "The serialized system predates the single id stream (it carries " *
+                "`next_component_id`/`next_supplemental_attribute_id`); regenerate it " *
+                "with this version of InfrastructureSystems.",
+            ),
+        )
+    end
+    next_id = Int(raw["next_id"])
     supplemental_attribute_manager = deserialize(
         SupplementalAttributeManager,
         get(
@@ -822,8 +815,7 @@ function deserialize(
     sys = SystemData(
         validation_descriptors,
         time_series_manager,
-        next_component_id,
-        next_supplemental_attribute_id,
+        next_id,
         subsystems,
         supplemental_attribute_manager,
         internal,
@@ -859,37 +851,23 @@ end
 # Redirect functions to Components
 
 """
-Assign an integer id to a component being attached to `data`, drawn from the component id
-stream.
+Assign an integer id to a component or supplemental attribute being attached to `data`.
 
-A freshly constructed component has [`UNASSIGNED_ID`](@ref) and receives the next component
-id. A component that already carries an id (for example, one restored during
-deserialization) keeps it; the counter is advanced past it so future ids do not collide.
-Components and supplemental attributes have independent id streams, so a component and an
-attribute may share a numeric id.
+A freshly constructed object has [`UNASSIGNED_ID`](@ref) and receives the next id. An object
+that already carries an id (for example, one restored during deserialization) keeps it; the
+counter is advanced past it so future ids do not collide. Components and supplemental
+attributes draw from the same stream, so an id is unique across both kinds.
 """
-function assign_id!(data::SystemData, component::InfrastructureSystemsComponent)
-    id = get_id(component)
+function assign_id!(
+    data::SystemData,
+    obj::Union{InfrastructureSystemsComponent, SupplementalAttribute},
+)
+    id = get_id(obj)
     if id == UNASSIGNED_ID
-        id = get_next_component_id!(data)
-        set_id!(component, id)
-    elseif id >= data.next_component_id
-        data.next_component_id = id + 1
-    end
-    return id
-end
-
-"""
-Assign an integer id to a supplemental attribute being attached to `data`, drawn from the
-supplemental attribute id stream (independent of the component id stream).
-"""
-function assign_id!(data::SystemData, attribute::SupplementalAttribute)
-    id = get_id(attribute)
-    if id == UNASSIGNED_ID
-        id = get_next_supplemental_attribute_id!(data)
-        set_id!(attribute, id)
-    elseif id >= data.next_supplemental_attribute_id
-        data.next_supplemental_attribute_id = id + 1
+        id = get_next_id!(data)
+        set_id!(obj, id)
+    elseif id >= data.next_id
+        data.next_id = id + 1
     end
     return id
 end

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -245,8 +245,7 @@ end
     IS.add_supplemental_attribute!(sys, components[1], attr)
     expected_ids = Dict(IS.get_name(c) => IS.get_id(c) for c in components)
     attr_id = IS.get_id(attr)
-    next_component_id_before = sys.next_component_id
-    next_attribute_id_before = sys.next_supplemental_attribute_id
+    next_id_before = sys.next_id
 
     sys2, result = validate_serialization(sys)
     @test result
@@ -258,14 +257,14 @@ end
     attr2 = only(IS.get_supplemental_attributes(IS.GeographicInfo, sys2))
     @test IS.get_id(attr2) == attr_id
 
-    # Both next-id counters survive the round trip; newly added objects do not collide
-    # within their own stream.
-    @test sys2.next_component_id == next_component_id_before
-    @test sys2.next_supplemental_attribute_id == next_attribute_id_before
+    # The next-id counter survives the round trip, so newly added objects collide with
+    # neither the restored components nor the restored attributes.
+    @test sys2.next_id == next_id_before
     new_component = IS.TestComponent("new_component", 9)
     IS.add_component!(sys2, new_component)
-    @test IS.get_id(new_component) == next_component_id_before
+    @test IS.get_id(new_component) == next_id_before
     @test IS.get_id(new_component) ∉ values(expected_ids)
+    @test IS.get_id(new_component) != attr_id
 end
 
 @testset "Test version info" begin

--- a/test/test_system_data.jl
+++ b/test/test_system_data.jl
@@ -595,7 +595,7 @@ end
     @test !(id1 in IS.get_component_ids(data, subsystem_name))
 end
 
-@testset "Test independent integer id streams" begin
+@testset "Test single integer id stream" begin
     data = IS.SystemData()
     component1 = IS.TestComponent("component1", 5)
     component2 = IS.TestComponent("component2", 6)
@@ -606,23 +606,28 @@ end
     @test IS.get_id(component1) == 1
     @test IS.get_id(component2) == 2
 
-    # Components and supplemental attributes have independent id streams, each starting at 1,
-    # so a component and an attribute may share a numeric id.
+    # Components and supplemental attributes draw from the same stream, so attributes
+    # continue where the components left off instead of restarting at 1.
     attr1 = IS.GeographicInfo()
     attr2 = IS.TestSupplemental(; value = 1.0)
     IS.add_supplemental_attribute!(data, component1, attr1)
     IS.add_supplemental_attribute!(data, component1, attr2)
-    @test IS.get_id(attr1) == 1
-    @test IS.get_id(attr2) == 2
+    @test IS.get_id(attr1) == 3
+    @test IS.get_id(attr2) == 4
 
-    # Component ids are unique among components; attribute ids unique among attributes.
+    # The next component added continues the same stream.
+    component3 = IS.TestComponent("component3", 7)
+    IS.add_component!(data, component3)
+    @test IS.get_id(component3) == 5
+
+    # Ids are unique across components and attributes together.
     component_ids = IS.get_id.(IS.get_components(IS.TestComponent, data))
-    @test length(component_ids) == length(unique(component_ids))
     attribute_ids = vcat(
         IS.get_id.(IS.get_supplemental_attributes(IS.GeographicInfo, data)),
         IS.get_id.(IS.get_supplemental_attributes(IS.TestSupplemental, data)),
     )
-    @test length(attribute_ids) == length(unique(attribute_ids))
+    all_ids = vcat(component_ids, attribute_ids)
+    @test length(all_ids) == length(unique(all_ids))
 end
 
 @testset "Test bulk add of time series" begin


### PR DESCRIPTION
Stacked on #611 — review that first; the diff here is one commit.

## What

`SystemData` carried two id counters, `next_component_id` and `next_supplemental_attribute_id`, so a component and a supplemental attribute could share a numeric id. This collapses them into a single `next_id`: an id now names exactly one object of either kind within a system.

- `get_next_component_id!` / `get_next_supplemental_attribute_id!` → one `get_next_id!(data)`.
- The two `assign_id!` methods had identical bodies once the counter merged, so they become one method over `Union{InfrastructureSystemsComponent, SupplementalAttribute}`. Semantics are unchanged: an `UNASSIGNED_ID` object gets the next id; one that already carries an id (deserialization, `assign_new_ids`) keeps it and the counter advances past it.
- `assign_new_id_internal!` draws from the shared counter.
- Serialization writes and reads one `"next_id"` key; `compare_values` skips the one counter unless `compare_uuids`.
- The 7-arg internal `SystemData` constructor loses a positional argument.

## Breaking

Deserializing a system written before this change now throws a `DataFormatError` naming the old keys, rather than defaulting the counter to 1. Defaulting would silently hand out ids that collide with the restored components — the silent-failure pattern the project bans. **Serialized systems on this line need regenerating, including any PSCB serialized cache.**

Downstream packages construct `SystemData` through the keyword constructor, so they are unaffected unless something calls the positional 7-arg form or the removed `get_next_*_id!` accessors. Worth a stack smoke test before merge.

## Verification

- Project formatter (`scripts/formatter/formatter_code.jl`): clean.
- Full suite: **8943 passing, 3 broken, 0 failing**. All 3 broken are the pre-existing `@test_broken false` markers in `test/test_time_series.jl`, unrelated to ids.
- `test/test_system_data.jl`: "Test independent integer id streams" → "Test single integer id stream", asserting attributes continue at 3/4 after two components and the next component gets 5.
- `test/test_serialization.jl`: one counter round-trips; the newly added component's id collides with neither the restored components nor the restored attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EAXp9EmbP5tyuuhkmL5AP