### PR TITLE
Refactor time series features as explicit dictionaries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,6 +33,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [sources]
+InfraStore = {url = "https://github.com/NatLabRockies/infrastore.git", rev = "refactor/optional-time-series-features", subdir = "julia/InfraStore.jl"}
 # Git rev, not a sibling path: a relative path resolves only in a workspace checkout and
 # fails outright in CI, which clones this repo alone. Pinned to a branch rather than a
 # version because PowerOpenAPIModels is not registered.

--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,6 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [sources]
-InfraStore = {url = "https://github.com/NatLabRockies/infrastore.git", rev = "refactor/optional-time-series-features", subdir = "julia/InfraStore.jl"}
 # Git rev, not a sibling path: a relative path resolves only in a workspace checkout and
 # fails outright in CI, which clones this repo alone. Pinned to a branch rather than a
 # version because PowerOpenAPIModels is not registered.

--- a/benchmark/bench.jl
+++ b/benchmark/bench.jl
@@ -76,7 +76,8 @@ end
 # Batched adds: stage on the transaction's AddBatch and commit once.
 function bulk_add!(f::Function, sys)
     IS.time_series_transaction(sys) do txn
-        f((c, ts; feat...) -> IS.add_time_series!(txn, c, ts; feat...))
+        f((c, ts; features = Dict{String, Any}()) ->
+            IS.add_time_series!(txn, c, ts; features = features))
     end
 end
 
@@ -507,7 +508,8 @@ function run_has_kind(n)
         nq,
         () -> bulk_add!(sys) do addfn
             for c in comps, (j, (name, scen)) in enumerate(names)
-                addfn(c, base[mod1(j, 2)]; scenario = scen, model_year = "2030")
+                addfn(c, base[mod1(j, 2)];
+                    features = Dict("scenario" => scen, "model_year" => "2030"))
             end
         end,
     )
@@ -522,7 +524,8 @@ function run_has_kind(n)
         () -> begin
             for c in comps, (name, scen) in names
                 hits[] += IS.has_time_series(c, IS.SingleTimeSeries, name;
-                    resolution = RES, scenario = scen, model_year = "2030")
+                    resolution = RES,
+                    features = Dict("scenario" => scen, "model_year" => "2030"))
             end
         end,
     )
@@ -537,7 +540,8 @@ function run_has_kind(n)
         () -> begin
             for c in comps, (name, _) in names
                 misses[] += IS.has_time_series(c, IS.SingleTimeSeries, name;
-                    resolution = RES, scenario = "s99", model_year = "2030")
+                    resolution = RES,
+                    features = Dict("scenario" => "s99", "model_year" => "2030"))
             end
         end,
     )

--- a/benchmark/bench.jl
+++ b/benchmark/bench.jl
@@ -76,7 +76,7 @@ end
 # Batched adds: stage on the transaction's AddBatch and commit once.
 function bulk_add!(f::Function, sys)
     IS.time_series_transaction(sys) do txn
