### PR TITLE
Upgrade InfraStore to v0.9.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPI
 PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
 
 [compat]
-InfraStore = "0.8"
+InfraStore = "0.9"
 DataFrames = "^1.7"
 DataStructures = "^0.18, ^0.19"
 Dates = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,7 +26,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-InfraStore = "0.8"
+InfraStore = "0.9"
 
 # `[sources]` applies ONLY to the top-level project, so the package's own entries are NOT
 # inherited by this environment. PowerCoreOpenAPIModels and PowerTimeSeriesOpenAPIModels are


### PR DESCRIPTION
This upgrade blocks de-serialization of sqlite catalogs created with v0.8.0 because of changes for time zone handling.