### PR TITLE
Fix time series correctness issues found in the InfraStore review

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -314,7 +314,11 @@ is selected by dispatch on the first argument. A transaction opened on a `System
 carries its owner validation (`owner_validator`); one opened on a bare manager does not.
 Read paths take no context and allocate nothing — a `TimeSeriesContext` owns an FFI
 `AddBatch` handle, so constructing one per read would be a real cost in per-timestep loops.
-The batch itself is created lazily on the first stage.
+The batch itself is created lazily on the first stage. Inside a block, reads (and
+removals/transforms) still see the block's buffered additions: the manager records the
+innermost open context in `active_context`, and `get_data_store(mgr)` flushes it before
+handing the store out. Code that must *not* flush (the batch commit itself, the
+per-stage forecast-parameter check) reaches `mgr.data_store` directly.
 
 Constraints: blocks nest innermost-first (SQLite savepoints are a stack), and an open block
 holds the store's write lock so gather data *before* opening one.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -314,11 +314,10 @@ is selected by dispatch on the first argument. A transaction opened on a `System
 carries its owner validation (`owner_validator`); one opened on a bare manager does not.
 Read paths take no context and allocate nothing — a `TimeSeriesContext` owns an FFI
 `AddBatch` handle, so constructing one per read would be a real cost in per-timestep loops.
-The batch itself is created lazily on the first stage. Inside a block, reads (and
-removals/transforms) still see the block's buffered additions: the manager records the
-innermost open context in `active_context`, and `get_data_store(mgr)` flushes it before
-handing the store out. Code that must *not* flush (the batch commit itself, the
-per-stage forecast-parameter check) reaches `mgr.data_store` directly.
+The batch itself is created lazily on the first stage. Reads through the manager or system
+do not see buffered additions until the transaction block commits. If code must read,
+remove, or transform a series staged earlier in the same block, call `flush!(txn)` first;
+the write remains transactional but the flush creates a batching boundary.
 
 Constraints: blocks nest innermost-first (SQLite savepoints are a stack), and an open block
 holds the store's write lock so gather data *before* opening one.