-        f((c, ts; features = Dict{String, Any}()) ->
+        f((c, ts; features = nothing) ->
             IS.add_time_series!(txn, c, ts; features = features))
     end
 end

--- a/docs/src/docs_best_practices/how-to/write_docstrings_org_api.md
+++ b/docs/src/docs_best_practices/how-to/write_docstrings_org_api.md
@@ -210,7 +210,7 @@ This is not commonly done in Sienna yet, but a goal is to improve our use of
         name::AbstractString;
         start_time::Union{Nothing, Dates.DateTime} = nothing,
         len::Union{Nothing, Int} = nothing,
-        features::Dict = Dict(),
+        features::Dict = Dict{String, Any}(),
     ) where {T <: TimeSeriesData}),
     [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
         owner::TimeSeriesOwners,

--- a/docs/src/docs_best_practices/how-to/write_docstrings_org_api.md
+++ b/docs/src/docs_best_practices/how-to/write_docstrings_org_api.md
@@ -210,7 +210,7 @@ This is not commonly done in Sienna yet, but a goal is to improve our use of
         name::AbstractString;
         start_time::Union{Nothing, Dates.DateTime} = nothing,
         len::Union{Nothing, Int} = nothing,
-        features...,
+        features::Dict = Dict(),
     ) where {T <: TimeSeriesData}),
     [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
         owner::TimeSeriesOwners,

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -459,7 +459,7 @@ end
 
 """
     serialize_single!(batch, owner_id, owner_type, owner_category, name, sts;
-                      features=Dict{String, Any}(), units=get_units(sts),
+                      features=nothing, units=get_units(sts),
                       quantity_kind=get_quantity_kind(sts), unit_system=get_unit_system(sts))
 
 Stage a `SingleTimeSeries` (data + metadata) onto a `InfraStore.AddBatch` for a
@@ -475,7 +475,7 @@ function serialize_single!(
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString,
     sts::SingleTimeSeries;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
     units::Union{Nothing, AbstractString} = get_units(sts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(sts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(sts),
@@ -499,7 +499,7 @@ end
 
 """
     serialize_non_sequential!(batch, owner_id, owner_type, owner_category, name, nts;
-                              features=Dict{String, Any}(), units=get_units(nts),
+                              features=nothing, units=get_units(nts),
                               quantity_kind=get_quantity_kind(nts),
                               unit_system=get_unit_system(nts))
 
@@ -517,7 +517,7 @@ function serialize_non_sequential!(
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString,
     nts::NonSequentialTimeSeries;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
     units::Union{Nothing, AbstractString} = get_units(nts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(nts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(nts),
@@ -538,7 +538,7 @@ function serialize_non_sequential!(
 end
 
 """
-    get_non_sequential(store, owner_id, owner_category, name; features=Dict{String, Any}(), time_range=nothing) -> NonSequentialTimeSeries
+    get_non_sequential(store, owner_id, owner_category, name; features=nothing, time_range=nothing) -> NonSequentialTimeSeries
 
 Reconstruct a `NonSequentialTimeSeries` (timestamps + decoded array) from the InfraStore
 store. A non-sequential series is addressed by name + features (it has no resolution).
@@ -551,7 +551,7 @@ function get_non_sequential(
     owner_id::Integer,
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
     time_range::Union{Nothing, Tuple{Dates.DateTime, Dates.DateTime}} = nothing,
 )
     nts = InfraStore.get_time_series(InfraStore.NonSequentialTimeSeries, store.inner,
@@ -704,7 +704,7 @@ function infrastore_add_time_series!(
     mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     batch = InfraStore.AddBatch()
     key, _ = _infrastore_stage!(
@@ -771,7 +771,7 @@ infrastore_get_time_series(
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: Forecast} = _infrastore_get_forecast(owner, name;
     time_series_type = T,
     start_time = start_time, len = len, count = count, resolution = resolution,
@@ -790,7 +790,7 @@ function infrastore_get_time_series(
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,  # rejected when provided
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     _check_interval_supported(SingleTimeSeries, interval)
     # Resolve the unique series matching a possibly-partial (subset) feature /
@@ -875,7 +875,7 @@ function infrastore_get_time_series(
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
     interval::Union{Nothing, Dates.Period} = nothing,  # rejected when provided
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     _check_interval_supported(NonSequentialTimeSeries, interval)
     # Resolve the unique series matching a possibly-partial (subset) feature query,
@@ -976,7 +976,7 @@ function _infrastore_stage!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     throw_if_does_not_support_time_series(owner)
     check_time_series_data(time_series)
@@ -996,7 +996,7 @@ function _infrastore_stage_data!(
     ::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::SingleTimeSeries;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
@@ -1009,7 +1009,7 @@ function _infrastore_stage_data!(
         initial_timestamp = get_initial_timestamp(time_series),
         resolution = get_resolution(time_series),
         length = length(time_series),
-        features = Dict{String, Any}(feats),
+        features = _key_features(feats),
     )
     return key, nbytes
 end
@@ -1020,7 +1020,7 @@ function _infrastore_stage_data!(
     ::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::NonSequentialTimeSeries;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
@@ -1031,7 +1031,7 @@ function _infrastore_stage_data!(
         time_series_type = NonSequentialTimeSeries,
         name = name,
         length = length(time_series),
-        features = Dict{String, Any}(feats),
+        features = _key_features(feats),
     )
     return key, nbytes
 end
@@ -1071,7 +1071,7 @@ function _infrastore_stage_forecast!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Forecast;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     _infrastore_check_staged_forecast!(params_cache, mgr, ts)
     owner_id, owner_type, category = _infrastore_owner_args(owner)
@@ -1091,7 +1091,7 @@ function _infrastore_stage_forecast!(
         time_series_type = _unparameterized_type(typeof(ts)), name = name,
         initial_timestamp = initial, resolution = resolution,
         horizon = horizon, interval = interval, count = count,
-        features = Dict{String, Any}(feats))
+        features = _key_features(feats))
     # `obj.data` is the encoded dense array the batch buffers; its byte size drives
     # auto-flush.
     return key, sizeof(obj.data)
@@ -1103,7 +1103,7 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Probabilistic;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
@@ -1123,7 +1123,7 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Deterministic;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
@@ -1147,7 +1147,7 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Scenarios;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
@@ -1167,7 +1167,7 @@ _infrastore_stage_data!(
     ::AbstractDict,
     ::TimeSeriesOwners,
     ts::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) = error(
     "InfraStore backend supports SingleTimeSeries, NonSequentialTimeSeries, " *
     "Deterministic, Probabilistic, and Scenarios (got $(typeof(ts))). A " *
@@ -1267,7 +1267,7 @@ function _infrastore_get_forecast(
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     key::Union{Nothing, ForecastKey} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     mgr = get_time_series_manager(owner)
     store = mgr.data_store
@@ -1531,7 +1531,7 @@ _infrastore_row_match_identity(x) = (
 function _infrastore_metadata_by_identity(store::Store, resolution, name, features)
     metas = Dict{Any, InfraStore.TimeSeriesMetadata}()
     for m in InfraStore.list_time_series(store.inner;
-        resolution = resolution, name = name, features = Dict{String, Any}(features))
+        resolution = resolution, name = name, features = _infrastore_features(features))
         # Identities are unique per (resolution, interval, features); rows that
         # collide here differ only by interval and are unreachable behind a
         # reader build (they cannot share a window timeline).
@@ -1557,7 +1557,7 @@ function infrastore_build_forecast_reader(
     ::Type{T};
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: Forecast}
     inner = InfraStore.build_forecast_reader(store.inner, _tss_forecast_type(T);
         resolution = resolution, name = name, features = features)
@@ -1685,7 +1685,7 @@ function infrastore_build_static_time_series_reader(
     id_to_owner;
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     inner = InfraStore.build_static_reader(store.inner;
         resolution = resolution, name = name, features = features)
@@ -1807,7 +1807,7 @@ function infrastore_has_time_series(
     name::Union{Nothing, AbstractString};
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     _check_interval_supported(T, interval)
     mgr = get_time_series_manager(owner)
@@ -2019,10 +2019,10 @@ function _infrastore_list_keys(
     name = nothing,
     resolution = nothing,
     interval = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     type_filter = _infrastore_pushable_type(time_series_type)
-    feats = Dict{String, Any}(string(k) => v for (k, v) in features)
+    feats = _infrastore_features(features)
     rows =
         InfraStore.list_keys(store.inner; owner_id = owner_id,
             owner_category = owner_category, time_series_type = type_filter,
@@ -2049,7 +2049,7 @@ function infrastore_owner_list_keys(
     name = nothing,
     resolution = nothing,
     interval = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     !isnothing(time_series_type) &&
         _check_interval_supported(time_series_type, interval)
@@ -2068,7 +2068,7 @@ function infrastore_get_time_series_key(
     name::AbstractString;
     resolution = nothing,
     interval = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     items = infrastore_owner_list_keys(owner; time_series_type = T, name = name,
         resolution = resolution, interval = interval, features = features)
@@ -2125,7 +2125,7 @@ function infrastore_get_time_series_hashes(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     _check_interval_supported(T, interval)
     hashes = Dict{Int, String}()
@@ -2396,7 +2396,7 @@ function _infrastore_remove_by_filter!(
     name::Union{Nothing, String} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     !isnothing(time_series_type) &&
         _check_interval_supported(time_series_type, interval)

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -475,7 +475,7 @@ function serialize_single!(
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString,
     sts::SingleTimeSeries;
-    features = Dict{String, Any}(),
+    features::Dict = Dict(),
     units::Union{Nothing, AbstractString} = get_units(sts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(sts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(sts),
@@ -517,7 +517,7 @@ function serialize_non_sequential!(
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString,
     nts::NonSequentialTimeSeries;
-    features = Dict{String, Any}(),
+    features::Dict = Dict(),
     units::Union{Nothing, AbstractString} = get_units(nts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(nts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(nts),
@@ -551,7 +551,7 @@ function get_non_sequential(
     owner_id::Integer,
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString;
-    features = Dict{String, Any}(),
+    features::Dict = Dict(),
     time_range::Union{Nothing, Tuple{Dates.DateTime, Dates.DateTime}} = nothing,
 )
     nts = InfraStore.get_time_series(InfraStore.NonSequentialTimeSeries, store.inner,
@@ -704,7 +704,7 @@ function infrastore_add_time_series!(
     mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     batch = InfraStore.AddBatch()
     key, _ = _infrastore_stage!(
@@ -713,7 +713,7 @@ function infrastore_add_time_series!(
         Dict{Tuple{Dates.Period, Dates.Period}, Any}(),
         owner,
         time_series;
-        features...,
+        features = features,
     )
     try
         InfraStore.add_time_series_bulk!(mgr.data_store.inner, batch)
@@ -771,11 +771,11 @@ infrastore_get_time_series(
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: Forecast} = _infrastore_get_forecast(owner, name;
     time_series_type = T,
     start_time = start_time, len = len, count = count, resolution = resolution,
-    interval = interval, features...)
+    interval = interval, features = features)
 
 """
 Route a public `get_time_series(SingleTimeSeries, owner, name; ...)` to the InfraStore
@@ -789,7 +789,8 @@ function infrastore_get_time_series(
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    interval::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
+    features::Dict = Dict(),
 )
     # Resolve the unique series matching a possibly-partial (subset) feature /
     # resolution query, then read it by its exact stored attributes.
@@ -798,7 +799,7 @@ function infrastore_get_time_series(
         SingleTimeSeries,
         name;
         resolution = resolution,
-        features...,
+        features = features,
     )
     return _infrastore_read_single(owner, key; start_time = start_time, len = len)
 end
@@ -872,11 +873,13 @@ function infrastore_get_time_series(
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
-    features...,
+    interval::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
+    features::Dict = Dict(),
 )
     # Resolve the unique series matching a possibly-partial (subset) feature query,
     # then read it by its exact stored attributes.
-    key = infrastore_get_time_series_key(owner, NonSequentialTimeSeries, name; features...)
+    key = infrastore_get_time_series_key(
+        owner, NonSequentialTimeSeries, name; features = features)
     return _infrastore_read_non_sequential(owner, key; start_time = start_time, len = len)
 end
 
@@ -971,7 +974,7 @@ function _infrastore_stage!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     throw_if_does_not_support_time_series(owner)
     check_time_series_data(time_series)
@@ -981,7 +984,7 @@ function _infrastore_stage!(
         params_cache,
         owner,
         time_series;
-        features...,
+        features = features,
     )
 end
 
@@ -991,7 +994,7 @@ function _infrastore_stage_data!(
     ::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::SingleTimeSeries;
-    features...,
+    features::Dict = Dict(),
 )
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
@@ -1015,7 +1018,7 @@ function _infrastore_stage_data!(
     ::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::NonSequentialTimeSeries;
-    features...,
+    features::Dict = Dict(),
 )
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
@@ -1066,7 +1069,7 @@ function _infrastore_stage_forecast!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Forecast;
-    features...,
+    features::Dict = Dict(),
 )
     _infrastore_check_staged_forecast!(params_cache, mgr, ts)
     owner_id, owner_type, category = _infrastore_owner_args(owner)
@@ -1098,10 +1101,10 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Probabilistic;
-    features...,
+    features::Dict = Dict(),
 )
     return _infrastore_stage_forecast!(
-        batch, mgr, params_cache, owner, ts; features...,
+        batch, mgr, params_cache, owner, ts; features = features,
     ) do initial, resolution, horizon, interval, name
         arr = _dense_forecast_array(ts, length(get_percentiles(ts)))
         prob = InfraStore.Probabilistic(initial, resolution, horizon, interval,
@@ -1118,10 +1121,10 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Deterministic;
-    features...,
+    features::Dict = Dict(),
 )
     return _infrastore_stage_forecast!(
-        batch, mgr, params_cache, owner, ts; features...,
+        batch, mgr, params_cache, owner, ts; features = features,
     ) do initial, resolution, horizon, interval, name
         # (horizon_count, count) for scalars; (horizon_count, count, k) tagged
         # with the element type for FunctionData and NTuple windows.
@@ -1142,10 +1145,10 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Scenarios;
-    features...,
+    features::Dict = Dict(),
 )
     return _infrastore_stage_forecast!(
-        batch, mgr, params_cache, owner, ts; features...,
+        batch, mgr, params_cache, owner, ts; features = features,
     ) do initial, resolution, horizon, interval, name
         arr = _dense_forecast_array(ts, get_scenario_count(ts))
         scen = InfraStore.Scenarios(initial, resolution, horizon, interval,
@@ -1162,7 +1165,7 @@ _infrastore_stage_data!(
     ::AbstractDict,
     ::TimeSeriesOwners,
     ts::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 ) = error(
     "InfraStore backend supports SingleTimeSeries, NonSequentialTimeSeries, " *
     "Deterministic, Probabilistic, and Scenarios (got $(typeof(ts))). A " *
@@ -1262,7 +1265,7 @@ function _infrastore_get_forecast(
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     key::Union{Nothing, ForecastKey} = nothing,
-    features...,
+    features::Dict = Dict(),
 )
     mgr = get_time_series_manager(owner)
     store = mgr.data_store
@@ -1276,7 +1279,7 @@ function _infrastore_get_forecast(
     matched = if isnothing(key)
         infrastore_get_time_series_key(
             owner, time_series_type, name;
-            resolution = resolution, interval = interval, features...,
+            resolution = resolution, interval = interval, features = features,
         )
     else
         key
@@ -1552,7 +1555,7 @@ function infrastore_build_forecast_reader(
     ::Type{T};
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features = Dict{String, Any}(),
+    features::Dict = Dict(),
 ) where {T <: Forecast}
     inner = InfraStore.build_forecast_reader(store.inner, _tss_forecast_type(T);
         resolution = resolution, name = name, features = features)
@@ -1680,7 +1683,7 @@ function infrastore_build_static_time_series_reader(
     id_to_owner;
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features = Dict{String, Any}(),
+    features::Dict = Dict(),
 )
     inner = InfraStore.build_static_reader(store.inner;
         resolution = resolution, name = name, features = features)
@@ -1802,7 +1805,7 @@ function infrastore_has_time_series(
     name::Union{Nothing, AbstractString};
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(owner)
     store = mgr.data_store
@@ -2013,7 +2016,7 @@ function _infrastore_list_keys(
     name = nothing,
     resolution = nothing,
     interval = nothing,
-    features = (),
+    features::Dict = Dict(),
 )
     type_filter = _infrastore_pushable_type(time_series_type)
     feats = Dict{String, Any}(string(k) => v for (k, v) in features)
@@ -2043,7 +2046,7 @@ function infrastore_owner_list_keys(
     name = nothing,
     resolution = nothing,
     interval = nothing,
-    features...,
+    features::Dict = Dict(),
 )
     mgr = get_time_series_manager(owner)
     store = mgr.data_store
@@ -2060,10 +2063,10 @@ function infrastore_get_time_series_key(
     name::AbstractString;
     resolution = nothing,
     interval = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     items = infrastore_owner_list_keys(owner; time_series_type = T, name = name,
-        resolution = resolution, interval = interval, features...)
+        resolution = resolution, interval = interval, features = features)
     if isempty(items)
         throw(ArgumentError("No matching metadata is stored."))
     elseif length(items) > 1
@@ -2117,7 +2120,7 @@ function infrastore_get_time_series_hashes(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     hashes = Dict{Int, String}()
     isempty(owners) && return hashes
@@ -2387,7 +2390,7 @@ function _infrastore_remove_by_filter!(
     name::Union{Nothing, String} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::AbstractDict = Dict{String, Any}(),
+    features::Dict = Dict(),
 )
     remove =
         t -> InfraStore.remove_by_filter!(

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -789,9 +789,10 @@ function infrastore_get_time_series(
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,
-    interval::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
+    interval::Union{Nothing, Dates.Period} = nothing,  # rejected when provided
     features::Dict = Dict(),
 )
+    _check_interval_supported(SingleTimeSeries, interval)
     # Resolve the unique series matching a possibly-partial (subset) feature /
     # resolution query, then read it by its exact stored attributes.
     key = infrastore_get_time_series_key(
@@ -873,9 +874,10 @@ function infrastore_get_time_series(
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
-    interval::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
+    interval::Union{Nothing, Dates.Period} = nothing,  # rejected when provided
     features::Dict = Dict(),
 )
+    _check_interval_supported(NonSequentialTimeSeries, interval)
     # Resolve the unique series matching a possibly-partial (subset) feature query,
     # then read it by its exact stored attributes.
     key = infrastore_get_time_series_key(
@@ -1807,6 +1809,7 @@ function infrastore_has_time_series(
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
+    _check_interval_supported(T, interval)
     mgr = get_time_series_manager(owner)
     store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
@@ -2048,6 +2051,8 @@ function infrastore_owner_list_keys(
     interval = nothing,
     features::Dict = Dict(),
 )
+    !isnothing(time_series_type) &&
+        _check_interval_supported(time_series_type, interval)
     mgr = get_time_series_manager(owner)
     store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
@@ -2122,6 +2127,7 @@ function infrastore_get_time_series_hashes(
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
+    _check_interval_supported(T, interval)
     hashes = Dict{Int, String}()
     isempty(owners) && return hashes
     owner = first(owners)
@@ -2392,6 +2398,8 @@ function _infrastore_remove_by_filter!(
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Dict = Dict(),
 )
+    !isnothing(time_series_type) &&
+        _check_interval_supported(time_series_type, interval)
     remove =
         t -> InfraStore.remove_by_filter!(
             store.inner;

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -459,7 +459,7 @@ end
 
 """
     serialize_single!(batch, owner_id, owner_type, owner_category, name, sts;
-                      features=Dict(), units=get_units(sts),
+                      features=Dict{String, Any}(), units=get_units(sts),
                       quantity_kind=get_quantity_kind(sts), unit_system=get_unit_system(sts))
 
 Stage a `SingleTimeSeries` (data + metadata) onto a `InfraStore.AddBatch` for a
@@ -475,7 +475,7 @@ function serialize_single!(
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString,
     sts::SingleTimeSeries;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
     units::Union{Nothing, AbstractString} = get_units(sts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(sts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(sts),
@@ -499,7 +499,7 @@ end
 
 """
     serialize_non_sequential!(batch, owner_id, owner_type, owner_category, name, nts;
-                              features=Dict(), units=get_units(nts),
+                              features=Dict{String, Any}(), units=get_units(nts),
                               quantity_kind=get_quantity_kind(nts),
                               unit_system=get_unit_system(nts))
 
@@ -517,7 +517,7 @@ function serialize_non_sequential!(
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString,
     nts::NonSequentialTimeSeries;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
     units::Union{Nothing, AbstractString} = get_units(nts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(nts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(nts),
@@ -538,7 +538,7 @@ function serialize_non_sequential!(
 end
 
 """
-    get_non_sequential(store, owner_id, owner_category, name; features=Dict(), time_range=nothing) -> NonSequentialTimeSeries
+    get_non_sequential(store, owner_id, owner_category, name; features=Dict{String, Any}(), time_range=nothing) -> NonSequentialTimeSeries
 
 Reconstruct a `NonSequentialTimeSeries` (timestamps + decoded array) from the InfraStore
 store. A non-sequential series is addressed by name + features (it has no resolution).
@@ -551,7 +551,7 @@ function get_non_sequential(
     owner_id::Integer,
     owner_category::InfraStore.OwnerCategory,
     name::AbstractString;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
     time_range::Union{Nothing, Tuple{Dates.DateTime, Dates.DateTime}} = nothing,
 )
     nts = InfraStore.get_time_series(InfraStore.NonSequentialTimeSeries, store.inner,
@@ -704,7 +704,7 @@ function infrastore_add_time_series!(
     mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     batch = InfraStore.AddBatch()
     key, _ = _infrastore_stage!(
@@ -771,7 +771,7 @@ infrastore_get_time_series(
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: Forecast} = _infrastore_get_forecast(owner, name;
     time_series_type = T,
     start_time = start_time, len = len, count = count, resolution = resolution,
@@ -790,7 +790,7 @@ function infrastore_get_time_series(
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,  # rejected when provided
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     _check_interval_supported(SingleTimeSeries, interval)
     # Resolve the unique series matching a possibly-partial (subset) feature /
@@ -875,7 +875,7 @@ function infrastore_get_time_series(
     count::Union{Nothing, Int} = nothing,  # not applicable to a static series; ignored
     resolution::Union{Nothing, Dates.Period} = nothing,  # not applicable; ignored
     interval::Union{Nothing, Dates.Period} = nothing,  # rejected when provided
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     _check_interval_supported(NonSequentialTimeSeries, interval)
     # Resolve the unique series matching a possibly-partial (subset) feature query,
@@ -976,7 +976,7 @@ function _infrastore_stage!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     throw_if_does_not_support_time_series(owner)
     check_time_series_data(time_series)
@@ -996,7 +996,7 @@ function _infrastore_stage_data!(
     ::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::SingleTimeSeries;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
@@ -1020,7 +1020,7 @@ function _infrastore_stage_data!(
     ::AbstractDict,
     owner::TimeSeriesOwners,
     time_series::NonSequentialTimeSeries;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
@@ -1071,7 +1071,7 @@ function _infrastore_stage_forecast!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Forecast;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     _infrastore_check_staged_forecast!(params_cache, mgr, ts)
     owner_id, owner_type, category = _infrastore_owner_args(owner)
@@ -1103,7 +1103,7 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Probabilistic;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
@@ -1123,7 +1123,7 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Deterministic;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
@@ -1147,7 +1147,7 @@ function _infrastore_stage_data!(
     params_cache::AbstractDict,
     owner::TimeSeriesOwners,
     ts::Scenarios;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
@@ -1167,7 +1167,7 @@ _infrastore_stage_data!(
     ::AbstractDict,
     ::TimeSeriesOwners,
     ts::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) = error(
     "InfraStore backend supports SingleTimeSeries, NonSequentialTimeSeries, " *
     "Deterministic, Probabilistic, and Scenarios (got $(typeof(ts))). A " *
@@ -1267,7 +1267,7 @@ function _infrastore_get_forecast(
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     key::Union{Nothing, ForecastKey} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     mgr = get_time_series_manager(owner)
     store = mgr.data_store
@@ -1557,7 +1557,7 @@ function infrastore_build_forecast_reader(
     ::Type{T};
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: Forecast}
     inner = InfraStore.build_forecast_reader(store.inner, _tss_forecast_type(T);
         resolution = resolution, name = name, features = features)
@@ -1685,7 +1685,7 @@ function infrastore_build_static_time_series_reader(
     id_to_owner;
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     inner = InfraStore.build_static_reader(store.inner;
         resolution = resolution, name = name, features = features)
@@ -1807,7 +1807,7 @@ function infrastore_has_time_series(
     name::Union{Nothing, AbstractString};
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     _check_interval_supported(T, interval)
     mgr = get_time_series_manager(owner)
@@ -2019,7 +2019,7 @@ function _infrastore_list_keys(
     name = nothing,
     resolution = nothing,
     interval = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     type_filter = _infrastore_pushable_type(time_series_type)
     feats = Dict{String, Any}(string(k) => v for (k, v) in features)
@@ -2049,7 +2049,7 @@ function infrastore_owner_list_keys(
     name = nothing,
     resolution = nothing,
     interval = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     !isnothing(time_series_type) &&
         _check_interval_supported(time_series_type, interval)
@@ -2068,7 +2068,7 @@ function infrastore_get_time_series_key(
     name::AbstractString;
     resolution = nothing,
     interval = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     items = infrastore_owner_list_keys(owner; time_series_type = T, name = name,
         resolution = resolution, interval = interval, features = features)
@@ -2125,7 +2125,7 @@ function infrastore_get_time_series_hashes(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     _check_interval_supported(T, interval)
     hashes = Dict{Int, String}()
@@ -2396,7 +2396,7 @@ function _infrastore_remove_by_filter!(
     name::Union{Nothing, String} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     !isnothing(time_series_type) &&
         _check_interval_supported(time_series_type, interval)

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -173,7 +173,7 @@ function add_time_series!(
     data::SystemData,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     _validate(data, owner)
     return add_time_series!(data.time_series_manager, owner, time_series; features = features)
@@ -197,7 +197,7 @@ function add_time_series!(
     data::SystemData,
     components,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     # A block opened for just this call, so the components land as one batch,
     # atomically. The transaction's dispatch stores the array once and validates
@@ -217,7 +217,7 @@ function remove_time_series!(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     return remove_time_series!(
         data.time_series_manager,
@@ -1280,7 +1280,7 @@ function build_forecast_reader(
     ::Type{T};
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: Forecast}
     store = get_data_store(data)
     id_to_owner = _make_id_to_owner(data)
@@ -1311,7 +1311,7 @@ function build_static_time_series_reader(
     data::SystemData;
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     store = get_data_store(data)
     id_to_owner = _make_id_to_owner(data)

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -173,10 +173,10 @@ function add_time_series!(
     data::SystemData,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     _validate(data, owner)
-    return add_time_series!(data.time_series_manager, owner, time_series; features...)
+    return add_time_series!(data.time_series_manager, owner, time_series; features = features)
 end
 
 """
@@ -197,13 +197,13 @@ function add_time_series!(
     data::SystemData,
     components,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     # A block opened for just this call, so the components land as one batch,
     # atomically. The transaction's dispatch stores the array once and validates
     # each component against `data`.
     return time_series_transaction(data) do txn
-        add_time_series!(txn, components, time_series; features...)
+        add_time_series!(txn, components, time_series; features = features)
     end
 end
 
@@ -217,7 +217,7 @@ function remove_time_series!(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     return remove_time_series!(
         data.time_series_manager,
@@ -226,7 +226,7 @@ function remove_time_series!(
         name;
         resolution = resolution,
         interval = interval,
-        features...,
+        features = features,
     )
 end
 
@@ -1280,7 +1280,7 @@ function build_forecast_reader(
     ::Type{T};
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: Forecast}
     store = get_data_store(data)
     id_to_owner = _make_id_to_owner(data)
@@ -1290,7 +1290,7 @@ function build_forecast_reader(
         T;
         resolution = resolution,
         name = name,
-        features = Dict{String, Any}(string(k) => v for (k, v) in features),
+        features = features,
     )
 end
 
@@ -1311,7 +1311,7 @@ function build_static_time_series_reader(
     data::SystemData;
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features...,
+    features::Dict = Dict(),
 )
     store = get_data_store(data)
     id_to_owner = _make_id_to_owner(data)
@@ -1320,7 +1320,7 @@ function build_static_time_series_reader(
         id_to_owner;
         resolution = resolution,
         name = name,
-        features = Dict{String, Any}(string(k) => v for (k, v) in features),
+        features = features,
     )
 end
 

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -173,7 +173,7 @@ function add_time_series!(
     data::SystemData,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     _validate(data, owner)
     return add_time_series!(data.time_series_manager, owner, time_series; features = features)
@@ -197,7 +197,7 @@ function add_time_series!(
     data::SystemData,
     components,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     # A block opened for just this call, so the components land as one batch,
     # atomically. The transaction's dispatch stores the array once and validates
@@ -217,7 +217,7 @@ function remove_time_series!(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     return remove_time_series!(
         data.time_series_manager,
@@ -1280,7 +1280,7 @@ function build_forecast_reader(
     ::Type{T};
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: Forecast}
     store = get_data_store(data)
     id_to_owner = _make_id_to_owner(data)
@@ -1311,7 +1311,7 @@ function build_static_time_series_reader(
     data::SystemData;
     resolution::Dates.Period,
     name::Union{Nothing, AbstractString} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     store = get_data_store(data)
     id_to_owner = _make_id_to_owner(data)

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -42,7 +42,7 @@ Specify `start_time` and `len` if you only need a subset of data.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Union{Nothing, Dict} = nothing`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref), [`get_time_series_values`](@ref),
@@ -63,7 +63,7 @@ function get_time_series(
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     TimerOutputs.@timeit_debug SYSTEM_TIMERS "get_time_series" begin
         return infrastore_get_time_series(
@@ -92,7 +92,7 @@ Specify start_time and len if you only need a subset of data.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Union{Nothing, Dict} = nothing`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series` by name](@ref get_time_series(
@@ -102,7 +102,7 @@ See also: [`get_time_series` by name](@ref get_time_series(
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData})
 """
 function get_time_series(
@@ -230,7 +230,7 @@ function get_time_series_key(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(owner)
     return get_time_series_key(
@@ -265,7 +265,7 @@ Specify `start_time` and `len` if you only need a subset of data.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Union{Nothing, Dict} = nothing`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_values`](@ref get_time_series_values(
@@ -274,14 +274,14 @@ See also: [`get_time_series_values`](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-features::Dict = Dict{String, Any}(),) where {T <: TimeSeriesData}),
+features::Union{Nothing, Dict} = nothing,) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps`](@ref get_time_series_timestamps(
     ::Type{T},
     owner::TimeSeriesOwners,
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -304,7 +304,7 @@ function get_time_series_array(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     ts = get_time_series(
         T,
@@ -347,7 +347,7 @@ See also: [`get_time_series_array` by name](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values`](@ref),
 [`get_time_series_timestamps`](@ref)
@@ -405,7 +405,7 @@ See also [`get_time_series_values`](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -449,7 +449,7 @@ See also: [`get_time_series_values`](@ref get_time_series_values(owner::TimeSeri
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `ForecastCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -489,7 +489,7 @@ Return a vector of timestamps from storage for the given time series parameters.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Union{Nothing, Dict} = nothing`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
@@ -498,7 +498,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values`](@ref get_time_series_values(
     ::Type{T},
@@ -506,7 +506,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-features::Dict = Dict{String, Any}(),) where {T <: TimeSeriesData}),
+features::Union{Nothing, Dict} = nothing,) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `StaticTimeSeriesCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
     time_series::StaticTimeSeries;
@@ -528,7 +528,7 @@ function get_time_series_timestamps(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     return TimeSeries.timestamp(
         get_time_series_array(
@@ -562,7 +562,7 @@ See also: [`get_time_series_timestamps` by name](@ref get_time_series_timestamps
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array`](@ref),
 [`get_time_series_values`](@ref)
@@ -605,7 +605,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `StaticTimeSeriesCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -650,7 +650,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `ForecastCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -689,7 +689,7 @@ that accepts a cached `TimeSeriesData` instance.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Union{Nothing, Dict} = nothing`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
@@ -698,7 +698,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps`](@ref get_time_series_timestamps(
     ::Type{T},
@@ -706,7 +706,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series`](@ref),
 [`get_time_series_values` from a `StaticTimeSeriesCache`](@ref get_time_series_values(
@@ -730,7 +730,7 @@ function get_time_series_values(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     return TimeSeries.values(
         get_time_series_array(
@@ -764,7 +764,7 @@ See also: [`get_time_series_values` by name](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array`](@ref),
 [`get_time_series_timestamps`](@ref)
@@ -858,7 +858,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values` from a `ForecastCache`](@ref get_time_series_values(
     owner::TimeSeriesOwners,
@@ -907,7 +907,7 @@ function has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(val)
     isnothing(mgr) && return false
@@ -927,7 +927,7 @@ function has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     return has_time_series(
         owner,
@@ -950,7 +950,7 @@ has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) = has_time_series(
     owner,
     T,
@@ -1111,7 +1111,7 @@ function get_time_series_keys(
     name::Union{String, Nothing} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     mgr = get_time_series_manager(owner)
     isnothing(mgr) && return TimeSeriesKey[]
@@ -1163,7 +1163,7 @@ get_time_series_hashes(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData} =
     infrastore_get_time_series_hashes(
         owners,

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -42,7 +42,7 @@ Specify `start_time` and `len` if you only need a subset of data.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features...`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref), [`get_time_series_values`](@ref),
@@ -63,13 +63,13 @@ function get_time_series(
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     TimerOutputs.@timeit_debug SYSTEM_TIMERS "get_time_series" begin
         return infrastore_get_time_series(
             T, owner, name;
             start_time = start_time, len = len, count = count,
-            resolution = resolution, interval = interval, features...,
+            resolution = resolution, interval = interval, features = features,
         )
     end
 end
@@ -92,7 +92,7 @@ Specify start_time and len if you only need a subset of data.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features...`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series` by name](@ref get_time_series(
@@ -102,7 +102,7 @@ See also: [`get_time_series` by name](@ref get_time_series(
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData})
 """
 function get_time_series(
@@ -230,7 +230,7 @@ function get_time_series_key(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(owner)
     return get_time_series_key(
@@ -240,7 +240,7 @@ function get_time_series_key(
         name;
         resolution = resolution,
         interval = interval,
-        features...,
+        features = features,
     )
 end
 
@@ -265,7 +265,7 @@ Specify `start_time` and `len` if you only need a subset of data.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features...`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_values`](@ref get_time_series_values(
@@ -274,14 +274,14 @@ See also: [`get_time_series_values`](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-features...,) where {T <: TimeSeriesData}),
+features::Dict = Dict(),) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps`](@ref get_time_series_timestamps(
     ::Type{T},
     owner::TimeSeriesOwners,
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -304,7 +304,7 @@ function get_time_series_array(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     ts = get_time_series(
         T,
@@ -315,7 +315,7 @@ function get_time_series_array(
         start_time = start_time,
         len = len,
         count = 1,
-        features...,
+        features = features,
     )
     if start_time === nothing
         start_time = get_initial_timestamp(ts)
@@ -347,7 +347,7 @@ See also: [`get_time_series_array` by name](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values`](@ref),
 [`get_time_series_timestamps`](@ref)
@@ -405,7 +405,7 @@ See also [`get_time_series_values`](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -449,7 +449,7 @@ See also: [`get_time_series_values`](@ref get_time_series_values(owner::TimeSeri
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `ForecastCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -489,7 +489,7 @@ Return a vector of timestamps from storage for the given time series parameters.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features...`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
@@ -498,7 +498,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values`](@ref get_time_series_values(
     ::Type{T},
@@ -506,7 +506,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-features...,) where {T <: TimeSeriesData}),
+features::Dict = Dict(),) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `StaticTimeSeriesCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
     time_series::StaticTimeSeries;
@@ -528,7 +528,7 @@ function get_time_series_timestamps(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     return TimeSeries.timestamp(
         get_time_series_array(
@@ -539,7 +539,7 @@ function get_time_series_timestamps(
             interval = interval,
             start_time = start_time,
             len = len,
-            features...,
+            features = features,
         ),
     )
 end
@@ -562,7 +562,7 @@ See also: [`get_time_series_timestamps` by name](@ref get_time_series_timestamps
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array`](@ref),
 [`get_time_series_values`](@ref)
@@ -605,7 +605,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `StaticTimeSeriesCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -650,7 +650,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `ForecastCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -689,7 +689,7 @@ that accepts a cached `TimeSeriesData` instance.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features...`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
@@ -698,7 +698,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps`](@ref get_time_series_timestamps(
     ::Type{T},
@@ -706,7 +706,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series`](@ref),
 [`get_time_series_values` from a `StaticTimeSeriesCache`](@ref get_time_series_values(
@@ -730,7 +730,7 @@ function get_time_series_values(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     return TimeSeries.values(
         get_time_series_array(
@@ -741,7 +741,7 @@ function get_time_series_values(
             interval = interval,
             start_time = start_time,
             len = len,
-            features...,
+            features = features,
         ),
     )
 end
@@ -764,7 +764,7 @@ See also: [`get_time_series_values` by name](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array`](@ref),
 [`get_time_series_timestamps`](@ref)
@@ -808,7 +808,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+            features = features,
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values` from a `StaticTimeSeriesCache`](@ref get_time_series_values(
     owner::TimeSeriesOwners,
@@ -858,7 +858,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values` from a `ForecastCache`](@ref get_time_series_values(
     owner::TimeSeriesOwners,
@@ -907,13 +907,13 @@ function has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(val)
     isnothing(mgr) && return false
     return infrastore_has_time_series(
         T, val, name;
-        resolution = resolution, interval = interval, features...,
+        resolution = resolution, interval = interval, features = features,
     )
 end
 
@@ -927,7 +927,7 @@ function has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 )
     return has_time_series(
         owner,
@@ -935,7 +935,7 @@ function has_time_series(
         name;
         resolution = resolution,
         interval = interval,
-        features...,
+        features = features,
     )
 end
 
@@ -950,14 +950,14 @@ has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) = has_time_series(
     owner,
     T,
     name;
     resolution = resolution,
     interval = interval,
-    features...,
+    features = features,
 )
 
 """
@@ -1111,7 +1111,7 @@ function get_time_series_keys(
     name::Union{String, Nothing} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 )
     mgr = get_time_series_manager(owner)
     isnothing(mgr) && return TimeSeriesKey[]
@@ -1122,7 +1122,7 @@ function get_time_series_keys(
         name = name,
         resolution = resolution,
         interval = interval,
-        features...,
+        features = features,
     )
 end
 
@@ -1163,7 +1163,7 @@ get_time_series_hashes(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) where {T <: TimeSeriesData} =
     infrastore_get_time_series_hashes(
         owners,
@@ -1171,7 +1171,7 @@ get_time_series_hashes(
         name;
         resolution = resolution,
         interval = interval,
-        features...,
+        features = features,
     )
 
 function clear_time_series!(owner::TimeSeriesOwners)

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -42,7 +42,7 @@ Specify `start_time` and `len` if you only need a subset of data.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref), [`get_time_series_values`](@ref),
@@ -63,7 +63,7 @@ function get_time_series(
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     TimerOutputs.@timeit_debug SYSTEM_TIMERS "get_time_series" begin
         return infrastore_get_time_series(
@@ -92,7 +92,7 @@ Specify start_time and len if you only need a subset of data.
     entire length.
   - `count::Union{Nothing, Int} = nothing`: Only applicable to subtypes of Forecast. Number
     of forecast windows starting at `start_time` to return. Defaults to all available.
-  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series` by name](@ref get_time_series(
@@ -102,7 +102,7 @@ See also: [`get_time_series` by name](@ref get_time_series(
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData})
 """
 function get_time_series(
@@ -230,7 +230,7 @@ function get_time_series_key(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(owner)
     return get_time_series_key(
@@ -265,7 +265,7 @@ Specify `start_time` and `len` if you only need a subset of data.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_values`](@ref get_time_series_values(
@@ -274,14 +274,14 @@ See also: [`get_time_series_values`](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-features::Dict = Dict(),) where {T <: TimeSeriesData}),
+features::Dict = Dict{String, Any}(),) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps`](@ref get_time_series_timestamps(
     ::Type{T},
     owner::TimeSeriesOwners,
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -304,7 +304,7 @@ function get_time_series_array(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     ts = get_time_series(
         T,
@@ -347,7 +347,7 @@ See also: [`get_time_series_array` by name](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values`](@ref),
 [`get_time_series_timestamps`](@ref)
@@ -405,7 +405,7 @@ See also [`get_time_series_values`](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `StaticTimeSeriesCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -449,7 +449,7 @@ See also: [`get_time_series_values`](@ref get_time_series_values(owner::TimeSeri
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array` from a `ForecastCache`](@ref get_time_series_array(
     owner::TimeSeriesOwners,
@@ -489,7 +489,7 @@ Return a vector of timestamps from storage for the given time series parameters.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
@@ -498,7 +498,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values`](@ref get_time_series_values(
     ::Type{T},
@@ -506,7 +506,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-features::Dict = Dict(),) where {T <: TimeSeriesData}),
+features::Dict = Dict{String, Any}(),) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `StaticTimeSeriesCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
     time_series::StaticTimeSeries;
@@ -528,7 +528,7 @@ function get_time_series_timestamps(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     return TimeSeries.timestamp(
         get_time_series_array(
@@ -562,7 +562,7 @@ See also: [`get_time_series_timestamps` by name](@ref get_time_series_timestamps
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array`](@ref),
 [`get_time_series_values`](@ref)
@@ -605,7 +605,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `StaticTimeSeriesCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -650,7 +650,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps` from a `ForecastCache`](@ref get_time_series_timestamps(
     owner::TimeSeriesOwners,
@@ -689,7 +689,7 @@ that accepts a cached `TimeSeriesData` instance.
     `start_time` must be the first timestamp of a window.
   - `len::Union{Nothing, Int} = nothing`: Length of time-series to retrieve (i.e. number of
     timestamps). If nothing, use the entire length.
-  - `features::Dict = Dict()`: User-defined tags that differentiate multiple time series arrays for the
+  - `features::Dict = Dict{String, Any}()`: User-defined tags that differentiate multiple time series arrays for the
     same component attribute, such as different arrays for different scenarios or years
 
 See also: [`get_time_series_array`](@ref get_time_series_array(
@@ -698,7 +698,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_timestamps`](@ref get_time_series_timestamps(
     ::Type{T},
@@ -706,7 +706,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series`](@ref),
 [`get_time_series_values` from a `StaticTimeSeriesCache`](@ref get_time_series_values(
@@ -730,7 +730,7 @@ function get_time_series_values(
     interval::Union{Nothing, Dates.Period} = nothing,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     return TimeSeries.values(
         get_time_series_array(
@@ -764,7 +764,7 @@ See also: [`get_time_series_values` by name](@ref get_time_series_values(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_array`](@ref),
 [`get_time_series_timestamps`](@ref)
@@ -858,7 +858,7 @@ See also: [`get_time_series_array`](@ref get_time_series_array(
     name::AbstractString;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}),
 [`get_time_series_values` from a `ForecastCache`](@ref get_time_series_values(
     owner::TimeSeriesOwners,
@@ -907,7 +907,7 @@ function has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(val)
     isnothing(mgr) && return false
@@ -927,7 +927,7 @@ function has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     return has_time_series(
         owner,
@@ -950,7 +950,7 @@ has_time_series(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) = has_time_series(
     owner,
     T,
@@ -1111,7 +1111,7 @@ function get_time_series_keys(
     name::Union{String, Nothing} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     mgr = get_time_series_manager(owner)
     isnothing(mgr) && return TimeSeriesKey[]
@@ -1163,7 +1163,7 @@ get_time_series_hashes(
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) where {T <: TimeSeriesData} =
     infrastore_get_time_series_hashes(
         owners,

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -90,6 +90,17 @@ function _infrastore_features(features)
     return out
 end
 
+function _check_interval_supported(::Type{T}, interval) where {T <: TimeSeriesData}
+    if T <: StaticTimeSeries && !isnothing(interval)
+        throw(
+            ArgumentError(
+                "`interval` is not supported for $(nameof(T)); it is only valid for forecasts.",
+            ),
+        )
+    end
+    return
+end
+
 """
 Open a batch of time series work and run `func` on it, inside a store transaction.
 

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -178,7 +178,7 @@ function add_time_series!(
     mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     _throw_if_read_only(mgr)
     return infrastore_add_time_series!(mgr, owner, time_series; features = features)
@@ -192,7 +192,7 @@ function add_time_series!(
     context::TimeSeriesContext,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     _throw_if_closed(context)
     context.owner_validator(owner)
@@ -207,7 +207,7 @@ function add_time_series!(
     context::TimeSeriesContext,
     components,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     # Component information is not embedded into the key, so every component
     # produces the same one.
@@ -230,7 +230,7 @@ function _stage_on_context!(
     context::TimeSeriesContext,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     key, nbytes = _infrastore_stage!(
         _batch!(context),
@@ -285,7 +285,7 @@ get_time_series_key(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) = infrastore_get_time_series_key(
     component,
     time_series_type,
@@ -302,7 +302,7 @@ list_time_series_keys(
     name::Union{String, Nothing} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 ) = infrastore_owner_list_keys(
     component;
     time_series_type = time_series_type,
@@ -322,7 +322,7 @@ function remove_time_series!(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict(),
+    features::Dict = Dict{String, Any}(),
 )
     _throw_if_read_only(mgr)
     store = get_data_store(mgr)

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -82,13 +82,18 @@ _feature_value(k, v) = throw(
     ),
 )
 
-function _infrastore_features(features)
+_infrastore_features(::Nothing) = nothing
+
+function _infrastore_features(features::Dict)
     out = Dict{String, Any}()
     for (k, v) in features
         out[string(k)] = _feature_value(k, v)
     end
     return out
 end
+
+_key_features(::Nothing) = Dict{String, Any}()
+_key_features(features::Dict) = Dict{String, Any}(features)
 
 function _check_interval_supported(::Type{T}, interval) where {T <: TimeSeriesData}
     if T <: StaticTimeSeries && !isnothing(interval)
@@ -178,7 +183,7 @@ function add_time_series!(
     mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     _throw_if_read_only(mgr)
     return infrastore_add_time_series!(mgr, owner, time_series; features = features)
@@ -192,7 +197,7 @@ function add_time_series!(
     context::TimeSeriesContext,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     _throw_if_closed(context)
     context.owner_validator(owner)
@@ -207,7 +212,7 @@ function add_time_series!(
     context::TimeSeriesContext,
     components,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     # Component information is not embedded into the key, so every component
     # produces the same one.
@@ -230,7 +235,7 @@ function _stage_on_context!(
     context::TimeSeriesContext,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     key, nbytes = _infrastore_stage!(
         _batch!(context),
@@ -285,7 +290,7 @@ get_time_series_key(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) = infrastore_get_time_series_key(
     component,
     time_series_type,
@@ -302,7 +307,7 @@ list_time_series_keys(
     name::Union{String, Nothing} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 ) = infrastore_owner_list_keys(
     component;
     time_series_type = time_series_type,
@@ -322,12 +327,12 @@ function remove_time_series!(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features::Dict = Dict{String, Any}(),
+    features::Union{Nothing, Dict} = nothing,
 )
     _throw_if_read_only(mgr)
     store = get_data_store(mgr)
     owner_id, category = _infrastore_owner_id_category(owner)
-    feats = Dict{String, Any}(string(k) => v for (k, v) in features)
+    feats = _infrastore_features(features)
     # Subset (partial) feature/resolution matching: each bulk catalog call
     # removes every stored series of the query type that contains at least the
     # requested features, in one store transaction — no per-key listing or

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -167,10 +167,10 @@ function add_time_series!(
     mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     _throw_if_read_only(mgr)
-    return infrastore_add_time_series!(mgr, owner, time_series; features...)
+    return infrastore_add_time_series!(mgr, owner, time_series; features = features)
 end
 
 """
@@ -181,11 +181,11 @@ function add_time_series!(
     context::TimeSeriesContext,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     _throw_if_closed(context)
     context.owner_validator(owner)
-    return _stage_on_context!(context, owner, time_series; features...)
+    return _stage_on_context!(context, owner, time_series; features = features)
 end
 
 """
@@ -196,7 +196,7 @@ function add_time_series!(
     context::TimeSeriesContext,
     components,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     # Component information is not embedded into the key, so every component
     # produces the same one.
@@ -208,9 +208,9 @@ function add_time_series!(
         ),
     )
     first_component, rest = peeled
-    key = add_time_series!(context, first_component, time_series; features...)
+    key = add_time_series!(context, first_component, time_series; features = features)
     for component in rest
-        add_time_series!(context, component, time_series; features...)
+        add_time_series!(context, component, time_series; features = features)
     end
     return key
 end
@@ -219,7 +219,7 @@ function _stage_on_context!(
     context::TimeSeriesContext,
     owner::TimeSeriesOwners,
     time_series::TimeSeriesData;
-    features...,
+    features::Dict = Dict(),
 )
     key, nbytes = _infrastore_stage!(
         _batch!(context),
@@ -227,7 +227,7 @@ function _stage_on_context!(
         context.params_cache,
         owner,
         time_series;
-        features...,
+        features = features,
     )
     push!(context.keys, key)
     # `nbytes` is the exact size of the encoded array the batch copied at stage
@@ -274,14 +274,14 @@ get_time_series_key(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) = infrastore_get_time_series_key(
     component,
     time_series_type,
     name;
     resolution = resolution,
     interval = interval,
-    features...,
+    features = features,
 )
 
 list_time_series_keys(
@@ -291,14 +291,14 @@ list_time_series_keys(
     name::Union{String, Nothing} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 ) = infrastore_owner_list_keys(
     component;
     time_series_type = time_series_type,
     name = name,
     resolution = resolution,
     interval = interval,
-    features...,
+    features = features,
 )
 
 """
@@ -311,7 +311,7 @@ function remove_time_series!(
     name::String;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    features...,
+    features::Dict = Dict(),
 )
     _throw_if_read_only(mgr)
     store = get_data_store(mgr)

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -395,6 +395,23 @@ end
         "static";
         resolution = resolution,
     )
+    for operation in (
+        () -> IS.get_time_series(
+            IS.SingleTimeSeries, component, "static"; interval = resolution),
+        () -> IS.get_time_series_key(
+            IS.SingleTimeSeries, component, "static"; interval = resolution),
+        () -> IS.get_time_series_keys(
+            component; time_series_type = IS.SingleTimeSeries, interval = resolution),
+        () -> IS.has_time_series(
+            component, IS.SingleTimeSeries, "static"; interval = resolution),
+        () -> IS.get_time_series_hashes(
+            (component,), IS.SingleTimeSeries, "static"; interval = resolution),
+        () -> IS.remove_time_series!(
+            sys, IS.SingleTimeSeries, component, "static"; interval = resolution),
+        () -> IS.remove_time_series!(sys, IS.SingleTimeSeries; interval = resolution),
+    )
+        @test_throws ArgumentError operation()
+    end
 
     # The redesign's whole point is static `Bool` inference; the deleted
     # kwargs catch-all boxed its type filter as `Any` and broke this.
@@ -3170,6 +3187,28 @@ const IRREGULAR_TIMESTAMPS = [
     @test IS.get_resolution(key) === nothing
     @test IS.get_name(key) == name
     @test IS.length(key) == 4
+    interval = Dates.Hour(1)
+    for operation in (
+        () -> IS.get_time_series(
+            IS.NonSequentialTimeSeries, component, name; interval = interval),
+        () -> IS.get_time_series_key(
+            IS.NonSequentialTimeSeries, component, name; interval = interval),
+        () -> IS.get_time_series_keys(
+            component;
+            time_series_type = IS.NonSequentialTimeSeries,
+            interval = interval,
+        ),
+        () -> IS.has_time_series(
+            component, IS.NonSequentialTimeSeries, name; interval = interval),
+        () -> IS.get_time_series_hashes(
+            (component,), IS.NonSequentialTimeSeries, name; interval = interval),
+        () -> IS.remove_time_series!(
+            sys, IS.NonSequentialTimeSeries, component, name; interval = interval),
+        () -> IS.remove_time_series!(
+            sys, IS.NonSequentialTimeSeries; interval = interval),
+    )
+        @test_throws ArgumentError operation()
+    end
     # Retrieval through the key round-trips.
     got_by_key = IS.get_time_series(component, key)
     @test IS.get_timestamps(got_by_key) == timestamps

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -306,13 +306,12 @@ end
     sys = IS.SystemData()
     component = IS.TestComponent("Component1", 5)
     IS.add_component!(sys, component)
-    key_subset = IS.add_time_series!(sys, component, mk(collect(1.0:24.0)); scenario = "a")
+    key_subset = IS.add_time_series!(sys, component, mk(collect(1.0:24.0)); features = Dict("scenario" => "a"))
     key_superset = IS.add_time_series!(
         sys,
         component,
         mk(collect(101.0:124.0));
-        scenario = "a",
-        model = "x",
+        features = Dict("scenario" => "a", "model" => "x"),
     )
     @test IS.get_features(key_subset) == Dict("scenario" => "a")
     @test IS.get_features(key_superset) == Dict("scenario" => "a", "model" => "x")
@@ -341,7 +340,7 @@ end
 
     # The removal is exact in the other direction too: removing the superset key
     # leaves the subset series alone.
-    IS.add_time_series!(sys, component, mk(collect(1.0:24.0)); scenario = "a")
+    IS.add_time_series!(sys, component, mk(collect(1.0:24.0)); features = Dict("scenario" => "a"))
     IS.remove_time_series!(sys, component, key_superset)
     left = IS.get_time_series_keys(component)
     @test length(left) == 1
@@ -385,11 +384,11 @@ end
         data = TimeSeries.TimeArray(
             range(initial_time; length = 24, step = resolution), collect(1.0:24.0)),
         name = "static")
-    IS.add_time_series!(sys, component, sts; scenario = "a")
+    IS.add_time_series!(sys, component, sts; features = Dict("scenario" => "a"))
     @test IS.has_time_series(component, "static"; resolution = resolution)
     @test IS.has_time_series(component, "static"; resolution = Dates.Minute(5)) == false
-    @test IS.has_time_series(component, "static"; scenario = "a")
-    @test IS.has_time_series(component, "static"; scenario = "b") == false
+    @test IS.has_time_series(component, "static"; features = Dict("scenario" => "a"))
+    @test IS.has_time_series(component, "static"; features = Dict("scenario" => "b")) == false
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
@@ -923,7 +922,14 @@ end
     )
     ts_name = "test_c"
     ts = IS.SingleTimeSeries(; data = data, name = ts_name)
-    IS.add_time_series!(sys, component, ts; scenario = "low", model_year = "2030")
+    @test_throws MethodError IS.add_time_series!(sys, component, ts; scenaro = "low")
+    @test_throws TypeError IS.add_time_series!(
+        sys,
+        component,
+        ts;
+        features = (scenario = "low",),
+    )
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "model_year" => "2030"))
     # get_time_series with partial query works if there is only 1.
     @test IS.get_data(IS.get_time_series(IS.SingleTimeSeries, component, ts_name)) == data
     @test IS.get_data(
@@ -931,7 +937,7 @@ end
             IS.SingleTimeSeries,
             component,
             ts_name;
-            scenario = "low",
+            features = Dict("scenario" => "low"),
         ),
     ) == data
     @test IS.get_data(
@@ -939,28 +945,25 @@ end
             IS.SingleTimeSeries,
             component,
             ts_name;
-            scenario = "low",
-            model_year = "2030",
+            features = Dict("scenario" => "low", "model_year" => "2030"),
         ),
     ) == data
     @test IS.get_time_series_values(
         IS.SingleTimeSeries,
         component,
         ts_name;
-        scenario = "low",
-        model_year = "2030",
+        features = Dict("scenario" => "low", "model_year" => "2030"),
     ) == TimeSeries.values(data)
     @test IS.get_time_series_timestamps(
         IS.SingleTimeSeries,
         component,
         ts_name;
-        scenario = "low",
-        model_year = "2030",
+        features = Dict("scenario" => "low", "model_year" => "2030"),
     ) == TimeSeries.timestamp(data)
 
-    IS.add_time_series!(sys, component, ts; scenario = "high", model_year = "2030")
-    IS.add_time_series!(sys, component, ts; scenario = "low", model_year = "2035")
-    IS.add_time_series!(sys, component, ts; scenario = "high", model_year = "2035")
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "high", "model_year" => "2030"))
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "model_year" => "2035"))
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "high", "model_year" => "2035"))
 
     @test_throws ArgumentError IS.get_time_series(
         IS.SingleTimeSeries,
@@ -971,47 +974,48 @@ end
         IS.SingleTimeSeries,
         component,
         ts_name,
-        scenario = "low",
+        features = Dict("scenario" => "low"),
     )
     @test IS.get_time_series(
         IS.SingleTimeSeries,
         component,
         ts_name;
-        scenario = "low",
-        model_year = "2035",
+        features = Dict("scenario" => "low", "model_year" => "2035"),
     ) isa IS.SingleTimeSeries
     @test IS.has_time_series(component, IS.SingleTimeSeries)
     @test IS.has_time_series(component, IS.SingleTimeSeries, ts_name)
     @test IS.has_time_series(component, ts_name)
     @test IS.has_time_series(component, ts_name; resolution = resolution)
-    @test IS.has_time_series(component, IS.SingleTimeSeries, ts_name, scenario = "low")
+    @test IS.has_time_series(
+        component,
+        IS.SingleTimeSeries,
+        ts_name;
+        features = Dict("scenario" => "low"),
+    )
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name,
         resolution = resolution,
-        scenario = "low",
+        features = Dict("scenario" => "low"),
     )
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name,
-        model_year = "2030",
-        scenario = "low",
+        features = Dict("model_year" => "2030", "scenario" => "low"),
     )
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name,
-        model_year = "2030",
-        scenario = "low",
+        features = Dict("model_year" => "2030", "scenario" => "low"),
     )
     @test !IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        model_year = "2060",
-        scenario = "low",
+        features = Dict("model_year" => "2060", "scenario" => "low"),
     )
     @test length(IS.get_time_series_keys(component)) == 4
     @test IS.get_time_series_type(IS.get_time_series_keys(component)[1]) ===
@@ -1040,94 +1044,91 @@ end
     )
     ts_name = "test"
     ts = IS.SingleTimeSeries(; data = data, name = ts_name)
-    IS.add_time_series!(sys, component, ts; scenario = "low", model_year = "2030")
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "model_year" => "2030"))
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        scenario = "low",
-        model_year = "2030",
+        features = Dict("scenario" => "low", "model_year" => "2030"),
     )
     @test !IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        scenario = "low",
-        model_year = 2030,
+        features = Dict("scenario" => "low", "model_year" => 2030),
     )
-    IS.add_time_series!(sys, component, ts; scenario = "low", model_year = 2030)
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "model_year" => 2030))
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        scenario = "low",
-        model_year = 2030,
+        features = Dict("scenario" => "low", "model_year" => 2030),
     )
-    IS.add_time_series!(sys, component, ts; scenario = "low", model_year = 2035)
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "model_year" => 2035))
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        scenario = "low",
-        model_year = 2035,
+        features = Dict("scenario" => "low", "model_year" => 2035),
     )
     @test !IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        scenario = "low",
-        model_year = "2035",
+        features = Dict("scenario" => "low", "model_year" => "2035"),
     )
-    IS.add_time_series!(sys, component, ts; scenario = "low", model_year = "2035")
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "model_year" => "2035"))
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        scenario = "low",
-        model_year = "2035",
+        features = Dict("scenario" => "low", "model_year" => "2035"),
     )
-    IS.add_time_series!(sys, component, ts; scenario = "low", some_condition = true)
-    @test IS.has_time_series(component, IS.SingleTimeSeries, ts_name; some_condition = true)
-    @test !IS.has_time_series(
-        component,
-        IS.SingleTimeSeries,
-        ts_name;
-        some_condition = "true",
-    )
-    IS.add_time_series!(sys, component, ts; scenario = "low", some_condition = "false")
-    @test !IS.has_time_series(
-        component,
-        IS.SingleTimeSeries,
-        ts_name;
-        some_condition = false,
-    )
-    IS.add_time_series!(sys, component, ts; scenario = "low", some_condition = false)
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "some_condition" => true))
     @test IS.has_time_series(
         component,
         IS.SingleTimeSeries,
         ts_name;
-        some_condition = false,
+        features = Dict("some_condition" => true),
+    )
+    @test !IS.has_time_series(
+        component,
+        IS.SingleTimeSeries,
+        ts_name;
+        features = Dict("some_condition" => "true"),
+    )
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "some_condition" => "false"))
+    @test !IS.has_time_series(
+        component,
+        IS.SingleTimeSeries,
+        ts_name;
+        features = Dict("some_condition" => false),
+    )
+    IS.add_time_series!(sys, component, ts; features = Dict("scenario" => "low", "some_condition" => false))
+    @test IS.has_time_series(
+        component,
+        IS.SingleTimeSeries,
+        ts_name;
+        features = Dict("some_condition" => false),
     )
     @test_throws ArgumentError IS.add_time_series!(
         sys,
         component,
         ts;
-        scenario = Dict("key" => "val"),
+        features = Dict("scenario" => Dict("key" => "val")),
     )
     # Duplicate features in different order.
     @test_throws ArgumentError IS.add_time_series!(
         sys,
         component,
         ts;
-        scenario = "low",
-        model_year = "2035",
+        features = Dict("scenario" => "low", "model_year" => "2035"),
     )
     @test_throws ArgumentError IS.add_time_series!(
         sys,
         component,
         ts;
-        model_year = "2035",
-        scenario = "low",
+        features = Dict("model_year" => "2035", "scenario" => "low"),
     )
 end
 
@@ -1147,21 +1148,19 @@ end
         SortedDict(initial_time => rand(horizon_count), other_time => rand(horizon_count))
 
     forecast = IS.Deterministic(; data = data, name = ts_name, resolution = resolution)
-    IS.add_time_series!(sys, component, forecast; scenario = "low", model_year = "2030")
+    IS.add_time_series!(sys, component, forecast; features = Dict("scenario" => "low", "model_year" => "2030"))
     IS.add_time_series!(
         sys,
         component,
         forecast;
-        scenario = "high",
-        model_year = "2030",
+        features = Dict("scenario" => "high", "model_year" => "2030"),
     )
-    IS.add_time_series!(sys, component, forecast; scenario = "low", model_year = "2035")
+    IS.add_time_series!(sys, component, forecast; features = Dict("scenario" => "low", "model_year" => "2035"))
     IS.add_time_series!(
         sys,
         component,
         forecast;
-        scenario = "high",
-        model_year = "2035",
+        features = Dict("scenario" => "high", "model_year" => "2035"),
     )
 
     @test_throws ArgumentError IS.get_time_series(
@@ -1173,14 +1172,13 @@ end
         IS.Deterministic,
         component,
         ts_name,
-        scenario = "low",
+        features = Dict("scenario" => "low"),
     )
     @test IS.get_time_series(
         IS.Deterministic,
         component,
         ts_name;
-        scenario = "low",
-        model_year = "2035",
+        features = Dict("scenario" => "low", "model_year" => "2035"),
     ) isa IS.Deterministic
     @test length(IS.get_time_series_keys(component)) == 4
     @test length(
@@ -1198,7 +1196,7 @@ end
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
-            scenario = "low",
+            features = Dict("scenario" => "low"),
         ),
     ) == 2
     @test length(
@@ -1206,22 +1204,20 @@ end
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
-            scenario = "low",
-            model_year = "2035",
+            features = Dict("scenario" => "low", "model_year" => "2035"),
         ),
     ) == 1
     @test IS.get_time_series_keys(
         component;
         time_series_type = IS.Deterministic,
         name = ts_name,
-        scenario = "low",
-        model_year = "2035",
+        features = Dict("scenario" => "low", "model_year" => "2035"),
     )[1].features["model_year"] == "2035"
     @test length(IS.get_time_series_keys(component)) == 4
     @test IS.get_time_series_type(IS.get_time_series_keys(component)[1]) ===
           IS.Deterministic
 
-    IS.remove_time_series!(sys, IS.Deterministic, component, ts_name; scenario = "low")
+    IS.remove_time_series!(sys, IS.Deterministic, component, ts_name; features = Dict("scenario" => "low"))
     @test length(
         IS.get_time_series_keys(component; time_series_type = IS.Deterministic),
     ) == 2
@@ -2051,7 +2047,7 @@ end
     IS.add_time_series!(sys2, component2, forecast2)
 
     ts_with_features = IS.SingleTimeSeries(name, ta)
-    IS.add_time_series!(sys2, component2, ts_with_features; scenario = "high")
+    IS.add_time_series!(sys2, component2, ts_with_features; features = Dict("scenario" => "high"))
 
     IS.transform_single_time_series!(
         sys2,
@@ -2061,7 +2057,7 @@ end
     )
     @test IS.has_time_series(component2, IS.DeterministicSingleTimeSeries, name)
     @test IS.has_time_series(component2, IS.Deterministic, name)
-    @test IS.has_time_series(component2, IS.SingleTimeSeries, name; scenario = "high")
+    @test IS.has_time_series(component2, IS.SingleTimeSeries, name; features = Dict("scenario" => "high"))
 
     # Test 3: Transformation succeeds when resolution is different
     sys3 = IS.SystemData()
@@ -3931,7 +3927,7 @@ end
         ta = TimeSeries.TimeArray(dates, data, [IS.get_name(component)])
         ts_name = "power"
         ts = IS.SingleTimeSeries(; data = ta, name = ts_name)
-        key = IS.add_time_series!(sys, component, ts; scenario = scenario)
+        key = IS.add_time_series!(sys, component, ts; features = Dict("scenario" => scenario))
         push!(ts_keys, key)
     end
 
@@ -4021,7 +4017,7 @@ end
                 ),
                 name = "ts_$(i)", resolution = resolution,
             )
-            IS.add_time_series!(txn, component, forecast; model_year = "high")
+            IS.add_time_series!(txn, component, forecast; features = Dict("model_year" => "high"))
         end
     end
     ts_keys = IS.get_time_series_keys(component)
@@ -4063,7 +4059,7 @@ end
     # A duplicate anywhere in the batch rejects the whole batch.
     @test_throws ArgumentError IS.time_series_transaction(sys) do txn
         for year in ("high", "low", "high")
-            IS.add_time_series!(txn, component, forecast; model_year = year)
+            IS.add_time_series!(txn, component, forecast; features = Dict("model_year" => year))
         end
     end
     @test isempty(IS.get_time_series_keys(component))
@@ -4099,7 +4095,7 @@ end
                 ),
                 name = "ts_$(i)", resolution = resolution,
             )