--- a/src/component.jl
+++ b/src/component.jl
@@ -13,6 +13,9 @@ function assign_new_id_internal!(
     new_id = get_next_id!(data)
     mgr = get_time_series_manager(component)
     if !isnothing(mgr)
+        # Rewrites the owner id on every association row; refuse it in read-only mode
+        # like every other store mutation instead of leaking the store's own error.
+        _throw_if_read_only(mgr)
         InfraStore.replace_owner!(
             get_data_store(mgr).inner,
             old_id,

--- a/src/components.jl
+++ b/src/components.jl
@@ -186,17 +186,21 @@ function _remove_component!(
         throw(ArgumentError("component $T name=$name is not stored"))
     end
 
-    component = pop!(components.data[T], name)
-    if isempty(components.data[T])
-        pop!(components.data, T)
-    end
-
+    component = components.data[T][name]
+    # Detach before popping: if either cleanup throws (e.g. the time series store is
+    # read-only), the component is still in the container and the system's id index,
+    # subsystems, and shared references stay consistent with it.
     if remove_supplemental_attributes && has_supplemental_attributes(component)
         clear_supplemental_attributes!(component)
     end
 
     if remove_time_series
         prepare_for_removal!(component)
+    end
+
+    pop!(components.data[T], name)
+    if isempty(components.data[T])
+        pop!(components.data, T)
     end
 
     @debug "Removed component" _group = LOG_GROUP_SYSTEM T name

--- a/src/components.jl
+++ b/src/components.jl
@@ -187,9 +187,13 @@ function _remove_component!(
     end
 
     component = components.data[T][name]
-    # Detach before popping: if either cleanup throws (e.g. the time series store is
-    # read-only), the component is still in the container and the system's id index,
-    # subsystems, and shared references stay consistent with it.
+    # The time series cleanup refuses a read-only store, but only after the
+    # supplemental-attribute cleanup has already removed associations (and possibly
+    # the attribute itself), so check up front, before anything is mutated.
+    remove_time_series && _throw_if_read_only(components.time_series_manager)
+    # Detach before popping: if either cleanup throws, the component is still in the
+    # container and the system's id index, subsystems, and shared references stay
+    # consistent with it.
     if remove_supplemental_attributes && has_supplemental_attributes(component)
         clear_supplemental_attributes!(component)
     end

--- a/src/forecasts.jl
+++ b/src/forecasts.jl
@@ -196,12 +196,16 @@ function get_window_common(
     if isnothing(len)
         len = horizon_count
     end
+    (len >= 1 && len <= horizon_count) || throw(
+        ArgumentError(
+            "requested len=$len is outside the forecast horizon of $horizon_count steps",
+        ),
+    )
 
     data = get_data(forecast)[initial_time]
     if ndims(data) == 2
-        # This is necessary because the Deterministic and Probabilistic are 3D Arrays
-        # We need to do this to make the data a 2D TimeArray. In a get_window the data is always count = 1
-        @assert_op size(data)[1] <= len
+        # A Probabilistic / Scenarios window is a (horizon, member) matrix; the time
+        # axis is the first dimension either way.
         data = @view data[1:len, :]
     else
         data = @view data[1:len]

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -1179,18 +1179,30 @@ _infrastore_stage_data!(
 # read the window at `initial_timestamp`.
 function _forecast_window_index(initial_timestamp, interval, start_time)
     start_time == initial_timestamp && return 1
-    misaligned = ArgumentError(
-        "start_time=$start_time is not a forecast window timestamp " *
-        "(initial_timestamp=$initial_timestamp, interval=$(Dates.canonicalize(interval)))",
-    )
-    (start_time < initial_timestamp || iszero(Dates.value(interval))) && throw(misaligned)
+    (start_time < initial_timestamp || iszero(Dates.value(interval))) &&
+        _throw_misaligned(initial_timestamp, interval, start_time)
     return try
         compute_time_array_index(initial_timestamp, start_time, interval)
     catch e
         # `catch`-block exception inspection: the period arithmetic reports an
         # off-grid timestamp as an ArgumentError; name the window contract instead.
-        e isa ArgumentError ? throw(misaligned) : rethrow()
+        if e isa ArgumentError
+            _throw_misaligned(initial_timestamp, interval, start_time)
+        else
+            rethrow()
+        end
     end
+end
+
+# Kept out of line so the aligned path — every forecast read after the first window —
+# never pays for formatting the message.
+@noinline function _throw_misaligned(initial_timestamp, interval, start_time)
+    throw(
+        ArgumentError(
+            "start_time=$start_time is not a forecast window timestamp " *
+            "(initial_timestamp=$initial_timestamp, interval=$(Dates.canonicalize(interval)))",
+        ),
+    )
 end
 
 # Translate IS's `start_time` / `count` window selection into the core's
@@ -1845,17 +1857,22 @@ end
 
 # The three answers `_infrastore_query_types` can give. `AllStoredTypes` means one
 # unfiltered query serves the request; `NoStoredTypes` means no stored type can match (a
-# parameterized concrete such as `SingleTimeSeries{Float64, 1}`, which no stored UnionAll
-# subtypes) and the caller must answer empty WITHOUT querying.
+# `TimeSeriesData` subtype with no stored counterpart; a parameterized concrete such as
+# `SingleTimeSeries{Float64, 1}` is normalized to its UnionAll first) and the caller must
+# answer empty WITHOUT querying.
 struct AllStoredTypes end
 struct NoStoredTypes end
 
 # All InfraStore types whose IS type is a subtype of `T` (strict `<:` semantics —
 # distinct from `_infrastore_type_matches`, which treats a `Deterministic` query
 # as also matching a `DeterministicSingleTimeSeries`). Used by the store-wide
-# filters (`resolutions`, `list_owner_ids`) that key on subtyping.
+# filters (`resolutions`, `list_owner_ids`) that key on subtyping. A parameterized
+# concrete query is normalized the same way `_infrastore_type_matches` does, so a
+# `typeof(ts)` query answers the same on every path.
 _infrastore_subtype_types(::Type{T}) where {T <: TimeSeriesData} =
-    _infrastore_collapse_family(Tuple(c for (c, k) in _INFRASTORE_TYPE_PAIRS if k <: T))
+    _infrastore_collapse_family(
+        Tuple(c for (c, k) in _INFRASTORE_TYPE_PAIRS if k <: _unparameterized_type(T)),
+    )
 
 # The stored InfraStore types a query for `T` should match, under the same
 # `Deterministic`-matches-DST semantics as `_infrastore_type_matches`. `AllStoredTypes()`
@@ -2220,22 +2237,18 @@ function infrastore_get_time_series_resolutions(
 )
     # Calendar resolutions come back as `Month`/`Year`, which neither convert to nor
     # order against fixed periods, so the set is over `Period` and the sort goes
-    # through a nominal-length key.
+    # through `Dates.toms`, which is exact for fixed periods and uses the mean
+    # Gregorian length for calendar ones.
     isnothing(time_series_type) && return sort!(
         Vector{Dates.Period}(InfraStore.get_resolutions(store.inner));
-        by = _period_sort_key,
+        by = Dates.toms,
     )
     res = Set{Dates.Period}()
     for t in _infrastore_subtype_types(time_series_type)
         union!(res, InfraStore.get_resolutions(store.inner; time_series_type = t))
     end
-    return sort!(collect(res); by = _period_sort_key)
+    return sort!(collect(res); by = Dates.toms)
 end
-
-# Ordering key for a mix of fixed and calendar periods: exact milliseconds for fixed
-# periods, nominal (30-day month / 365-day year) milliseconds for calendar ones.
-_period_sort_key(p::Dates.FixedPeriod) = Dates.toms(p)
-_period_sort_key(p::Dates.Period) = Dates.days(p) * 86_400_000
 
 # Counts of time series grouped by type name.
 function infrastore_get_time_series_counts_by_type(store::Store)
@@ -2362,9 +2375,11 @@ function infrastore_list_keys_with_owner(
         time_series_type = _infrastore_pushable_type(time_series_type),
         resolution = resolution)
     out = NamedTuple[]
+    query_type =
+        isnothing(time_series_type) ? nothing : _unparameterized_type(time_series_type)
     for row in rows
-        if !isnothing(time_series_type)
-            _infrastore_is_type(row.time_series_type) <: time_series_type || continue
+        if !isnothing(query_type)
+            _infrastore_is_type(row.time_series_type) <: query_type || continue
         end
         push!(out, (owner_id = Int(row.owner_id), metadata = _key_from_row(row)))
     end

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -716,10 +716,7 @@ function infrastore_add_time_series!(
         features...,
     )
     try
-        # `get_data_store` flushes any open transaction's staged adds first, so this add
-        # lands after them (and a duplicate of a staged series is caught here, not at
-        # the block's commit).
-        InfraStore.add_time_series_bulk!(get_data_store(mgr).inner, batch)
+        InfraStore.add_time_series_bulk!(mgr.data_store.inner, batch)
     catch e
         _infrastore_rethrow_duplicate(
             e,
@@ -832,7 +829,7 @@ function _infrastore_read_single(
     len::Union{Nothing, Int} = nothing,
 )
     mgr = get_time_series_manager(owner)
-    store = get_data_store(mgr)
+    store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
     name = get_name(key)
     initial_timestamp = get_initial_timestamp(key)
@@ -896,7 +893,7 @@ function _infrastore_read_non_sequential(
     len::Union{Nothing, Int} = nothing,
 )
     mgr = get_time_series_manager(owner)
-    store = get_data_store(mgr)
+    store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
     feats = get_features(key)
     time_range = if isnothing(start_time)
@@ -1268,7 +1265,7 @@ function _infrastore_get_forecast(
     features...,
 )
     mgr = get_time_series_manager(owner)
-    store = get_data_store(mgr)::Store
+    store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
     # Resolve the unique forecast of the requested type matching a possibly-partial
     # (subset) feature / resolution / interval query, then read it by its exact stored
@@ -1808,7 +1805,7 @@ function infrastore_has_time_series(
     features...,
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(owner)
-    store = get_data_store(mgr)::Store
+    store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
     feats = _infrastore_features(features)
     # Pure existence probe — a covering-index `SELECT 1 ... LIMIT 1` in the store; nothing
@@ -1903,7 +1900,7 @@ _infrastore_probe_types(probe, types::Tuple) = any(probe, types)
 # `Any` instead of `Bool` — real cost on the `has_time_series` hot path.
 function infrastore_has_any(owner; time_series_type = nothing)
     mgr = get_time_series_manager(owner)
-    store = get_data_store(mgr)::Store
+    store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
     probe =
         t -> InfraStore.has_for_owner(
@@ -2049,7 +2046,7 @@ function infrastore_owner_list_keys(
     features...,
 )
     mgr = get_time_series_manager(owner)
-    store = get_data_store(mgr)::Store
+    store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
     return _infrastore_list_keys(store, owner_id, category;
         time_series_type = time_series_type, name = name, resolution = resolution,
@@ -2091,7 +2088,7 @@ function infrastore_get_time_series_hash(owner::TimeSeriesOwners, key::TimeSerie
     mgr = get_time_series_manager(owner)
     isnothing(mgr) &&
         throw(InfraStore.NotFoundError("owner has no time series to hash"))
-    store = get_data_store(mgr)::Store
+    store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
     T = get_time_series_type(key)
     rows = InfraStore.list_array_groups(store.inner; owner_id = owner_id,
@@ -2127,7 +2124,7 @@ function infrastore_get_time_series_hashes(
     owner = first(owners)
     mgr = get_time_series_manager(owner)
     isnothing(mgr) && return hashes
-    store = get_data_store(mgr)::Store
+    store = mgr.data_store
     ids = Set{Int}(get_id(o) for o in owners)
     rows = InfraStore.list_array_groups(store.inner;
         owner_category = get_owner_category(owner),

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -172,6 +172,12 @@ end
 _storage_array(v::AbstractVector{<:Real}) =
     (collect(v), _element_type_name(eltype(v)))
 
+# N-D per-step scalars (`SingleTimeSeries{T, N}` / `NonSequentialTimeSeries{T, N}` with
+# `N > 1`): the store takes the array whole, with dim 1 as the time axis, and the read
+# side (`_decode_stored_values`) hands it back unchanged.
+_storage_array(v::AbstractArray{<:Real}) =
+    (collect(v), _element_type_name(eltype(v)))
+
 # Encoded width `k` of a vector of structured elements, without encoding it. The forecast
 # encoder needs the widest window's `k` before it allocates, so this is the single source
 # of truth every `_storage_array` below allocates from.
@@ -710,7 +716,10 @@ function infrastore_add_time_series!(
         features...,
     )
     try
-        InfraStore.add_time_series_bulk!(mgr.data_store.inner, batch)
+        # `get_data_store` flushes any open transaction's staged adds first, so this add
+        # lands after them (and a duplicate of a staged series is caught here, not at
+        # the block's commit).
+        InfraStore.add_time_series_bulk!(get_data_store(mgr).inner, batch)
     catch e
         _infrastore_rethrow_duplicate(
             e,
@@ -757,7 +766,7 @@ infrastore_get_time_series(
 # window to its first `len` horizon steps. A forecast stored as a
 # DeterministicSingleTimeSeries is materialized into a regular `Deterministic`.
 infrastore_get_time_series(
-    ::Type{<:Forecast},
+    ::Type{T},
     owner::TimeSeriesOwners,
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
@@ -766,7 +775,8 @@ infrastore_get_time_series(
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     features...,
-) = _infrastore_get_forecast(owner, name;
+) where {T <: Forecast} = _infrastore_get_forecast(owner, name;
+    time_series_type = T,
     start_time = start_time, len = len, count = count, resolution = resolution,
     interval = interval, features...)
 
@@ -822,7 +832,7 @@ function _infrastore_read_single(
     len::Union{Nothing, Int} = nothing,
 )
     mgr = get_time_series_manager(owner)
-    store = mgr.data_store
+    store = get_data_store(mgr)
     owner_id, _, category = _infrastore_owner_args(owner)
     name = get_name(key)
     initial_timestamp = get_initial_timestamp(key)
@@ -886,7 +896,7 @@ function _infrastore_read_non_sequential(
     len::Union{Nothing, Int} = nothing,
 )
     mgr = get_time_series_manager(owner)
-    store = mgr.data_store
+    store = get_data_store(mgr)
     owner_id, _, category = _infrastore_owner_args(owner)
     feats = get_features(key)
     time_range = if isnothing(start_time)
@@ -1072,8 +1082,11 @@ function _infrastore_stage_forecast!(
     obj, count = build(initial, resolution, horizon, interval, name)
     InfraStore.add_time_series!(batch, owner_id, owner_type, category, obj;
         features = feats)
+    # The key names the stored type as its UnionAll (`Probabilistic`, not
+    # `Probabilistic{Float64, 2}`), exactly as a key listed back from the catalog does,
+    # so the two compare and query alike.
     key = ForecastKey(;
-        time_series_type = typeof(ts), name = name,
+        time_series_type = _unparameterized_type(typeof(ts)), name = name,
         initial_timestamp = initial, resolution = resolution,
         horizon = horizon, interval = interval, count = count,
         features = Dict{String, Any}(feats))
@@ -1160,6 +1173,29 @@ _infrastore_stage_data!(
     "transform_single_time_series!.",
 )
 
+# 1-based index of the forecast window that starts at `start_time`, on the grid
+# `initial_timestamp + k·interval`. `compute_time_array_index` does the period
+# arithmetic, so calendar intervals (`Month`, `Year`) work like fixed ones. A
+# single-window forecast carries a zero interval: its only window starts at
+# `initial_timestamp`, which is then the only valid `start_time` — the zero-interval
+# case must not skip the alignment check, or a misaligned request would silently
+# read the window at `initial_timestamp`.
+function _forecast_window_index(initial_timestamp, interval, start_time)
+    start_time == initial_timestamp && return 1
+    misaligned = ArgumentError(
+        "start_time=$start_time is not a forecast window timestamp " *
+        "(initial_timestamp=$initial_timestamp, interval=$(Dates.canonicalize(interval)))",
+    )
+    (start_time < initial_timestamp || iszero(Dates.value(interval))) && throw(misaligned)
+    return try
+        compute_time_array_index(initial_timestamp, start_time, interval)
+    catch e
+        # `catch`-block exception inspection: the period arithmetic reports an
+        # off-grid timestamp as an ArgumentError; name the window contract instead.
+        e isa ArgumentError ? throw(misaligned) : rethrow()
+    end
+end
+
 # Translate IS's `start_time` / `count` window selection into the core's
 # half-open `[start, end)` `time_range`, validated against the forecast's stored
 # window grid (`initial_timestamp + k·interval`, `total_count` windows). Returns
@@ -1171,23 +1207,10 @@ _infrastore_stage_data!(
 function _forecast_time_range(initial_timestamp, interval, total_count, start_time, count)
     isnothing(start_time) && isnothing(count) && return nothing
 
-    if isnothing(start_time)
-        start_idx = 1
+    start_idx = if isnothing(start_time)
+        1
     else
-        offset = start_time - initial_timestamp  # Millisecond
-        interval_ms = Dates.Millisecond(interval).value
-        if start_time < initial_timestamp ||
-           (!iszero(interval_ms) && !iszero(rem(offset.value, interval_ms)))
-            throw(
-                ArgumentError(
-                    "start_time=$start_time is not a forecast window timestamp"),
-            )
-        end
-        start_idx = if iszero(interval_ms)
-            1
-        else
-            div(offset.value, interval_ms) + 1
-        end
+        _forecast_window_index(initial_timestamp, interval, start_time)
     end
     if start_idx < 1 || start_idx > total_count
         throw(ArgumentError(
@@ -1235,6 +1258,7 @@ honoring `start_time` / `count` slicing on the window axis. Pass `key` (a
 previously resolved `ForecastKey`) to skip the catalog resolution query."""
 function _infrastore_get_forecast(
     owner, name;
+    time_series_type::Type{<:Forecast} = Forecast,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,
@@ -1244,16 +1268,17 @@ function _infrastore_get_forecast(
     features...,
 )
     mgr = get_time_series_manager(owner)
-    store = mgr.data_store::Store
+    store = get_data_store(mgr)::Store
     owner_id, _, category = _infrastore_owner_args(owner)
-    # Resolve the unique forecast matching a possibly-partial (subset) feature /
-    # resolution / interval query, then read it by its exact stored attributes.
-    # `interval` matters when one series name carries several forecasts that differ only
-    # by interval (`transform_single_time_series!` with `delete_existing = false`);
-    # without it the lookup is ambiguous.
+    # Resolve the unique forecast of the requested type matching a possibly-partial
+    # (subset) feature / resolution / interval query, then read it by its exact stored
+    # attributes. `interval` matters when one series name carries several forecasts
+    # that differ only by interval (`transform_single_time_series!` with
+    # `delete_existing = false`); without it the lookup is ambiguous. The type is part
+    # of the lookup too: one name can carry a Deterministic and a Probabilistic.
     matched = if isnothing(key)
         infrastore_get_time_series_key(
-            owner, Forecast, name;
+            owner, time_series_type, name;
             resolution = resolution, interval = interval, features...,
         )
     else
@@ -1261,6 +1286,18 @@ function _infrastore_get_forecast(
     end
     feats = get_features(matched)
     resolution = get_resolution(matched)
+    # `len` truncates each window to its first `len` steps; validate it against the
+    # horizon here rather than letting the slice fail with a BoundsError (or silently
+    # return empty windows for `len = 0`), matching the static read path.
+    if !isnothing(len)
+        horizon_count = get_horizon_count(matched)
+        (len < 1 || len > horizon_count) && throw(
+            ArgumentError(
+                "requested len=$len is outside the forecast horizon of " *
+                "$horizon_count steps",
+            ),
+        )
+    end
     # Pin every store lookup below to the resolved forecast's exact interval.
     # One name can carry several forecasts differing only by interval, and the
     # typed lookups match on attributes, so without this they would match more
@@ -1771,7 +1808,7 @@ function infrastore_has_time_series(
     features...,
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(owner)
-    store = mgr.data_store::Store
+    store = get_data_store(mgr)::Store
     owner_id, _, category = _infrastore_owner_args(owner)
     feats = _infrastore_features(features)
     # Pure existence probe — a covering-index `SELECT 1 ... LIMIT 1` in the store; nothing
@@ -1866,7 +1903,7 @@ _infrastore_probe_types(probe, types::Tuple) = any(probe, types)
 # `Any` instead of `Bool` — real cost on the `has_time_series` hot path.
 function infrastore_has_any(owner; time_series_type = nothing)
     mgr = get_time_series_manager(owner)
-    store = mgr.data_store::Store
+    store = get_data_store(mgr)::Store
     owner_id, _, category = _infrastore_owner_args(owner)
     probe =
         t -> InfraStore.has_for_owner(
@@ -1897,8 +1934,17 @@ _infrastore_type_matches(
 _infrastore_type_matches(row_type::Type, ::Type{<:AbstractDeterministic}) =
     row_type <: AbstractDeterministic
 
+# A parameterized concrete query (`SingleTimeSeries{Float64, 1}`, i.e. `typeof(ts)`)
+# matches the same rows as its UnionAll: the catalog does not key on the element
+# type, so the parameters can only restate what the stored array is, never select
+# between arrays.
 _infrastore_type_matches(row_type::Type, ::Type{T}) where {T <: TimeSeriesData} =
-    row_type <: T
+    row_type <: _unparameterized_type(T)
+
+# `SingleTimeSeries{Float64, 1}` -> `SingleTimeSeries`; a UnionAll or a `Union` of
+# time series types is returned as is.
+_unparameterized_type(::Type{T}) where {T} =
+    T isa Union ? T : Base.typename(T).wrapper
 
 # `_infrastore_query_types`' answer is static per query type, and its generic
 # method's runtime match loop costs ~2 µs — real money on the
@@ -2003,7 +2049,7 @@ function infrastore_owner_list_keys(
     features...,
 )
     mgr = get_time_series_manager(owner)
-    store = mgr.data_store::Store
+    store = get_data_store(mgr)::Store
     owner_id, _, category = _infrastore_owner_args(owner)
     return _infrastore_list_keys(store, owner_id, category;
         time_series_type = time_series_type, name = name, resolution = resolution,
@@ -2045,7 +2091,7 @@ function infrastore_get_time_series_hash(owner::TimeSeriesOwners, key::TimeSerie
     mgr = get_time_series_manager(owner)
     isnothing(mgr) &&
         throw(InfraStore.NotFoundError("owner has no time series to hash"))
-    store = mgr.data_store::Store
+    store = get_data_store(mgr)::Store
     owner_id, _, category = _infrastore_owner_args(owner)
     T = get_time_series_type(key)
     rows = InfraStore.list_array_groups(store.inner; owner_id = owner_id,
@@ -2081,7 +2127,7 @@ function infrastore_get_time_series_hashes(
     owner = first(owners)
     mgr = get_time_series_manager(owner)
     isnothing(mgr) && return hashes
-    store = mgr.data_store::Store
+    store = get_data_store(mgr)::Store
     ids = Set{Int}(get_id(o) for o in owners)
     rows = InfraStore.list_array_groups(store.inner;
         owner_category = get_owner_category(owner),
@@ -2175,13 +2221,24 @@ function infrastore_get_time_series_resolutions(
     store::Store;
     time_series_type::Union{Nothing, Type{<:TimeSeriesData}} = nothing,
 )
-    isnothing(time_series_type) && return sort!(InfraStore.get_resolutions(store.inner))
-    res = Set{Dates.Millisecond}()
+    # Calendar resolutions come back as `Month`/`Year`, which neither convert to nor
+    # order against fixed periods, so the set is over `Period` and the sort goes
+    # through a nominal-length key.
+    isnothing(time_series_type) && return sort!(
+        Vector{Dates.Period}(InfraStore.get_resolutions(store.inner));
+        by = _period_sort_key,
+    )
+    res = Set{Dates.Period}()
     for t in _infrastore_subtype_types(time_series_type)
         union!(res, InfraStore.get_resolutions(store.inner; time_series_type = t))
     end
-    return sort!(collect(res))
+    return sort!(collect(res); by = _period_sort_key)
 end
+
+# Ordering key for a mix of fixed and calendar periods: exact milliseconds for fixed
+# periods, nominal (30-day month / 365-day year) milliseconds for calendar ones.
+_period_sort_key(p::Dates.FixedPeriod) = Dates.toms(p)
+_period_sort_key(p::Dates.Period) = Dates.days(p) * 86_400_000
 
 # Counts of time series grouped by type name.
 function infrastore_get_time_series_counts_by_type(store::Store)
@@ -2272,12 +2329,19 @@ function infrastore_list_owner_ids(
         end
         return collect(ids)
     end
+    # Same `Deterministic`-family semantics as the branch above (the core widens a
+    # pushed `Deterministic` filter to DST rows), so the answer does not change with
+    # the presence of a `resolution` filter.
     ids = Set{Int}()
     for row in
         InfraStore.list_keys(store.inner; owner_category = category,
+        time_series_type = _infrastore_pushable_type(time_series_type),
         resolution = resolution)
         if !isnothing(time_series_type)
-            _infrastore_is_type(row.time_series_type) <: time_series_type || continue
+            _infrastore_type_matches(
+                _infrastore_is_type(row.time_series_type),
+                time_series_type,
+            ) || continue
         end
         push!(ids, Int(row.owner_id))
     end

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -376,8 +376,16 @@ function make_time_array(
     end
 
     # Period arithmetic, so a calendar resolution (`Month`) indexes like a fixed one.
-    start_index =
-        compute_time_array_index(first_time, start_time, get_resolution(time_series))
+    resolution = get_resolution(time_series)
+    start_index = compute_time_array_index(first_time, start_time, resolution)
+    # `compute_time_array_index` already rejects a `start_time` before `first_time`;
+    # catch one past the end here so `len` is derived from a valid index.
+    start_index <= n || throw(
+        ArgumentError(
+            "start_time=$start_time is past the end of the series " *
+            "(length $n from $first_time through $(first_time + resolution * (n - 1)))",
+        ),
+    )
     # `len = nothing` means "to the end", per the accessor docstrings.
     isnothing(len) && (len = n - start_index + 1)
     end_index = start_index + len - 1
@@ -389,6 +397,6 @@ function make_time_array(
     )
     colons = ntuple(_ -> Colon(), ndims(time_series.data) - 1)
     sub = time_series.data[start_index:end_index, colons...]
-    timestamps = range(start_time; step = get_resolution(time_series), length = len)
+    timestamps = range(start_time; step = resolution, length = len)
     return TimeSeries.TimeArray(collect(timestamps), sub)
 end

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -375,9 +375,18 @@ function make_time_array(
         return get_time_array(time_series)
     end
 
-    resolution = Dates.Millisecond(get_resolution(time_series))
-    start_index = Int((start_time - first_time) / resolution) + 1
+    # Period arithmetic, so a calendar resolution (`Month`) indexes like a fixed one.
+    start_index =
+        compute_time_array_index(first_time, start_time, get_resolution(time_series))
+    # `len = nothing` means "to the end", per the accessor docstrings.
+    isnothing(len) && (len = n - start_index + 1)
     end_index = start_index + len - 1
+    (len >= 1 && end_index <= n) || throw(
+        ArgumentError(
+            "requested len=$len from start_time=$start_time exceeds the series " *
+            "(length $n from $first_time)",
+        ),
+    )
     colons = ntuple(_ -> Colon(), ndims(time_series.data) - 1)
     sub = time_series.data[start_index:end_index, colons...]
     timestamps = range(start_time; step = get_resolution(time_series), length = len)

--- a/src/supplemental_attribute_manager.jl
+++ b/src/supplemental_attribute_manager.jl
@@ -211,6 +211,7 @@ function remove_supplemental_attribute!(
     attribute::SupplementalAttribute,
 )
     throw_if_not_attached(mgr, attribute)
+    _throw_if_time_series_read_only(attribute)
     remove_association!(mgr.associations, component, attribute)
     if !has_association(mgr.associations, attribute)
         remove_supplemental_attribute!(mgr, attribute)
@@ -231,12 +232,25 @@ function remove_supplemental_attribute!(
         )
     end
 
+    _throw_if_time_series_read_only(supplemental_attribute)
+    # Clear time series before popping, so a failure there leaves the attribute
+    # attached rather than popped with its series still in the store.
+    prepare_for_removal!(supplemental_attribute)
     T = typeof(supplemental_attribute)
     pop!(mgr.data[T], get_id(supplemental_attribute))
-    prepare_for_removal!(supplemental_attribute)
     if isempty(mgr.data[T])
         pop!(mgr.data, T)
     end
+    return
+end
+
+# Removing an attribute ends in `prepare_for_removal!`, which refuses a read-only time
+# series store. Refuse before touching the association rows or the manager's index so
+# the failure leaves nothing half-removed. The manager has no handle on the time series
+# manager; an attached attribute reaches it through its shared references.
+function _throw_if_time_series_read_only(attribute::SupplementalAttribute)
+    mgr = get_time_series_manager(attribute)
+    isnothing(mgr) || _throw_if_read_only(mgr)
     return
 end
 

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -971,17 +971,31 @@ has_component(
     name::AbstractString,
 ) = has_component(data.components, T, name)
 
+# Integer ids are not unique across systems, so this is membership by identity: true
+# only for the very instance stored under that id, not a copy or a same-id component
+# from another system.
 function has_component(data::SystemData, component::InfrastructureSystemsComponent)
-    return get_id(component) in keys(data.component_ids)
+    return get(data.component_ids, get_id(component), nothing) === component
 end
 
 function assign_new_id!(data::SystemData, component::InfrastructureSystemsComponent)
+    # Integer ids are not unique across systems, so membership is by identity: this
+    # must be the very instance the system stores, both by type/name and under its id.
+    _validate(data, component)
     orig_id = get_id(component)
-    if isnothing(pop!(data.component_ids, orig_id, nothing))
-        throw(ArgumentError("component with id = $orig_id is not stored."))
+    if !has_component(data, component)
+        throw(
+            ArgumentError(
+                "$(summary(component)) is not attached to the system.",
+            ),
+        )
     end
 
+    # Re-index only once the id has actually changed: the internal call refuses a
+    # read-only store before mutating anything, and the index must still name the
+    # component under its old id in that case.
     assign_new_id_internal!(data, component)
+    pop!(data.component_ids, orig_id)
     data.component_ids[get_id(component)] = component
     return
 end
@@ -1566,18 +1580,38 @@ function fast_deepcopy_system(
         old_supplemental_attribute_manager
     end
 
+    # Every path from `data` to the old managers has to be redirected, or `deepcopy`
+    # follows it and copies the real store anyway: the two manager fields, the component
+    # containers (each holds the manager), and the shared references on every owner —
+    # main and masked components and supplemental attributes alike.
+    old_components = data.components
+    old_masked_components = data.masked_components
     data.time_series_manager = new_time_series_manager
     data.supplemental_attribute_manager = new_supplemental_attribute_manager
+    data.components = Components(
+        old_components.data,
+        new_time_series_manager,
+        old_components.validation_descriptors,
+    )
+    data.masked_components = Components(
+        old_masked_components.data,
+        new_time_series_manager,
+        old_masked_components.validation_descriptors,
+    )
 
-    old_refs = Dict{Tuple{DataType, String}, SharedSystemReferences}()
-    for comp in iterate_components(data)
-        old_refs[(typeof(comp), get_name(comp))] =
-            comp.internal.shared_system_references
-        new_refs = SharedSystemReferences(;
-            time_series_manager = new_time_series_manager,
-            supplemental_attribute_manager = new_supplemental_attribute_manager,
-        )
-        set_shared_system_references!(comp, new_refs)
+    new_refs = SharedSystemReferences(;
+        time_series_manager = new_time_series_manager,
+        supplemental_attribute_manager = new_supplemental_attribute_manager,
+    )
+    owners = Iterators.flatten((
+        iterate_components(old_components),
+        iterate_components(old_masked_components),
+        iterate_supplemental_attributes(old_supplemental_attribute_manager),
+    ))
+    old_refs = IdDict{Any, Union{Nothing, SharedSystemReferences}}()
+    for owner in owners
+        old_refs[owner] = get_shared_system_references(owner)
+        set_shared_system_references!(owner, new_refs)
     end
 
     new_data = try
@@ -1585,10 +1619,10 @@ function fast_deepcopy_system(
     finally
         data.time_series_manager = old_time_series_manager
         data.supplemental_attribute_manager = old_supplemental_attribute_manager
-
-        for comp in iterate_components(data)
-            set_shared_system_references!(comp,
-                old_refs[(typeof(comp), get_name(comp))])
+        data.components = old_components
+        data.masked_components = old_masked_components
+        for (owner, refs) in old_refs
+            set_shared_system_references!(owner, refs)
         end
     end
 

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -127,6 +127,11 @@ written as one bulk call. The block commits when `func` returns; if it throws,
 everything the block did is rolled back — **including removals**, which are
 recoverable only in here.
 
+Buffered additions are not visible to reads through the system until the block
+commits. Call `flush!(txn)` first when a read inside the block must see additions
+staged through `txn`; doing so creates a batching boundary but keeps the writes
+inside the transaction.
+
 Blocks nest innermost-first.
 
 A batch that grows past `auto_flush_threshold` staged additions or

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -985,8 +985,10 @@ end
 
 function assign_new_id!(data::SystemData, component::InfrastructureSystemsComponent)
     # Integer ids are not unique across systems, so membership is by identity: this
-    # must be the very instance the system stores, both by type/name and under its id.
-    _validate(data, component)
+    # must be the very instance the system stores under its id. The id index covers
+    # main and masked components alike, whereas a (type, name) lookup would not — the
+    # two containers do not share a name space, so a masked component may legitimately
+    # share its name with a main one.
     orig_id = get_id(component)
     if !has_component(data, component)
         throw(

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -600,10 +600,6 @@ function _transform_single_time_series!(
     resolution::Union{Nothing, Dates.Period} = nothing,
     delete_existing::Bool = true,
 )
-    if delete_existing
-        remove_time_series!(data, DeterministicSingleTimeSeries; resolution = resolution)
-    end
-
     # The store derives a DeterministicSingleTimeSeries view over every stored
     # component SingleTimeSeries that shares the array (no data is copied); the
     # window parameters are recorded in the metadata. Supplemental-attribute
@@ -612,12 +608,25 @@ function _transform_single_time_series!(
     # The two policy flags are IS's contract, not store invariants: the single-window
     # interval is stored as zero (what IS looks views up by), and one system holds one
     # forecast grid.
-    outcome = infrastore_transform_single_time_series!(
-        get_data_store(data),
-        horizon,
-        interval;
-        resolution = resolution,
-    )
+    #
+    # The removal of the previous transforms and the new transform are one store
+    # transaction: if the store rejects the new parameters, the old views are still
+    # there, which is the all-or-nothing promise in the docstring.
+    outcome = time_series_transaction(data) do _
+        if delete_existing
+            remove_time_series!(
+                data,
+                DeterministicSingleTimeSeries;
+                resolution = resolution,
+            )
+        end
+        infrastore_transform_single_time_series!(
+            get_data_store(data),
+            horizon,
+            interval;
+            resolution = resolution,
+        )
+    end
 
     if iszero(outcome.sources)
         @warn "There are no SingleTimeSeries arrays to transform"

--- a/src/time_series_cache.jl
+++ b/src/time_series_cache.jl
@@ -276,9 +276,12 @@ function ForecastCache(
 
     count = get_count(ts_metadata)
     if start_time != initial_timestamp
-        count -=
-            Dates.Millisecond(start_time - initial_timestamp) ÷
-            Dates.Millisecond(get_interval(ts_metadata))
+        # Period arithmetic, so a calendar interval (`Month`) counts like a fixed one.
+        count -= compute_periods_between(
+            initial_timestamp,
+            start_time,
+            get_interval(ts_metadata),
+        )
     end
 
     window_size = row_size * horizon_count
@@ -380,7 +383,12 @@ function StaticTimeSeriesCache(
 
     total_length = length(ts_metadata)
     if start_time != initial_timestamp
-        total_length -= (start_time - initial_timestamp) ÷ get_resolution(ts_metadata)
+        # Period arithmetic, so a calendar resolution (`Month`) counts like a fixed one.
+        total_length -= compute_periods_between(
+            initial_timestamp,
+            start_time,
+            get_resolution(ts_metadata),
+        )
     end
 
     # Get an instance to assess data size.

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -467,10 +467,8 @@ function get_time_series_array(
         start_time = get_initial_timestamp(time_series)
     end
 
-    if len === nothing
-        len = length(time_series)
-    end
-
+    # `len = nothing` means "to the end of the series", which depends on `start_time`;
+    # `make_time_array` resolves it
     return make_time_array(time_series, start_time; len = len)
 end
 
@@ -963,6 +961,9 @@ has_time_series(
 Efficiently add all time_series in one component to another by copying the underlying
 references.
 
+Both owners must be attached to the same system and be the same kind of owner (two
+components or two supplemental attributes); anything else throws an `ArgumentError`.
+
 # Arguments
 
   - `dst::TimeSeriesOwners`: Destination owner
@@ -986,10 +987,40 @@ function copy_time_series!(
     end
 end
 
-function _copy_time_series!(
+# The store addresses an owner by `(id, category)` and its copy keeps the source's
+# category, so only a component→component or attribute→attribute copy is expressible
+# as the in-store clone; dispatch on the owner kind selects those two.
+_copy_time_series!(
+    dst::InfrastructureSystemsComponent,
+    src::InfrastructureSystemsComponent;
+    name_mapping::Union{Nothing, Dict{Tuple{String, String}, String}} = nothing,
+) = _copy_time_series_same_kind!(dst, src, name_mapping)
+
+_copy_time_series!(
+    dst::SupplementalAttribute,
+    src::SupplementalAttribute;
+    name_mapping::Union{Nothing, Dict{Tuple{String, String}, String}} = nothing,
+) = _copy_time_series_same_kind!(dst, src, name_mapping)
+
+# A component/attribute pair is rejected outright rather than falling back to a
+# read/re-add with different semantics (a derived forecast would materialize).
+_copy_time_series!(
     dst::TimeSeriesOwners,
     src::TimeSeriesOwners;
     name_mapping::Union{Nothing, Dict{Tuple{String, String}, String}} = nothing,
+) = throw(
+    ArgumentError(
+        "$(summary(src)) and $(summary(dst)) are different kinds of owner; " *
+        "copy_time_series! only copies between components or between supplemental " *
+        "attributes. Read the time series from the source and add them to the " *
+        "destination instead.",
+    ),
+)
+
+function _copy_time_series_same_kind!(
+    dst::TimeSeriesOwners,
+    src::TimeSeriesOwners,
+    name_mapping::Union{Nothing, Dict{Tuple{String, String}, String}},
 )
     mgr = get_time_series_manager(dst)
     if isnothing(mgr)
@@ -1001,7 +1032,29 @@ function _copy_time_series!(
         )
     end
 
+    src_mgr = get_time_series_manager(src)
+    if isnothing(src_mgr)
+        throw(
+            ArgumentError(
+                "$(summary(src)) does not have time series storage. " *
+                "It may not be attached to the system.",
+            ),
+        )
+    end
+
     store = get_data_store(mgr)
+    # Ids are only unique within one system: copying from another system would look
+    # `src`'s id up in `dst`'s store and find a different owner (or nothing). The
+    # store handle is the system identity here — the managers of one system share it.
+    if get_data_store(src_mgr) !== store
+        throw(
+            ArgumentError(
+                "$(summary(src)) and $(summary(dst)) are not attached to the same " *
+                "system; copy_time_series! only copies within one system. Read the " *
+                "time series from the source and add them to the destination instead.",
+            ),
+        )
+    end
     dst_id, dst_type, _ = _infrastore_owner_args(dst)
     src_id, category = _infrastore_owner_id_category(src)
 

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -961,7 +961,7 @@ has_time_series(
 )
 
 """
-Efficiently add all time_series in one component to another by copying the underlying
+Efficiently add all time_series in one owner to another by copying the underlying
 references.
 
 Both owners must be attached to the same system and be the same kind of owner (two

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -437,7 +437,8 @@ Return a `TimeSeries.TimeArray` from a cached `StaticTimeSeries` instance.
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp to retrieve.
     If nothing, use the `initial_timestamp` of the time series.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number
-    of timestamps). If nothing, use the entire length
+    of timestamps). If nothing, return all timestamps from `start_time` through the end
+    of the time series.
 
 See also: [`get_time_series_values`](@ref get_time_series_values(owner::TimeSeriesOwners, time_series::StaticTimeSeries; start_time::Union{Nothing, Dates.DateTime} = nothing, len::Union{Nothing, Int} = nothing)),
 [`get_time_series_timestamps`](@ref get_time_series_timestamps(owner::TimeSeriesOwners, time_series::StaticTimeSeries; start_time::Union{Nothing, Dates.DateTime} = nothing, len::Union{Nothing, Int} = nothing,)),
@@ -633,7 +634,8 @@ Return a vector of timestamps from a cached StaticTimeSeries instance.
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp to retrieve.
     If nothing, use the `initial_timestamp` of the time series.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number
-    of timestamps). If nothing, use the entire length
+    of timestamps). If nothing, return all timestamps from `start_time` through the end
+    of the time series.
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -840,7 +842,8 @@ Return an vector of timeseries data without timestamps from a cached `StaticTime
   - `start_time::Union{Nothing, Dates.DateTime} = nothing`: the first timestamp to retrieve.
     If nothing, use the `initial_timestamp` of the time series.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number
-    of timestamps). If nothing, use the entire length
+    of timestamps). If nothing, return all timestamps from `start_time` through the end
+    of the time series.
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
     owner::TimeSeriesOwners,

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -9,6 +9,14 @@ directly.
 mutable struct TimeSeriesManager <: AbstractTimeSeriesManager
     data_store::Store
     read_only::Bool
+    """
+    The innermost open [`TimeSeriesContext`](@ref) (a `time_series_transaction` block),
+    or `nothing`. Its buffered additions are not in the store yet; `get_data_store`
+    flushes them before handing the store out, so a read, removal, or transform issued
+    inside the block sees everything the block has added so far. Typed loosely because
+    the context type is parameterized on the manager.
+    """
+    active_context::Any
 end
 
 function TimeSeriesManager(;
@@ -51,13 +59,23 @@ function TimeSeriesManager(;
                 catalog = :memory,
             )
     end
-    return TimeSeriesManager(data_store, read_only)
+    return TimeSeriesManager(data_store, read_only, nothing)
 end
 
 """
 The [`Store`](@ref) holding this manager's time series arrays and their catalog.
+
+Inside a [`time_series_transaction`](@ref) block this first writes the block's
+buffered additions to the store, so whatever is done with the returned store sees
+them. Outside a block it is a plain field access.
 """
-get_data_store(mgr::TimeSeriesManager) = mgr.data_store
+function get_data_store(mgr::TimeSeriesManager)
+    context = mgr.active_context
+    # A closed context is one being torn down (`discard!` rolling back); it has
+    # nothing buffered and must not be touched.
+    isnothing(context) || context.closed || flush!(context)
+    return mgr.data_store
+end
 
 # (owner_id::Int, owner_type::String, owner_category::InfraStore.OwnerCategory)
 # for the InfraStore binding. The owner is identified by its integer id.
@@ -137,6 +155,11 @@ function _time_series_transaction(
         auto_flush_bytes = auto_flush_bytes,
     )
     begin_transaction!(context)
+    # Register the block as the manager's innermost context so reads issued inside it
+    # flush its buffer first (see `get_data_store`). Blocks nest innermost-first, so
+    # the enclosing block's context is restored on exit, whichever way the block ends.
+    outer = mgr.active_context
+    mgr.active_context = context
     # `commit!` must stay inside the protected region: buffered additions are only
     # written (and validated by the store) at the final flush it performs, so a bad
     # add in a small block throws here rather than at `add_time_series!` time. If it
@@ -149,6 +172,8 @@ function _time_series_transaction(
     catch
         discard!(context)
         rethrow()
+    finally
+        mgr.active_context = outer
     end
     return result
 end

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -9,14 +9,6 @@ directly.
 mutable struct TimeSeriesManager <: AbstractTimeSeriesManager
     data_store::Store
     read_only::Bool
-    """
-    The innermost open [`TimeSeriesContext`](@ref) (a `time_series_transaction` block),
-    or `nothing`. Its buffered additions are not in the store yet; `get_data_store`
-    flushes them before handing the store out, so a read, removal, or transform issued
-    inside the block sees everything the block has added so far. Typed loosely because
-    the context type is parameterized on the manager.
-    """
-    active_context::Any
 end
 
 function TimeSeriesManager(;
@@ -59,23 +51,13 @@ function TimeSeriesManager(;
                 catalog = :memory,
             )
     end
-    return TimeSeriesManager(data_store, read_only, nothing)
+    return TimeSeriesManager(data_store, read_only)
 end
 
 """
 The [`Store`](@ref) holding this manager's time series arrays and their catalog.
-
-Inside a [`time_series_transaction`](@ref) block this first writes the block's
-buffered additions to the store, so whatever is done with the returned store sees
-them. Outside a block it is a plain field access.
 """
-function get_data_store(mgr::TimeSeriesManager)
-    context = mgr.active_context
-    # A closed context is one being torn down (`discard!` rolling back); it has
-    # nothing buffered and must not be touched.
-    isnothing(context) || context.closed || flush!(context)
-    return mgr.data_store
-end
+get_data_store(mgr::TimeSeriesManager) = mgr.data_store
 
 # (owner_id::Int, owner_type::String, owner_category::InfraStore.OwnerCategory)
 # for the InfraStore binding. The owner is identified by its integer id.
@@ -114,6 +96,11 @@ Open a batch of time series work and run `func` on it, inside a store transactio
 Additions made through the yielded [`TimeSeriesContext`](@ref) are buffered and
 written as one bulk call, so the store pays one catalog transaction for the block
 instead of one per series. The block commits when `func` returns.
+
+Buffered additions are not visible to reads through the manager or system until
+the block commits. Call `flush!(txn)` first when a read inside the block must see
+additions staged through `txn`; doing so creates a batching boundary but keeps the
+writes inside the transaction.
 
 If `func` throws, the transaction is rolled back and the whole block is undone —
 buffered additions never reached the store, and everything that did, **including
@@ -155,11 +142,6 @@ function _time_series_transaction(
         auto_flush_bytes = auto_flush_bytes,
     )
     begin_transaction!(context)
-    # Register the block as the manager's innermost context so reads issued inside it
-    # flush its buffer first (see `get_data_store`). Blocks nest innermost-first, so
-    # the enclosing block's context is restored on exit, whichever way the block ends.
-    outer = mgr.active_context
-    mgr.active_context = context
     # `commit!` must stay inside the protected region: buffered additions are only
     # written (and validated by the store) at the final flush it performs, so a bad
     # add in a small block throws here rather than at `add_time_series!` time. If it
@@ -172,8 +154,6 @@ function _time_series_transaction(
     catch
         discard!(context)
         rethrow()
-    finally
-        mgr.active_context = outer
     end
     return result
 end

--- a/src/time_series_structs.jl
+++ b/src/time_series_structs.jl
@@ -112,6 +112,21 @@ get_horizon_count(key::ForecastKey) =
     get_horizon_count(get_horizon(key), get_resolution(key))
 Base.length(key::ForecastKey) = get_horizon_count(key)
 
+# Keys are values: two keys naming the same stored association are equal, whatever
+# spelling their periods arrived in (`Hour(1)` from a constructor, `Millisecond(3600000)`
+# back from the catalog — `==` and `hash` on `Period` already agree across those).
+function Base.:(==)(a::T, b::T) where {T <: TimeSeriesKey}
+    return all(getfield(a, f) == getfield(b, f) for f in fieldnames(T))
+end
+
+function Base.hash(key::T, h::UInt) where {T <: TimeSeriesKey}
+    h = hash(T, h)
+    for f in fieldnames(T)
+        h = hash(getfield(key, f), h)
+    end
+    return h
+end
+
 # All concrete key types, for use in struct fields: a `Union` of concrete types
 # union-splits (no boxing / dynamic dispatch in per-timestep paths), unlike the
 # abstract `TimeSeriesKey`.

--- a/src/time_series_utils.jl
+++ b/src/time_series_utils.jl
@@ -143,7 +143,9 @@ function compute_periods_between(
     year1, month1 = Dates.yearmonth(t1)
     year2, month2 = Dates.yearmonth(t2)
     time_diff = (year2 - year1) * 12 + (month2 - month1)
-    return _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+    n = _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+    _check_calendar_alignment(t1, t2, Dates.Month(time_diff))
+    return n
 end
 
 function compute_periods_between(
@@ -156,12 +158,27 @@ function compute_periods_between(
     year2 = Dates.year(t2)
     quarter2 = Dates.quarter(t2)
     time_diff = (year2 - year1) * 4 + (quarter2 - quarter1)
-    return _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+    n = _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+    _check_calendar_alignment(t1, t2, Dates.Quarter(time_diff))
+    return n
 end
 
 function compute_periods_between(t1::Dates.DateTime, t2::Dates.DateTime, period::Dates.Year)
     time_diff = Dates.year(t2) - Dates.year(t1)
-    return _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+    n = _compute_periods_between_common(t1, t2, Dates.value(period), time_diff, 0)
+    _check_calendar_alignment(t1, t2, Dates.Year(time_diff))
+    return n
+end
+
+# The calendar methods count whole months / quarters / years from the date fields
+# alone, which says nothing about the day or time of day. A timestamp is on the grid
+# only if stepping `t1` by that many periods lands exactly on it — the same
+# `initial + period * k` arithmetic that generates the grid, so day-of-month clamping
+# (Jan 31 + 1 month == Feb 29) agrees with the series' own timestamps.
+function _check_calendar_alignment(t1::Dates.DateTime, t2::Dates.DateTime, offset)
+    t1 + offset == t2 ||
+        throw(ArgumentError("$t2 is not a whole number of $(typeof(offset)) from $t1"))
+    return
 end
 
 function _compute_periods_between_common(

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -453,6 +453,34 @@ end
     @test IS.has_component(sys, component)
 end
 
+@testset "Test removals on a read-only system leave supplemental attributes intact" begin
+    sys, component = _sys_with_component()
+    attr = IS.TestSupplemental(; value = 1.0)
+    IS.add_supplemental_attribute!(sys, component, attr)
+    IS.add_time_series!(sys, attr, _hourly_sts("a"))
+    sys.time_series_manager.read_only = true
+
+    # The component keeps its attribute, and the attribute keeps its series and its
+    # place in the manager, whether the removal is of the component or of the link.
+    @test_throws ArgumentError IS.remove_component!(sys, component)
+    @test IS.has_component(sys, component)
+    @test IS.has_supplemental_attributes(component)
+    @test IS.get_supplemental_attribute(sys, IS.get_id(attr)) === attr
+    @test IS.has_time_series(attr, IS.SingleTimeSeries, "a")
+
+    @test_throws ArgumentError IS.remove_supplemental_attribute!(sys, component, attr)
+    @test IS.has_supplemental_attributes(component)
+    @test IS.get_supplemental_attribute(sys, IS.get_id(attr)) === attr
+    @test IS.has_time_series(attr, IS.SingleTimeSeries, "a")
+
+    # Writable again: the same removals go through and take the attribute with them.
+    sys.time_series_manager.read_only = false
+    IS.remove_component!(sys, component)
+    @test !IS.has_component(sys, component)
+    @test isempty(collect(IS.iterate_supplemental_attributes(sys)))
+    @test isnothing(IS.get_time_series_manager(attr))
+end
+
 @testset "Test assign_new_id! on a masked component sharing a name" begin
     # Main and masked components do not share a name space, so a masked "c" can sit
     # beside a main "c"; membership is by identity under the id, not by name.

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -86,15 +86,20 @@ end
     @test_throws ArgumentError IS.get_time_series(IS.Forecast, component, "fx")
 end
 
-@testset "Test reads inside a transaction see staged additions" begin
+@testset "Test transaction reads require an explicit flush" begin
     sys, component = _sys_with_component()
     IS.time_series_transaction(sys) do txn
         IS.add_time_series!(txn, component, _hourly_sts("v"))
+        @test IS.has_staged_data(txn)
+        @test !IS.has_time_series(component, IS.SingleTimeSeries, "v")
+        @test isempty(IS.get_time_series_keys(component))
+        IS.flush!(txn)
+        @test !IS.has_staged_data(txn)
         @test IS.has_time_series(component, IS.SingleTimeSeries, "v")
         @test length(IS.get_time_series_keys(component)) == 1
         @test IS.get_time_series_values(IS.SingleTimeSeries, component, "v") ==
               collect(1.0:24)
-        # Adds keep working after the implicit flush, and the block stays one transaction.
+        # Adds keep working after an explicit flush, and the block stays one transaction.
         IS.add_time_series!(txn, component, _hourly_sts("w"))
     end
     @test IS.has_time_series(component, IS.SingleTimeSeries, "w")
@@ -102,6 +107,7 @@ end
     # A removal inside the block of a series staged earlier in it removes it.
     IS.time_series_transaction(sys) do txn
         IS.add_time_series!(txn, component, _hourly_sts("x"))
+        IS.flush!(txn)
         IS.remove_time_series!(sys, IS.SingleTimeSeries, component, "x")
     end
     @test !IS.has_time_series(component, IS.SingleTimeSeries, "x")
@@ -109,6 +115,7 @@ end
     # A transform inside the block covers the staged series.
     IS.time_series_transaction(sys) do txn
         IS.add_time_series!(txn, component, _hourly_sts("y"))
+        IS.flush!(txn)
         IS.transform_single_time_series!(
             sys,
             IS.DeterministicSingleTimeSeries,
@@ -121,11 +128,11 @@ end
     # Everything flushed inside a failing block still rolls back.
     @test_throws ErrorException IS.time_series_transaction(sys) do txn
         IS.add_time_series!(txn, component, _hourly_sts("z"))
+        IS.flush!(txn)
         @test IS.has_time_series(component, IS.SingleTimeSeries, "z")
         error("boom")
     end
     @test !IS.has_time_series(component, IS.SingleTimeSeries, "z")
-    @test isnothing(sys.time_series_manager.active_context)
 end
 
 @testset "Test calendar-interval forecast windows" begin

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -1,7 +1,7 @@
-# Regression tests for the InfraStore-backed time series paths: copy restricted to one
-# system and one owner kind, typed forecast lookups, reads inside a
-# transaction, calendar periods, key type identity, N-D static series, forecast `len`
-# validation, and transform atomicity.
+# Consistency of the time series API with the store behind it: what a copy may target,
+# typed forecast lookups, visibility inside a transaction, calendar periods, key identity,
+# N-D static series, forecast window bounds, atomicity of transforms, and what a
+# read-only or copied system leaves intact.
 
 const _T0 = Dates.DateTime("2020-01-01T00:00:00")
 
@@ -23,7 +23,7 @@ function _sys_with_component(name = "c")
     return sys, component
 end
 
-@testset "Test store review: copy_time_series! rejects owners from different systems" begin
+@testset "Test copy_time_series! rejects owners from different systems" begin
     sys1, a = _sys_with_component("a")
     sys2, b = _sys_with_component("b")
     # Both components have id 1 in their own systems, so a store-level copy would
@@ -48,7 +48,7 @@ end
     @test_throws ArgumentError IS.copy_time_series!(loose, a)
 end
 
-@testset "Test store review: copy_time_series! rejects a component/attribute pair" begin
+@testset "Test copy_time_series! rejects a component/attribute pair" begin
     sys, component = _sys_with_component()
     attr = IS.TestSupplemental(; value = 1.0)
     IS.add_supplemental_attribute!(sys, component, attr)
@@ -65,7 +65,7 @@ end
     @test length(collect(IS.iterate_supplemental_attributes_with_time_series(sys))) == 1
 end
 
-@testset "Test store review: get_time_series honors the requested forecast type" begin
+@testset "Test get_time_series honors the requested forecast type" begin
     sys, component = _sys_with_component()
     IS.add_time_series!(sys, component, _hourly_det("fx"))
     @test_throws ArgumentError IS.get_time_series(IS.Probabilistic, component, "fx")
@@ -86,7 +86,7 @@ end
     @test_throws ArgumentError IS.get_time_series(IS.Forecast, component, "fx")
 end
 
-@testset "Test store review: reads inside a transaction see staged additions" begin
+@testset "Test reads inside a transaction see staged additions" begin
     sys, component = _sys_with_component()
     IS.time_series_transaction(sys) do txn
         IS.add_time_series!(txn, component, _hourly_sts("v"))
@@ -128,7 +128,7 @@ end
     @test isnothing(sys.time_series_manager.active_context)
 end
 
-@testset "Test store review: calendar-interval forecast windows" begin
+@testset "Test calendar-interval forecast windows" begin
     sys, component = _sys_with_component()
     resolution = Dates.Month(1)
     interval = Dates.Month(2)
@@ -174,7 +174,7 @@ end
     @test isnothing(IS.get_next_time(cache))
 end
 
-@testset "Test store review: calendar-resolution static series slicing" begin
+@testset "Test calendar-resolution static series slicing" begin
     sys, component = _sys_with_component()
     sts = IS.SingleTimeSeries(
         "monthly",
@@ -217,7 +217,7 @@ end
     @test vals == collect(3.0:24)
 end
 
-@testset "Test store review: single-window forecast rejects a misaligned start_time" begin
+@testset "Test single-window forecast rejects a misaligned start_time" begin
     sys, component = _sys_with_component()
     IS.add_time_series!(sys, component, _hourly_sts("s"))
     IS.transform_single_time_series!(
@@ -245,7 +245,7 @@ end
     )
 end
 
-@testset "Test store review: component iteration is consistent with and without resolution" begin
+@testset "Test component iteration is consistent with and without resolution" begin
     sys, component = _sys_with_component()
     IS.add_time_series!(sys, component, _hourly_sts("s", 48))
     IS.transform_single_time_series!(
@@ -289,7 +289,7 @@ end
     end
 end
 
-@testset "Test store review: keys and queries use the unparameterized type" begin
+@testset "Test keys and queries use the unparameterized type" begin
     sys, component = _sys_with_component()
     data = SortedDict(_T0 + Dates.Hour(k) => rand(24, 3) for k in 0:23)
     prob = IS.Probabilistic(
@@ -316,7 +316,7 @@ end
     @test !IS.has_time_series(component, IS.SingleTimeSeries, "s")
 end
 
-@testset "Test store review: N-D SingleTimeSeries round-trips through the store" begin
+@testset "Test N-D SingleTimeSeries round-trips through the store" begin
     sys, component = _sys_with_component()
     mat = reshape(collect(1.0:72), 24, 3)
     mts = IS.SingleTimeSeries("matrix", _T0, Dates.Hour(1), mat)
@@ -353,7 +353,7 @@ end
           reshape(collect(1.0:6), 3, 2)
 end
 
-@testset "Test store review: forecast len is validated against the horizon" begin
+@testset "Test forecast len is validated against the horizon" begin
     sys, component = _sys_with_component()
     IS.add_time_series!(sys, component, _hourly_det("fc"))
     @test_throws ArgumentError IS.get_time_series(
@@ -376,7 +376,7 @@ end
     ) == 3
 end
 
-@testset "Test store review: transform_single_time_series! keeps old views on failure" begin
+@testset "Test transform_single_time_series! keeps old views on failure" begin
     sys, component = _sys_with_component()
     IS.add_time_series!(sys, component, _hourly_sts("s", 48))
     IS.transform_single_time_series!(
@@ -394,4 +394,118 @@ end
     )
     @test IS.has_time_series(component, IS.DeterministicSingleTimeSeries, "s")
     @test IS.get_forecast_parameters(sys).horizon == Dates.Hour(24)
+end
+
+@testset "Test remove_component! on a read-only system leaves it consistent" begin
+    sys, component = _sys_with_component()
+    IS.add_time_series!(sys, component, _hourly_sts("s"))
+    sys.time_series_manager.read_only = true
+    @test_throws ArgumentError IS.remove_component!(sys, component)
+    @test IS.get_component(IS.TestComponent, sys, "c") === component
+    @test IS.has_component(sys, component)
+    @test IS.has_time_series(component, IS.SingleTimeSeries, "s")
+    @test_throws ArgumentError IS.assign_new_id!(sys, component)
+    @test IS.has_component(sys, component)
+    # A copy, or another system's component that happens to carry the same id, is not
+    # the stored instance.
+    @test_throws ArgumentError IS.assign_new_id!(sys, deepcopy(component))
+    other_sys, other = _sys_with_component("c")
+    @test IS.get_id(other) == IS.get_id(component)
+    @test_throws ArgumentError IS.assign_new_id!(sys, other)
+    @test IS.get_component(IS.TestComponent, sys, "c") === component
+    @test !IS.has_component(sys, deepcopy(component))
+    @test !IS.has_component(sys, other)
+
+    sys.time_series_manager.read_only = false
+    IS.remove_component!(sys, component)
+    @test isempty(collect(IS.iterate_components(sys)))
+    @test !IS.has_component(sys, component)
+    # The id is free again: the same component can come back.
+    IS.add_component!(sys, component)
+    @test IS.has_component(sys, component)
+end
+
+@testset "Test instance-form forecast window honors len" begin
+    sys, component = _sys_with_component()
+    data = SortedDict(_T0 + Dates.Hour(k) => rand(24, 3) for k in 0:3)
+    prob = IS.Probabilistic(
+        "p",
+        data,
+        [0.25, 0.5, 0.75],
+        Dates.Hour(1);
+        interval = Dates.Hour(1),
+    )
+    IS.add_time_series!(sys, component, prob)
+    full = IS.get_time_series(IS.Probabilistic, component, "p")
+    ta = IS.get_time_series_array(component, full; len = 12)
+    @test size(TimeSeries.values(ta)) == (12, 3)
+    @test TimeSeries.values(ta) == data[_T0][1:12, :]
+    ta =
+        IS.get_time_series_array(component, full; start_time = _T0 + Dates.Hour(2), len = 5)
+    @test TimeSeries.values(ta) == data[_T0 + Dates.Hour(2)][1:5, :]
+    @test_throws ArgumentError IS.get_time_series_array(component, full; len = 25)
+    @test_throws ArgumentError IS.get_time_series_array(component, full; len = 0)
+end
+
+@testset "Test TimeSeriesKey equality and hashing" begin
+    sys, component = _sys_with_component()
+    key_added = IS.add_time_series!(sys, component, _hourly_sts("s"))
+    key_listed = only(IS.get_time_series_keys(component))
+    @test IS.get_resolution(key_added) == Dates.Hour(1)
+    @test IS.get_resolution(key_listed) == Dates.Millisecond(3_600_000)
+    @test key_added == key_listed
+    @test hash(key_added) == hash(key_listed)
+    @test length(Set([key_added, key_listed])) == 1
+
+    fkey_added = IS.add_time_series!(sys, component, _hourly_det("d"))
+    fkey_listed =
+        only(IS.get_time_series_keys(component; time_series_type = IS.Deterministic))
+    @test fkey_added == fkey_listed
+    @test hash(fkey_added) == hash(fkey_listed)
+    @test fkey_added != key_added
+    @test key_added != IS.add_time_series!(sys, component, _hourly_sts("s"); scenario = "a")
+end
+
+@testset "Test fast_deepcopy_system rewires every owner" begin
+    sys, component = _sys_with_component()
+    masked = IS.TestComponent("masked", 5)
+    IS.add_component!(sys, masked)
+    attr = IS.TestSupplemental(; value = 1.0)
+    IS.add_supplemental_attribute!(sys, component, attr)
+    IS.add_time_series!(sys, component, _hourly_sts("s"))
+    IS.add_time_series!(sys, masked, _hourly_sts("m"))
+    IS.add_time_series!(sys, attr, _hourly_sts("a"))
+    IS.mask_component!(sys, masked)
+    @test IS.has_time_series(masked, IS.SingleTimeSeries, "m")
+
+    copied = IS.fast_deepcopy_system(
+        sys;
+        skip_time_series = true,
+        skip_supplemental_attributes = false,
+    )
+    new_mgr = copied.time_series_manager
+    @test new_mgr !== sys.time_series_manager
+    # No time series (the store does hold the copied attribute association rows).
+    @test IS.get_num_time_series(IS.get_data_store(copied)) == 0
+    @test copied.components.time_series_manager === new_mgr
+    @test copied.masked_components.time_series_manager === new_mgr
+    for owner in Iterators.flatten((
+        IS.iterate_components(copied),
+        IS.iterate_components(copied.masked_components),
+        IS.iterate_supplemental_attributes(copied),
+    ))
+        @test IS.get_time_series_manager(owner) === new_mgr
+        @test !IS.has_time_series(owner)
+    end
+    @test length(collect(IS.iterate_supplemental_attributes(copied))) == 1
+
+    # The original is untouched: every owner is back on its own managers and data.
+    for owner in (component, masked, attr)
+        @test IS.get_time_series_manager(owner) === sys.time_series_manager
+    end
+    @test IS.has_time_series(component, IS.SingleTimeSeries, "s")
+    @test IS.has_time_series(masked, IS.SingleTimeSeries, "m")
+    @test IS.has_time_series(attr, IS.SingleTimeSeries, "a")
+    @test sys.components.time_series_manager === sys.time_series_manager
+    @test sys.masked_components.time_series_manager === sys.time_series_manager
 end

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -168,6 +168,13 @@ end
         "month_fc";
         start_time = t1 + Dates.Month(1),
     )
+    # Same month as a window but not the window's timestamp.
+    @test_throws ArgumentError IS.get_time_series(
+        IS.Deterministic,
+        component,
+        "month_fc";
+        start_time = t2 + Dates.Day(14) + Dates.Hour(7),
+    )
     @test IS.get_time_series_resolutions(sys) == [Dates.Month(1)]
     @test IS.get_time_series_resolutions(sys; time_series_type = IS.Deterministic) ==
           [Dates.Month(1)]
@@ -202,6 +209,20 @@ end
           [4.0, 5.0, 6.0, 7.0]
     @test IS.get_time_series_values(component, full; start_time = _T0 + Dates.Month(20)) ==
           collect(21.0:24)
+    # A mid-month start_time is not one of the series' timestamps.
+    @test_throws ArgumentError IS.get_time_series_values(
+        component,
+        full;
+        start_time = _T0 + Dates.Month(3) + Dates.Day(14),
+        len = 2,
+    )
+    @test_throws ArgumentError IS.get_time_series_values(
+        IS.SingleTimeSeries,
+        component,
+        "monthly";
+        start_time = _T0 + Dates.Month(3) + Dates.Day(14),
+        len = 2,
+    )
     IS.add_time_series!(
         sys,
         component,

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -381,6 +381,29 @@ end
           reshape(collect(1.0:6), 3, 2)
 end
 
+@testset "Test static series rejects a start_time past the end" begin
+    sys, component = _sys_with_component()
+    IS.add_time_series!(sys, component, _hourly_sts("s"))
+    sts = IS.get_time_series(IS.SingleTimeSeries, component, "s")
+    # Aligned to the grid but one step beyond the last timestamp: the error must name
+    # `start_time`, not a `len` the caller never passed.
+    @test_throws(
+        ArgumentError(
+            "start_time=$(_T0 + Dates.Hour(24)) is past the end of the " *
+            "series (length 24 from $_T0 through $(_T0 + Dates.Hour(23)))",
+        ),
+        IS.get_time_series_values(component, sts; start_time = _T0 + Dates.Hour(24)),
+    )
+    @test_throws ArgumentError IS.get_time_series_values(
+        component,
+        sts;
+        start_time = _T0 + Dates.Hour(24),
+        len = 1,
+    )
+    @test IS.get_time_series_values(component, sts; start_time = _T0 + Dates.Hour(23)) ==
+          [24.0]
+end
+
 @testset "Test forecast len is validated against the horizon" begin
     sys, component = _sys_with_component()
     IS.add_time_series!(sys, component, _hourly_det("fc"))

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -453,6 +453,31 @@ end
     @test IS.has_component(sys, component)
 end
 
+@testset "Test assign_new_id! on a masked component sharing a name" begin
+    # Main and masked components do not share a name space, so a masked "c" can sit
+    # beside a main "c"; membership is by identity under the id, not by name.
+    sys, masked = _sys_with_component("c")
+    IS.mask_component!(sys, masked)
+    main = IS.TestComponent("c", 6)
+    IS.add_component!(sys, main)
+    @test IS.get_component(IS.TestComponent, sys, "c") === main
+    @test IS.get_masked_component(IS.TestComponent, sys, "c") === masked
+    masked_id = IS.get_id(masked)
+    main_id = IS.get_id(main)
+
+    IS.assign_new_id!(sys, masked)
+    @test IS.get_id(masked) != masked_id
+    @test IS.has_component(sys, masked)
+    @test IS.get_masked_component(sys, IS.get_id(masked)) === masked
+    @test !haskey(sys.component_ids, masked_id)
+
+    IS.assign_new_id!(sys, main)
+    @test IS.get_id(main) != main_id
+    @test IS.has_component(sys, main)
+    @test IS.get_component(IS.TestComponent, sys, "c") === main
+    @test IS.get_masked_component(IS.TestComponent, sys, "c") === masked
+end
+
 @testset "Test instance-form forecast window honors len" begin
     sys, component = _sys_with_component()
     data = SortedDict(_T0 + Dates.Hour(k) => rand(24, 3) for k in 0:3)

--- a/test/test_time_series_store_review.jl
+++ b/test/test_time_series_store_review.jl
@@ -1,0 +1,397 @@
+# Regression tests for the InfraStore-backed time series paths: copy restricted to one
+# system and one owner kind, typed forecast lookups, reads inside a
+# transaction, calendar periods, key type identity, N-D static series, forecast `len`
+# validation, and transform atomicity.
+
+const _T0 = Dates.DateTime("2020-01-01T00:00:00")
+
+function _hourly_sts(name, len = 24)
+    return IS.SingleTimeSeries(name, _T0, Dates.Hour(1), collect(1.0:len))
+end
+
+function _hourly_det(name, count = 24, horizon = 24)
+    data = SortedDict(
+        _T0 + Dates.Hour(k) => fill(Float64(k + 1), horizon) for k in 0:(count - 1)
+    )
+    return IS.Deterministic(name, data, Dates.Hour(1); interval = Dates.Hour(1))
+end
+
+function _sys_with_component(name = "c")
+    sys = IS.SystemData()
+    component = IS.TestComponent(name, 5)
+    IS.add_component!(sys, component)
+    return sys, component
+end
+
+@testset "Test store review: copy_time_series! rejects owners from different systems" begin
+    sys1, a = _sys_with_component("a")
+    sys2, b = _sys_with_component("b")
+    # Both components have id 1 in their own systems, so a store-level copy would
+    # address the wrong owner.
+    @test IS.get_id(a) == IS.get_id(b)
+    IS.add_time_series!(sys1, a, _hourly_sts("s"); scenario = "x")
+    IS.add_time_series!(
+        sys2,
+        b,
+        IS.SingleTimeSeries("other", _T0, Dates.Hour(1), fill(100.0, 24)),
+    )
+    @test_throws ArgumentError IS.copy_time_series!(b, a)
+    @test_throws ArgumentError IS.copy_time_series!(a, b)
+    # Nothing changed on either side.
+    @test [IS.get_name(k) for k in IS.get_time_series_keys(a)] == ["s"]
+    @test [IS.get_name(k) for k in IS.get_time_series_keys(b)] == ["other"]
+    @test IS.get_time_series_values(IS.SingleTimeSeries, b, "other") == fill(100.0, 24)
+
+    # An owner that is not attached anywhere is rejected too.
+    loose = IS.TestComponent("loose", 5)
+    @test_throws ArgumentError IS.copy_time_series!(a, loose)
+    @test_throws ArgumentError IS.copy_time_series!(loose, a)
+end
+
+@testset "Test store review: copy_time_series! rejects a component/attribute pair" begin
+    sys, component = _sys_with_component()
+    attr = IS.TestSupplemental(; value = 1.0)
+    IS.add_supplemental_attribute!(sys, component, attr)
+    IS.add_time_series!(sys, attr, _hourly_sts("attr_series"))
+    IS.add_time_series!(sys, component, _hourly_sts("comp_series"))
+
+    @test_throws ArgumentError IS.copy_time_series!(component, attr)
+    @test_throws ArgumentError IS.copy_time_series!(attr, component)
+    # Nothing changed, and no orphan rows: the system-wide iterators still resolve
+    # every owner.
+    @test [IS.get_name(k) for k in IS.get_time_series_keys(component)] == ["comp_series"]
+    @test [IS.get_name(k) for k in IS.get_time_series_keys(attr)] == ["attr_series"]
+    @test length(collect(IS.iterate_components_with_time_series(sys))) == 1
+    @test length(collect(IS.iterate_supplemental_attributes_with_time_series(sys))) == 1
+end
+
+@testset "Test store review: get_time_series honors the requested forecast type" begin
+    sys, component = _sys_with_component()
+    IS.add_time_series!(sys, component, _hourly_det("fx"))
+    @test_throws ArgumentError IS.get_time_series(IS.Probabilistic, component, "fx")
+    @test_throws ArgumentError IS.get_time_series(IS.Scenarios, component, "fx")
+    @test IS.get_time_series(IS.Deterministic, component, "fx") isa IS.Deterministic
+
+    data = SortedDict(_T0 + Dates.Hour(k) => rand(24, 3) for k in 0:23)
+    prob = IS.Probabilistic(
+        "fx",
+        data,
+        [0.25, 0.5, 0.75],
+        Dates.Hour(1);
+        interval = Dates.Hour(1),
+    )
+    IS.add_time_series!(sys, component, prob)
+    @test IS.get_time_series(IS.Deterministic, component, "fx") isa IS.Deterministic
+    @test IS.get_time_series(IS.Probabilistic, component, "fx") isa IS.Probabilistic
+    @test_throws ArgumentError IS.get_time_series(IS.Forecast, component, "fx")
+end
+
+@testset "Test store review: reads inside a transaction see staged additions" begin
+    sys, component = _sys_with_component()
+    IS.time_series_transaction(sys) do txn
+        IS.add_time_series!(txn, component, _hourly_sts("v"))
+        @test IS.has_time_series(component, IS.SingleTimeSeries, "v")
+        @test length(IS.get_time_series_keys(component)) == 1
+        @test IS.get_time_series_values(IS.SingleTimeSeries, component, "v") ==
+              collect(1.0:24)
+        # Adds keep working after the implicit flush, and the block stays one transaction.
+        IS.add_time_series!(txn, component, _hourly_sts("w"))
+    end
+    @test IS.has_time_series(component, IS.SingleTimeSeries, "w")
+
+    # A removal inside the block of a series staged earlier in it removes it.
+    IS.time_series_transaction(sys) do txn
+        IS.add_time_series!(txn, component, _hourly_sts("x"))
+        IS.remove_time_series!(sys, IS.SingleTimeSeries, component, "x")
+    end
+    @test !IS.has_time_series(component, IS.SingleTimeSeries, "x")
+
+    # A transform inside the block covers the staged series.
+    IS.time_series_transaction(sys) do txn
+        IS.add_time_series!(txn, component, _hourly_sts("y"))
+        IS.transform_single_time_series!(
+            sys,
+            IS.DeterministicSingleTimeSeries,
+            Dates.Hour(24),
+            Dates.Hour(24),
+        )
+    end
+    @test IS.has_time_series(component, IS.DeterministicSingleTimeSeries, "y")
+
+    # Everything flushed inside a failing block still rolls back.
+    @test_throws ErrorException IS.time_series_transaction(sys) do txn
+        IS.add_time_series!(txn, component, _hourly_sts("z"))
+        @test IS.has_time_series(component, IS.SingleTimeSeries, "z")
+        error("boom")
+    end
+    @test !IS.has_time_series(component, IS.SingleTimeSeries, "z")
+    @test isnothing(sys.time_series_manager.active_context)
+end
+
+@testset "Test store review: calendar-interval forecast windows" begin
+    sys, component = _sys_with_component()
+    resolution = Dates.Month(1)
+    interval = Dates.Month(2)
+    horizon_count = 12
+    t1 = _T0
+    t2 = t1 + interval
+    t3 = t2 + interval
+    data = Dict(
+        t => TimeSeries.TimeArray(
+            range(t; length = horizon_count, step = resolution),
+            fill(Float64(i), horizon_count),
+        ) for (i, t) in enumerate((t1, t2, t3))
+    )
+    det = IS.Deterministic("month_fc", data; resolution = resolution, interval = interval)
+    IS.add_time_series!(sys, component, det)
+
+    fc = IS.get_time_series(IS.Deterministic, component, "month_fc"; start_time = t2)
+    @test IS.get_count(fc) == 2
+    @test first(keys(IS.get_data(fc))) == t2
+    @test IS.get_time_series_values(
+        IS.Deterministic,
+        component,
+        "month_fc";
+        start_time = t3,
+    ) ==
+          fill(3.0, horizon_count)
+    @test_throws ArgumentError IS.get_time_series(
+        IS.Deterministic,
+        component,
+        "month_fc";
+        start_time = t1 + Dates.Month(1),
+    )
+    @test IS.get_time_series_resolutions(sys) == [Dates.Month(1)]
+    @test IS.get_time_series_resolutions(sys; time_series_type = IS.Deterministic) ==
+          [Dates.Month(1)]
+
+    cache = IS.ForecastCache(IS.Deterministic, component, "month_fc"; start_time = t2)
+    @test length(cache) == 2
+    @test TimeSeries.values(IS.get_next_time_series_array!(cache)) ==
+          fill(2.0, horizon_count)
+    @test TimeSeries.values(IS.get_next_time_series_array!(cache)) ==
+          fill(3.0, horizon_count)
+    @test isnothing(IS.get_next_time(cache))
+end
+
+@testset "Test store review: calendar-resolution static series slicing" begin
+    sys, component = _sys_with_component()
+    sts = IS.SingleTimeSeries(
+        "monthly",
+        TimeSeries.TimeArray(
+            range(_T0; length = 24, step = Dates.Month(1)),
+            collect(1.0:24),
+        );
+        resolution = Dates.Month(1),
+    )
+    IS.add_time_series!(sys, component, sts)
+    full = IS.get_time_series(IS.SingleTimeSeries, component, "monthly")
+    @test IS.get_time_series_values(
+        component,
+        full;
+        start_time = _T0 + Dates.Month(3),
+        len = 4,
+    ) ==
+          [4.0, 5.0, 6.0, 7.0]
+    @test IS.get_time_series_values(component, full; start_time = _T0 + Dates.Month(20)) ==
+          collect(21.0:24)
+    IS.add_time_series!(
+        sys,
+        component,
+        IS.SingleTimeSeries("hourly", _T0, Dates.Hour(1), collect(1.0:24)),
+    )
+    @test IS.get_time_series_resolutions(sys) == [Dates.Hour(1), Dates.Month(1)]
+
+    cache = IS.StaticTimeSeriesCache(
+        IS.SingleTimeSeries,
+        component,
+        "monthly";
+        start_time = _T0 + Dates.Month(2),
+        cache_size_bytes = 5 * sizeof(Float64),
+    )
+    @test length(cache) == 22
+    vals = Float64[]
+    for ta in cache
+        append!(vals, TimeSeries.values(ta))
+    end
+    @test vals == collect(3.0:24)
+end
+
+@testset "Test store review: single-window forecast rejects a misaligned start_time" begin
+    sys, component = _sys_with_component()
+    IS.add_time_series!(sys, component, _hourly_sts("s"))
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        Dates.Hour(24),
+        Dates.Hour(24),
+    )
+    key = only(IS.get_time_series_keys(component; time_series_type = IS.Deterministic))
+    @test IS.get_interval(key) == Dates.Millisecond(0)
+    @test IS.get_count(
+        IS.get_time_series(IS.Deterministic, component, "s"; start_time = _T0),
+    ) == 1
+    @test_throws ArgumentError IS.get_time_series(
+        IS.Deterministic,
+        component,
+        "s";
+        start_time = _T0 + Dates.Hour(5),
+    )
+    @test_throws ArgumentError IS.get_time_series_array(
+        IS.Deterministic,
+        component,
+        "s";
+        start_time = _T0 + Dates.Hour(5),
+    )
+end
+
+@testset "Test store review: component iteration is consistent with and without resolution" begin
+    sys, component = _sys_with_component()
+    IS.add_time_series!(sys, component, _hourly_sts("s", 48))
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        Dates.Hour(24),
+        Dates.Hour(24),
+    )
+    for T in (
+        IS.Deterministic,
+        IS.AbstractDeterministic,
+        IS.DeterministicSingleTimeSeries,
+        IS.Forecast,
+    )
+        @test length(
+            collect(IS.iterate_components_with_time_series(sys; time_series_type = T)),
+        ) == 1
+        @test length(
+            collect(
+                IS.iterate_components_with_time_series(
+                    sys;
+                    time_series_type = T,
+                    resolution = Dates.Hour(1),
+                ),
+            ),
+        ) == 1
+    end
+    for T in (IS.Probabilistic, IS.Scenarios)
+        @test isempty(
+            collect(IS.iterate_components_with_time_series(sys; time_series_type = T)),
+        )
+        @test isempty(
+            collect(
+                IS.iterate_components_with_time_series(
+                    sys;
+                    time_series_type = T,
+                    resolution = Dates.Hour(1),
+                ),
+            ),
+        )
+    end
+end
+
+@testset "Test store review: keys and queries use the unparameterized type" begin
+    sys, component = _sys_with_component()
+    data = SortedDict(_T0 + Dates.Hour(k) => rand(24, 3) for k in 0:23)
+    prob = IS.Probabilistic(
+        "p",
+        data,
+        [0.25, 0.5, 0.75],
+        Dates.Hour(1);
+        interval = Dates.Hour(1),
+    )
+    key = IS.add_time_series!(sys, component, prob)
+    @test IS.get_time_series_type(key) === IS.Probabilistic
+    @test IS.get_time_series_type(key) ===
+          IS.get_time_series_type(only(IS.get_time_series_keys(component)))
+    @test IS.get_time_series_hash(component, key) ==
+          IS.get_time_series_hash(component, only(IS.get_time_series_keys(component)))
+
+    sts = _hourly_sts("s")
+    IS.add_time_series!(sys, component, sts)
+    @test IS.has_time_series(component, typeof(sts), "s")
+    @test IS.has_time_series(component, typeof(prob), "p")
+    @test length(IS.get_time_series_keys(component; time_series_type = typeof(sts))) == 1
+    @test IS.get_time_series(typeof(sts), component, "s") isa IS.SingleTimeSeries
+    IS.remove_time_series!(sys, typeof(sts), component, "s")
+    @test !IS.has_time_series(component, IS.SingleTimeSeries, "s")
+end
+
+@testset "Test store review: N-D SingleTimeSeries round-trips through the store" begin
+    sys, component = _sys_with_component()
+    mat = reshape(collect(1.0:72), 24, 3)
+    mts = IS.SingleTimeSeries("matrix", _T0, Dates.Hour(1), mat)
+    @test mts isa IS.SingleTimeSeries{Float64, 2}
+    IS.add_time_series!(sys, component, mts)
+    back = IS.get_time_series(IS.SingleTimeSeries, component, "matrix")
+    @test back isa IS.SingleTimeSeries{Float64, 2}
+    @test IS.get_array(back) == mat
+    sliced = IS.get_time_series(
+        IS.SingleTimeSeries,
+        component,
+        "matrix";
+        start_time = _T0 + Dates.Hour(2),
+        len = 5,
+    )
+    @test IS.get_array(sliced) == mat[3:7, :]
+    @test IS.get_initial_timestamp(sliced) == _T0 + Dates.Hour(2)
+
+    cube = rand(24, 2, 2)
+    IS.add_time_series!(
+        sys,
+        component,
+        IS.SingleTimeSeries("cube", _T0, Dates.Hour(1), cube),
+    )
+    @test IS.get_array(IS.get_time_series(IS.SingleTimeSeries, component, "cube")) == cube
+
+    nts = IS.NonSequentialTimeSeries(
+        "nseq",
+        [_T0, _T0 + Dates.Hour(3), _T0 + Dates.Hour(7)],
+        reshape(collect(1.0:6), 3, 2),
+    )
+    IS.add_time_series!(sys, component, nts)
+    @test IS.get_array(IS.get_time_series(IS.NonSequentialTimeSeries, component, "nseq")) ==
+          reshape(collect(1.0:6), 3, 2)
+end
+
+@testset "Test store review: forecast len is validated against the horizon" begin
+    sys, component = _sys_with_component()
+    IS.add_time_series!(sys, component, _hourly_det("fc"))
+    @test_throws ArgumentError IS.get_time_series(
+        IS.Deterministic,
+        component,
+        "fc";
+        len = 25,
+    )
+    @test_throws ArgumentError IS.get_time_series(
+        IS.Deterministic,
+        component,
+        "fc";
+        len = 0,
+    )
+    @test length(
+        IS.get_time_series_values(IS.Deterministic, component, "fc"; len = 24),
+    ) == 24
+    @test length(
+        IS.get_time_series_values(IS.Deterministic, component, "fc"; len = 3),
+    ) == 3
+end
+
+@testset "Test store review: transform_single_time_series! keeps old views on failure" begin
+    sys, component = _sys_with_component()
+    IS.add_time_series!(sys, component, _hourly_sts("s", 48))
+    IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        Dates.Hour(24),
+        Dates.Hour(24),
+    )
+    @test IS.has_time_series(component, IS.DeterministicSingleTimeSeries, "s")
+    @test_throws IS.ConflictingInputsError IS.transform_single_time_series!(
+        sys,
+        IS.DeterministicSingleTimeSeries,
+        Dates.Hour(100),
+        Dates.Hour(1),
+    )
+    @test IS.has_time_series(component, IS.DeterministicSingleTimeSeries, "s")
+    @test IS.get_forecast_parameters(sys).horizon == Dates.Hour(24)
+end

--- a/test/test_time_series_utils.jl
+++ b/test/test_time_series_utils.jl
@@ -154,6 +154,45 @@ end
         DateTime(2024, 1, 1, 0),
         Hour(1),
     )
+
+    # Calendar periods: the month / quarter / year count must also land exactly on the
+    # timestamp, not just on the same month / quarter / year.
+    @test_throws ArgumentError IS.compute_time_array_index(
+        DateTime(2020, 1, 1),
+        DateTime(2020, 3, 15, 7),
+        Month(2),
+    )
+    @test_throws ArgumentError IS.compute_time_array_index(
+        DateTime(2020, 1, 1),
+        DateTime(2020, 3, 1, 0, 30),
+        Month(1),
+    )
+    @test_throws ArgumentError IS.compute_time_array_index(
+        DateTime(2020, 1, 1),
+        DateTime(2020, 5, 1),
+        Quarter(1),
+    )
+    @test_throws ArgumentError IS.compute_time_array_index(
+        DateTime(2020, 1, 1),
+        DateTime(2021, 6, 1),
+        Year(1),
+    )
+    # Day-of-month clamping follows the grid's own `initial + period * k` arithmetic.
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 31),
+        DateTime(2024, 2, 29),
+        Month(1),
+    ) == 2
+    @test IS.compute_time_array_index(
+        DateTime(2024, 1, 31),
+        DateTime(2024, 3, 31),
+        Month(2),
+    ) == 2
+    @test_throws ArgumentError IS.compute_time_array_index(
+        DateTime(2024, 1, 31),
+        DateTime(2024, 2, 28),
+        Month(1),
+    )
 end
 
 @testset "Test get_initial_timestamp" begin


### PR DESCRIPTION
## Summary

A correctness review of the time series layer against `src/infrastore.jl` and the InfraStore.jl 0.8.0 binding turned up a set of real bugs; this PR fixes the ones that are IS's to fix, with a regression test per finding in `test/test_time_series_consistency.jl`.

### Store glue and API (`7c90bd0a3`)

- **`copy_time_series!` wrote wrong or orphaned association rows** across systems or for a component/attribute pair (the store addresses an owner by `(id, category)`, ids are only unique within one system, and the store's copy keeps the source category). It now only copies within one system between owners of the same kind — selected by dispatch on the owner type — and throws an `ArgumentError` otherwise.
- **`get_time_series(T <: Forecast, …)` ignored `T`**: asking for a `Probabilistic` returned the `Deterministic` of the same name. The requested type is now part of the key lookup.
- **Calendar intervals/resolutions (`Month`, `Year`) threw `MethodError`** on any `start_time`/`len` slicing, in the caches, and in `get_time_series_resolutions`. Window and index arithmetic now goes through `compute_periods_between`/`compute_time_array_index`.
- **A zero-interval (transform-derived single-window) forecast silently accepted a misaligned `start_time`**, returning the first window, after which `get_time_series_array` died with a `KeyError`. It now throws the same `ArgumentError` as a dense forecast.
- `iterate_components_with_time_series(; time_series_type = Deterministic)` answered differently with and without a `resolution` filter (DST owners were dropped by the strict branch).
- `ForecastKey` from `add_time_series!` carried `typeof(ts)` (e.g. `Probabilistic{Float64, 2}`) while listed keys carry the UnionAll, so `get_time_series_hash` on a just-returned key threw `NotFoundError`; keys and type queries now use the unparameterized type.
- `SingleTimeSeries{T, N ≥ 2}` could be constructed and read but not added (`MethodError` in `_storage_array`).
- Forecast `len` is validated against the horizon (`BoundsError` / silently empty windows before).
- `transform_single_time_series!(delete_existing = true)` deleted the old views before the store could reject the new parameters; removal and transform are now one store transaction.
- Instance-form `get_time_series_array(owner, ts; start_time)` with `len = nothing` overran the series.

### System consistency (`f3dd1d2ba`)

- `remove_component!` on a read-only system popped the component before the time series cleanup threw, desyncing the id index, subsystems, and shared references; cleanup now runs first.
- `assign_new_id!` had the same pop-before-mutate pattern and skipped the read-only check. It now requires the stored instance by identity (`_validate` + the id index), refuses a read-only store before mutating, and re-indexes after the id changes. `has_component(data, component)` is likewise membership by identity — integer ids are not unique across systems.
- `fast_deepcopy_system(skip_time_series = true)` still deep-copied the real store: the `Components` containers hold the manager, and masked components and supplemental attributes kept their old references. Every path is now redirected before `deepcopy` and restored after.
- The instance-form forecast window check `@assert_op size(data)[1] <= len` was inverted for 2-D (`Probabilistic`/`Scenarios`) windows; replaced by a `len` range check.
- `TimeSeriesKey` gained field-wise `==`/`hash`, so the key from `add_time_series!` (`Hour(1)`) equals the one listed back from the catalog (`Millisecond(3600000)`).

Also documented the flush-on-read rule in `.claude/CLAUDE.md`.

### Not in this PR

Findings that are upstream (InfraStore.jl: typed exact-key operations not widening `Deterministic` → DST, `resolution = nothing` asymmetry between remove/rename and has/get, pre-1970 `get_forecast_parameters`, strict feature-value typing) or judgment calls (silent no-match on by-name `remove_time_series!`, `StaticTimeSeriesCache` over `NonSequentialTimeSeries`).

## Test plan

- [x] New `test/test_time_series_consistency.jl` (16 test sets, 133 tests), each tied to a finding above
- [x] Full suite: 9198 pass, 2 pre-existing broken, 0 fail
- [x] Formatter run
- [ ] Downstream smoke (`using PowerSystems, PowerNetworkMatrices, PowerFlows, PowerOperationsModels, PowerSystemCaseBuilder`) — the stricter `copy_time_series!` and identity-based `has_component` are the behaviors most likely to surface there

🤖 Generated with [Claude Code](https://claude.com/claude-code)