-            IS.add_time_series!(txn, component, forecast; model_year = "high")
+            IS.add_time_series!(txn, component, forecast; features = Dict("model_year" => "high"))
         end
     end
     ts_keys = IS.get_time_series_keys(component)
@@ -5619,17 +5615,17 @@ end
     # features: the unfiltered query is underdetermined and raises; a features
     # filter resolves it.
     wk = IS.add_time_series!(sys, c4, mk(collect(2.0:2.0:96.0); name = "wind");
-        scenario = "high")
+        features = Dict("scenario" => "high"))
     IS.add_time_series!(sys, c4, mk(collect(3.0:3.0:144.0); name = "wind");
-        scenario = "low")
+        features = Dict("scenario" => "low"))
     @test_throws ArgumentError IS.get_time_series_hashes(
         [c4], IS.SingleTimeSeries, "wind",
     )
     @test IS.get_time_series_hashes(
-        [c4], IS.SingleTimeSeries, "wind"; scenario = "high",
+        [c4], IS.SingleTimeSeries, "wind"; features = Dict("scenario" => "high",)
     ) == Dict(id(c4) => IS.get_time_series_hash(c4, wk))
     # Multiple matches that resolve to the SAME array are not ambiguous.
-    IS.add_time_series!(sys, c1, mk(copy(shared)); scenario = "alt")
+    IS.add_time_series!(sys, c1, mk(copy(shared)); features = Dict("scenario" => "alt"))
     @test IS.get_time_series_hashes((c1,), IS.SingleTimeSeries, "load") ==
           Dict(id(c1) => hashes[id(c1)])
 

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -29,7 +29,7 @@ end
     # Both components have id 1 in their own systems, so a store-level copy would
     # address the wrong owner.
     @test IS.get_id(a) == IS.get_id(b)
-    IS.add_time_series!(sys1, a, _hourly_sts("s"); scenario = "x")
+    IS.add_time_series!(sys1, a, _hourly_sts("s"); features = Dict("scenario" => "x"))
     IS.add_time_series!(
         sys2,
         b,
@@ -470,7 +470,7 @@ end
     @test fkey_added == fkey_listed
     @test hash(fkey_added) == hash(fkey_listed)
     @test fkey_added != key_added
-    @test key_added != IS.add_time_series!(sys, component, _hourly_sts("s"); scenario = "a")
+    @test key_added != IS.add_time_series!(sys, component, _hourly_sts("s"); features = Dict("scenario" => "a"))
 end
 
 @testset "Test fast_deepcopy_system rewires every owner" begin


### PR DESCRIPTION
## Do not merge until infrastore 0.9.x is released. This is now tied to this [PR](https://github.com/Sienna-Platform/InfrastructureSystems.jl/pull/619).

## Summary
- replace time-series feature keyword splats with an explicit `features` keyword so unrelated or misspelled keywords cannot bleed into feature identity
- use `features::Union{Nothing, Dict} = nothing` on InfrastructureSystems hot paths, materializing `Dict{String, Any}` only when a stored key requires it
- reject `interval` for `SingleTimeSeries` and `NonSequentialTimeSeries` across retrieval, catalog queries, hashes, and removal
- update the benchmark harness, documentation, and regression coverage for the new interface
- temporarily source the coordinated [InfraStore branch](https://github.com/NatLabRockies/infrastore/tree/refactor/optional-time-series-features), where Julia APIs use `features::Union{Nothing, AbstractDict} = nothing` and forward absent features as `C_NULL`.

## Performance
Benchmark timings remain effectively unchanged. Compared with the explicit-empty-dictionary implementation, representative featureless operations allocate less memory per call:

- static and forecast reads: 640 fewer bytes/op
- time-series adds: 160–176 fewer bytes/op
- bulk removal: 528 fewer bytes/op

## Testing
- InfrastructureSystems full test suite: 9,234 passed
- coordinated benchmark run: `julia --project=. benchmark/bench.jl`
- InfraStore Julia feature-related tests passed; the remainder of its local suite requires a freshly built FFI library because the installed 0.8 artifact predates the `is_empty` symbol on `main`