### PR TITLE
Fold has_time_series type translation to compile time

### DIFF
--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -1809,11 +1809,14 @@ _decode_element(element, ::ScalarEncoding) = element
 _decode_element(element, encoding::RowEncoding) =
     _decode_static_values(reshape(element, 1, :), encoding, 1)[1]
 
-"""Route `has_time_series(owner, T, name; ...)` to the InfraStore store. Honors partial
-(subset) feature / resolution queries: matches if any stored series of type `T`
-contains at least the requested features. `name = nothing` probes across all names.
-`mgr` is the caller's already-resolved manager: every public entry point null-checks
-one before reaching here, so re-resolving it would be a second lookup per probe."""
+"""Route a narrowed `has_time_series` query to the InfraStore store — the general
+catalog filter, serving every query the owner-scoped probe in `infrastore_has_any`
+cannot. Honors partial (subset) feature / resolution queries: matches if any stored
+series of type `T` carries at least the requested features. Each of `name`,
+`resolution`, `interval`, and `features` is optional; `name = nothing` probes across
+all names. `mgr` is the caller's already-resolved manager: the public entry point
+null-checks one before reaching here, so re-resolving it would be a second lookup per
+probe."""
 function infrastore_has_time_series(
     ::Type{T},
     mgr::TimeSeriesManager,

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -1811,10 +1811,12 @@ _decode_element(element, encoding::RowEncoding) =
 
 """Route `has_time_series(owner, T, name; ...)` to the InfraStore store. Honors partial
 (subset) feature / resolution queries: matches if any stored series of type `T`
-contains at least the requested features. `name = nothing` probes across all
-names (the name-less kwargs form with resolution/interval/feature filters)."""
+contains at least the requested features. `name = nothing` probes across all names.
+`mgr` is the caller's already-resolved manager: every public entry point null-checks
+one before reaching here, so re-resolving it would be a second lookup per probe."""
 function infrastore_has_time_series(
     ::Type{T},
+    mgr::TimeSeriesManager,
     owner::TimeSeriesOwners,
     name::Union{Nothing, AbstractString};
     resolution::Union{Nothing, Dates.Period} = nothing,
@@ -1822,9 +1824,8 @@ function infrastore_has_time_series(
     features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
     _check_interval_supported(T, interval)
-    mgr = get_time_series_manager(owner)
-    store = mgr.data_store
-    owner_id, _, category = _infrastore_owner_args(owner)
+    store = mgr.data_store::Store
+    owner_id, category = _infrastore_owner_id_category(owner)
     feats = _infrastore_features(features)
     # Pure existence probe — a covering-index `SELECT 1 ... LIMIT 1` in the store; nothing
     # is listed, hydrated, or marshaled, so this is safe in hot per-component loops. A
@@ -1869,6 +1870,16 @@ end
 struct AllStoredTypes end
 struct NoStoredTypes end
 
+# `SingleTimeSeries{Float64, 1}` -> `SingleTimeSeries`; a UnionAll is returned as is. A
+# `Union` is normalized member-wise, so a parameterized concrete inside one is narrowed
+# like a bare one — `Union{SingleTimeSeries{Float64, 1}, Probabilistic}` must not quietly
+# match nothing. A `Union` type's own type is `Union`, which is what separates the two
+# methods.
+_unparameterized_type(u::Union) =
+    Union{map(_unparameterized_type, Base.uniontypes(u))...}
+
+_unparameterized_type(::Type{T}) where {T} = Base.typename(T).wrapper
+
 # All InfraStore types whose IS type is a subtype of `T` (strict `<:` semantics —
 # distinct from `_infrastore_type_matches`, which treats a `Deterministic` query
 # as also matching a `DeterministicSingleTimeSeries`). Used by the store-wide
@@ -1880,16 +1891,57 @@ _infrastore_subtype_types(::Type{T}) where {T <: TimeSeriesData} =
         Tuple(c for (c, k) in _INFRASTORE_TYPE_PAIRS if k <: _unparameterized_type(T)),
     )
 
+# The query type as the store answers it. Both normalizations are pure widenings, and
+# both are constants per query type:
+#
+#   - a parameterized concrete (`SingleTimeSeries{Float64, 1}`, i.e. `typeof(ts)`) matches
+#     the same rows as its UnionAll, because the catalog does not key on the element type
+#     — the parameters can only restate what the stored array is, never select between
+#     arrays;
+#   - a `Deterministic` query also matches a `DeterministicSingleTimeSeries`, which reads
+#     back as a `Deterministic`. DST is `Deterministic`'s sibling under
+#     `AbstractDeterministic` rather than its subtype, so widening to their common parent
+#     is how that rule is stated in the type domain rather than as a special case in the
+#     comparison below.
+#
+# A `DeterministicSingleTimeSeries` query is not widened, and so still matches DST alone.
+_infrastore_query_bound(::Type{T}) where {T} = _unparameterized_type(T)
+
+_infrastore_query_bound(u::Union) = _unparameterized_type(u)
+
+_infrastore_query_bound(::Type{<:Deterministic}) = AbstractDeterministic
+
+# Subtyping, with dispatch rather than a `<:` expression deciding it: a row type that is
+# a subtype of the (normalized) query type selects the first method. Both answers are
+# constants, so a query type known at compile time folds the match away entirely.
+_infrastore_matches_bound(::Type{<:B}, ::Type{B}) where {B} = true
+
+_infrastore_matches_bound(::Type, ::Type) = false
+
+# Whether a stored row of concrete type `R` satisfies a query for type `Q`. Defined here
+# rather than beside the other row helpers because `_infrastore_query_types` generates
+# against it, and a generated function may only call methods that already exist when it
+# is defined.
+_infrastore_type_matches(::Type{R}, ::Type{Q}) where {R <: TimeSeriesData, Q} =
+    _infrastore_matches_bound(R, _infrastore_query_bound(Q))
+
 # The stored InfraStore types a query for `T` should match, under the same
 # `Deterministic`-matches-DST semantics as `_infrastore_type_matches`. `AllStoredTypes()`
 # / `NoStoredTypes()` for the two degenerate answers; otherwise a non-empty tuple.
 _infrastore_query_types(::Nothing) = AllStoredTypes()
 
-function _infrastore_query_types(::Type{T}) where {T <: TimeSeriesData}
+# The answer is a pure function of the query type, so compute it once per `T` at compile
+# time and splice in the literal. `@generated` rather than a table of baked methods
+# because the answer must be constant for *every* spelling a caller can pass — including
+# parameterized concretes (`SingleTimeSeries{Float64, 1}`) and `Union`s, neither of which
+# is enumerable up front and both of which a method table would leave on a ~2 µs runtime
+# match loop, real money on the `has_time_series` per-component hot path.
+@generated function _infrastore_query_types(::Type{T}) where {T <: TimeSeriesData}
     types = Tuple(c for (c, k) in _INFRASTORE_TYPE_PAIRS if _infrastore_type_matches(k, T))
-    length(types) == length(_INFRASTORE_TYPE_PAIRS) && return AllStoredTypes()
-    isempty(types) && return NoStoredTypes()
-    return _infrastore_collapse_family(types)
+    length(types) == length(_INFRASTORE_TYPE_PAIRS) && return :(AllStoredTypes())
+    isempty(types) && return :(NoStoredTypes())
+    collapsed = _infrastore_collapse_family(types)
+    return :($collapsed)
 end
 
 # The single InfraStore type to push into the core `list_keys` filter for a query
@@ -1921,10 +1973,9 @@ _infrastore_probe_types(probe, types::Tuple) = any(probe, types)
 # widens the passed `Type{T}` constant to abstract `Type`, which defeats constant
 # propagation through `_infrastore_query_types` and boxes this function's return as
 # `Any` instead of `Bool` — real cost on the `has_time_series` hot path.
-function infrastore_has_any(owner; time_series_type = nothing)
-    mgr = get_time_series_manager(owner)
-    store = mgr.data_store
-    owner_id, _, category = _infrastore_owner_args(owner)
+function infrastore_has_any(mgr::TimeSeriesManager, owner; time_series_type = nothing)
+    store = mgr.data_store::Store
+    owner_id, category = _infrastore_owner_id_category(owner)
     probe =
         t -> InfraStore.has_for_owner(
             store.inner, owner_id, category; time_series_type = t,
@@ -1942,46 +1993,6 @@ _infrastore_is_type(s::Symbol) =
     get(_INFRASTORE_IS_TYPES, s) do
         error("InfraStore backend does not support time series type $s")
     end
-
-# Whether a stored row of concrete type `row_type` satisfies a query for the query type.
-# Mirrors InfraStore's semantics: a `Deterministic` (or `AbstractDeterministic`) query
-# also matches a `DeterministicSingleTimeSeries` (which reads as a `Deterministic`),
-# while a `DeterministicSingleTimeSeries` query matches DST only.
-_infrastore_type_matches(
-    row_type::Type, ::Type{<:DeterministicSingleTimeSeries},
-) = row_type <: DeterministicSingleTimeSeries
-
-_infrastore_type_matches(row_type::Type, ::Type{<:AbstractDeterministic}) =
-    row_type <: AbstractDeterministic
-
-# A parameterized concrete query (`SingleTimeSeries{Float64, 1}`, i.e. `typeof(ts)`)
-# matches the same rows as its UnionAll: the catalog does not key on the element
-# type, so the parameters can only restate what the stored array is, never select
-# between arrays.
-_infrastore_type_matches(row_type::Type, ::Type{T}) where {T <: TimeSeriesData} =
-    row_type <: _unparameterized_type(T)
-
-# `SingleTimeSeries{Float64, 1}` -> `SingleTimeSeries`; a UnionAll or a `Union` of
-# time series types is returned as is.
-_unparameterized_type(::Type{T}) where {T} =
-    T isa Union ? T : Base.typename(T).wrapper
-
-# `_infrastore_query_types`' answer is static per query type, and its generic
-# method's runtime match loop costs ~2 µs — real money on the
-# `has_time_series` per-component hot path. Bake a constant-returning method
-# for each type callers actually pass (the UnionAlls; parameterized concretes
-# still take the generic method).
-for T in (
-    (k for (_, k) in _INFRASTORE_TYPE_PAIRS)...,
-    AbstractDeterministic,
-    Forecast,
-    StaticTimeSeries,
-    TimeSeriesData,
-)
-    let types = _infrastore_query_types(T)
-        @eval _infrastore_query_types(::Type{$T}) = $types
-    end
-end
 
 # Build the matching IS `TimeSeriesKey` from a catalog row — a
 # `InfraStore.list_keys` / `list_array_groups` row or a `list_time_series`

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -898,7 +898,7 @@ function has_time_series(
 ) where {T <: TimeSeriesData}
     mgr = get_time_series_manager(val)
     isnothing(mgr) && return false
-    return infrastore_has_any(val; time_series_type = T)
+    return infrastore_has_any(mgr, val; time_series_type = T)
 end
 
 function has_time_series(
@@ -912,7 +912,7 @@ function has_time_series(
     mgr = get_time_series_manager(val)
     isnothing(mgr) && return false
     return infrastore_has_time_series(
-        T, val, name;
+        T, mgr, val, name;
         resolution = resolution, interval = interval, features = features,
     )
 end

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -885,79 +885,88 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Return true if the component or supplemental attribute has any time series data.
-"""
-has_time_series(owner::TimeSeriesOwners) = has_time_series(owner, TimeSeriesData)
+Return true if the component or supplemental attribute has time series data matching the
+query.
 
-"""
-Return true if the component or supplemental attribute has time series data of type T.
+Every argument past `owner` narrows the query, and each may be omitted:
+
+  - `T` restricts the match to one time series type or family, defaulting to any
+    (`TimeSeriesData`). A `Deterministic` query also matches a series stored by
+    [`transform_single_time_series!`](@ref), which reads back as a `Deterministic`.
+  - `name` restricts it to one series name, defaulting to any name.
+  - `resolution`, `interval`, and `features` narrow it further. A feature query is a
+    subset match: a series carrying features beyond those given still matches.
+
+```julia
+has_time_series(component)                                # any series at all
+has_time_series(component, Deterministic)                 # any forecast of that type
+has_time_series(component, "max_active_power")            # any series by that name
+has_time_series(component; resolution = Dates.Hour(1))    # any hourly series
+has_time_series(component, SingleTimeSeries, "load";
+                features = Dict("scenario" => "high"))
+```
+
+Answering is a pure existence probe in the store — a `SELECT 1 ... LIMIT 1` against a
+covering index. Nothing is listed, hydrated, or deserialized, so this is safe to call in
+a per-component loop.
 """
 function has_time_series(
-    val::TimeSeriesOwners,
-    ::Type{T},
-) where {T <: TimeSeriesData}
-    mgr = get_time_series_manager(val)
-    isnothing(mgr) && return false
-    return infrastore_has_any(mgr, val; time_series_type = T)
-end
-
-function has_time_series(
-    val::TimeSeriesOwners,
-    ::Type{T},
-    name::AbstractString;
+    owner::TimeSeriesOwners,
+    ::Type{T} = TimeSeriesData,
+    name::Union{Nothing, AbstractString} = nothing;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
-    mgr = get_time_series_manager(val)
+    mgr = get_time_series_manager(owner)
     isnothing(mgr) && return false
-    return infrastore_has_time_series(
-        T, mgr, val, name;
-        resolution = resolution, interval = interval, features = features,
-    )
+    return _has_time_series(mgr, owner, T, name, resolution, interval, features)
 end
 
 """
 $(TYPEDSIGNATURES)
-Return true if the component or supplemental attribute has time series data named
-`name`, optionally narrowed by `resolution`, `interval`, or `features`.
+Return true if the component or supplemental attribute has time series data named `name`,
+of any type. The `T = TimeSeriesData` case of the method above, which a default argument
+cannot express because the type and the name occupy the same position.
 """
-function has_time_series(
-    owner::TimeSeriesOwners,
-    name::AbstractString;
-    resolution::Union{Nothing, Dates.Period} = nothing,
-    interval::Union{Nothing, Dates.Period} = nothing,
-    features::Union{Nothing, Dict} = nothing,
-)
-    return has_time_series(
-        owner,
-        TimeSeriesData,
-        name;
-        resolution = resolution,
-        interval = interval,
-        features = features,
-    )
-end
-
 has_time_series(
-    T::Type{<:TimeSeriesData},
-    owner::TimeSeriesOwners,
-) = has_time_series(owner, T)
-
-has_time_series(
-    T::Type{<:TimeSeriesData},
     owner::TimeSeriesOwners,
     name::AbstractString;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Union{Nothing, Dict} = nothing,
 ) = has_time_series(
-    owner,
-    T,
-    name;
-    resolution = resolution,
-    interval = interval,
-    features = features,
+    owner, TimeSeriesData, name;
+    resolution = resolution, interval = interval, features = features,
+)
+
+# The two store probes answer the same question at different costs, so the route is a
+# dispatch on the query rather than a branch in the body: an unnarrowed query — no name,
+# no resolution, no interval, no features — takes the owner-scoped probe, consistently
+# ~40% faster (848/861/871 ns vs 1208/1213/1247 ns over three runs) than the general
+# catalog filter that would otherwise serve it. Everything else takes the filter.
+_has_time_series(
+    mgr::TimeSeriesManager,
+    owner::TimeSeriesOwners,
+    ::Type{T},
+    ::Nothing,
+    ::Nothing,
+    ::Nothing,
+    ::Nothing,
+) where {T <: TimeSeriesData} =
+    infrastore_has_any(mgr, owner; time_series_type = T)
+
+_has_time_series(
+    mgr::TimeSeriesManager,
+    owner::TimeSeriesOwners,
+    ::Type{T},
+    name::Union{Nothing, AbstractString},
+    resolution::Union{Nothing, Dates.Period},
+    interval::Union{Nothing, Dates.Period},
+    features::Union{Nothing, Dict},
+) where {T <: TimeSeriesData} = infrastore_has_time_series(
+    T, mgr, owner, name;
+    resolution = resolution, interval = interval, features = features,
 )
 
 """

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -885,23 +885,19 @@ end
 
 """
 $(TYPEDSIGNATURES)
-Return true if the component or supplemental attribute has time series data matching the
-query.
+Return true if the component or supplemental attribute has time series data of type `T`,
+optionally narrowed further.
 
-Every argument past `owner` narrows the query, and each may be omitted:
-
-  - `T` restricts the match to one time series type or family, defaulting to any
-    (`TimeSeriesData`). A `Deterministic` query also matches a series stored by
-    [`transform_single_time_series!`](@ref), which reads back as a `Deterministic`.
-  - `name` restricts it to one series name, defaulting to any name.
-  - `resolution`, `interval`, and `features` narrow it further. A feature query is a
-    subset match: a series carrying features beyond those given still matches.
+`name` restricts the match to one series name; omitted, any name matches. `resolution`,
+`interval`, and `features` narrow it further, with or without a name. A feature query is
+a subset match: a series carrying features beyond those given still matches. A
+`Deterministic` query also matches a series stored by
+[`transform_single_time_series!`](@ref), which reads back as a `Deterministic`.
 
 ```julia
-has_time_series(component)                                # any series at all
 has_time_series(component, Deterministic)                 # any forecast of that type
-has_time_series(component, "max_active_power")            # any series by that name
-has_time_series(component; resolution = Dates.Hour(1))    # any hourly series
+has_time_series(component, SingleTimeSeries, "load")
+has_time_series(component, SingleTimeSeries; resolution = Dates.Hour(1))
 has_time_series(component, SingleTimeSeries, "load";
                 features = Dict("scenario" => "high"))
 ```
@@ -909,10 +905,12 @@ has_time_series(component, SingleTimeSeries, "load";
 Answering is a pure existence probe in the store — a `SELECT 1 ... LIMIT 1` against a
 covering index. Nothing is listed, hydrated, or deserialized, so this is safe to call in
 a per-component loop.
+
+See also the two type-less forms below, which query across every time series type.
 """
 function has_time_series(
     owner::TimeSeriesOwners,
-    ::Type{T} = TimeSeriesData,
+    ::Type{T},
     name::Union{Nothing, AbstractString} = nothing;
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
@@ -925,9 +923,23 @@ end
 
 """
 $(TYPEDSIGNATURES)
+Return true if the component or supplemental attribute has any time series data,
+optionally narrowed by `resolution`, `interval`, or `features`.
+"""
+has_time_series(
+    owner::TimeSeriesOwners;
+    resolution::Union{Nothing, Dates.Period} = nothing,
+    interval::Union{Nothing, Dates.Period} = nothing,
+    features::Union{Nothing, Dict} = nothing,
+) = has_time_series(
+    owner, TimeSeriesData, nothing;
+    resolution = resolution, interval = interval, features = features,
+)
+
+"""
+$(TYPEDSIGNATURES)
 Return true if the component or supplemental attribute has time series data named `name`,
-of any type. The `T = TimeSeriesData` case of the method above, which a default argument
-cannot express because the type and the name occupy the same position.
+of any type, optionally narrowed by `resolution`, `interval`, or `features`.
 """
 has_time_series(
     owner::TimeSeriesOwners,

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -206,7 +206,7 @@ end
     attrs = collect(IS.get_supplemental_attributes(IS.TestSupplemental, sys2))
     @test length(attrs) == 2
     for attr in attrs
-        @test IS.has_time_series(IS.SingleTimeSeries, attr)
+        @test IS.has_time_series(attr, IS.SingleTimeSeries)
         ts2 = IS.get_time_series(IS.SingleTimeSeries, attr, "test")
         @test IS.get_data(ts2) == ta
     end

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -381,12 +381,20 @@ end
     )
     IS.add_time_series!(sys, component, forecast)
 
-    # A parameterized concrete query type matches no stored type; it must not
-    # degrade to an unfiltered probe that answers true for the wrong type.
+    # A parameterized concrete query type is normalized to its UnionAll and narrows
+    # on that; it must not degrade to an unfiltered probe that answers true for the
+    # wrong type. Only a `Deterministic` is stored so far, so this is false.
     @test IS.has_time_series(component, IS.SingleTimeSeries{Float64, 1}, name) == false
     @test IS.has_time_series(component, IS.SingleTimeSeries{Float64, 1}) == false
     @test IS.has_time_series(component, IS.Deterministic, name)
     @test IS.has_time_series(component, IS.Deterministic)
+
+    # A `Union` query type matches each member's stored type, and only those. Unions
+    # are not dispatchable, so this is the case a baked method table would miss.
+    @test IS.has_time_series(component, Union{IS.Deterministic, IS.Probabilistic}, name)
+    @test IS.has_time_series(component, Union{IS.Deterministic, IS.Probabilistic})
+    @test IS.has_time_series(
+        component, Union{IS.SingleTimeSeries, IS.Probabilistic}, name) == false
 
     # The (owner, name) form must apply resolution/interval/feature filters
     # instead of silently dropping them.
@@ -423,6 +431,11 @@ end
     )
         @test_throws ArgumentError operation()
     end
+
+    # ...and the same query spelled as `typeof(ts)` answers identically: the catalog
+    # does not key on the element type, so the parameters cannot select between arrays.
+    @test IS.has_time_series(component, IS.SingleTimeSeries{Float64, 1}, "static")
+    @test IS.has_time_series(component, typeof(sts), "static")
 
     # The redesign's whole point is static `Bool` inference; the deleted
     # kwargs catch-all boxed its type filter as `Any` and broke this.

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -396,6 +396,12 @@ end
     @test IS.has_time_series(
         component, Union{IS.SingleTimeSeries, IS.Probabilistic}, name) == false
 
+    # A parameterized concrete *inside* a `Union` is normalized member-wise, like a bare
+    # one. Left un-normalized this answers false for every row, since no stored UnionAll
+    # is a subtype of `SingleTimeSeries{Float64, 1}`.
+    @test IS.has_time_series(
+        component, Union{IS.Deterministic{Float64, 2}, IS.Probabilistic}, name)
+
     # The (owner, name) form must apply resolution/interval/feature filters
     # instead of silently dropping them.
     sts = IS.SingleTimeSeries(;
@@ -437,10 +443,53 @@ end
     @test IS.has_time_series(component, IS.SingleTimeSeries{Float64, 1}, "static")
     @test IS.has_time_series(component, typeof(sts), "static")
 
+    # Every filter also works without a name — the name is one more optional narrowing,
+    # not a precondition for the others.
+    @test IS.has_time_series(component; resolution = resolution)
+    @test IS.has_time_series(component; resolution = Dates.Minute(5)) == false
+    @test IS.has_time_series(component; features = Dict("scenario" => "a"))
+    @test IS.has_time_series(component; features = Dict("scenario" => "b")) == false
+    @test IS.has_time_series(
+        component, IS.SingleTimeSeries; features = Dict("scenario" => "a"))
+    # ...and the type still narrows: only the static series carries `scenario`.
+    @test IS.has_time_series(
+        component, IS.Deterministic; features = Dict("scenario" => "a")) == false
+
     # The redesign's whole point is static `Bool` inference; the deleted
     # kwargs catch-all boxed its type filter as `Any` and broke this.
     @test Base.return_types(IS.has_time_series, (typeof(component),)) == [Bool]
     @test Base.return_types(IS.has_time_series, (typeof(component), String)) == [Bool]
+    @test Base.return_types(
+        IS.has_time_series, (typeof(component), Type{IS.Deterministic})) == [Bool]
+    @test Base.return_types(
+        IS.has_time_series,
+        (typeof(component), Type{IS.SingleTimeSeries}, String),
+    ) == [Bool]
+
+    # An unnarrowed query must keep taking the cheaper owner-scoped probe: the route is
+    # a dispatch, so the wrong method here is a silent ~40% regression, not a failure.
+    mgr = IS.get_time_series_manager(component)
+    fast = which(
+        IS._has_time_series,
+        (typeof(mgr), typeof(component), Type{IS.Deterministic},
+            Nothing, Nothing, Nothing, Nothing),
+    )
+    for narrowed in (
+        (String, Nothing, Nothing, Nothing),
+        (Nothing, Dates.Hour, Nothing, Nothing),
+        (Nothing, Nothing, Dates.Hour, Nothing),
+        (Nothing, Nothing, Nothing, Dict{String, Any}),
+    )
+        @test which(
+            IS._has_time_series,
+            (typeof(mgr), typeof(component), Type{IS.Deterministic}, narrowed...),
+        ) !== fast
+    end
+
+    # The legacy type-first spellings are gone, not silently forwarded.
+    @test !hasmethod(IS.has_time_series, (Type{IS.SingleTimeSeries}, typeof(component)))
+    @test !hasmethod(
+        IS.has_time_series, (Type{IS.SingleTimeSeries}, typeof(component), String))
 end
 
 @testset "Test add forecast with irregular resolution and interval" begin

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -490,6 +490,18 @@ end
     @test !hasmethod(IS.has_time_series, (Type{IS.SingleTimeSeries}, typeof(component)))
     @test !hasmethod(
         IS.has_time_series, (Type{IS.SingleTimeSeries}, typeof(component), String))
+
+    # The query type is a required positional, not a defaulted one: the two type-less
+    # shapes are their own methods, so reaching `name` never means passing a type first.
+    @test length(methods(IS.has_time_series)) == 4
+    for shape in (
+        (typeof(component),),
+        (typeof(component), String),
+        (typeof(component), Type{IS.SingleTimeSeries}),
+        (typeof(component), Type{IS.SingleTimeSeries}, String),
+    )
+        @test hasmethod(IS.has_time_series, shape)
+    end
 end
 
 @testset "Test add forecast with irregular resolution and interval" begin


### PR DESCRIPTION
Closes #613.

Rebased onto `IS4`, including #623 — the features refactor lands cleanly under this and
actually simplifies it: with `features::Union{Nothing, Dict}` replacing the kwargs
splat, the fast-route dispatch below keys on a plain `::Nothing` instead of an empty
`NamedTuple`. The base was also retargeted from `feat/infrastore-integration`, which is
merged into IS4.

Three commits: the backend type-translation work, the consolidation the issue asks for, then
the review fix making the query type required.

### 1. Type translation folds to compile time

`_infrastore_query_types` answers a pure function of the query type, but the `@eval`
table only baked constants for ten hand-listed `UnionAll`s. Parameterized concretes
(`SingleTimeSeries{Float64, 1}`) and `Union`s escaped it and stayed on the ~2 µs runtime
match loop. Neither is enumerable up front, and `Union`s are not dispatchable, so adding
methods could not close the gap — hence `@generated`. Verified with `code_typed` that
every spelling folds to a literal with a concrete return type:

| query type | returns |
|---|---|
| `SingleTimeSeries` | `(InfraStore.SingleTimeSeries,)` |
| `Forecast` | `(Deterministic, Probabilistic, Scenarios)` |
| `TimeSeriesData` | `AllStoredTypes()` |
| `SingleTimeSeries{Float64,1}` | `(InfraStore.SingleTimeSeries,)` |
| `Union{Deterministic, Probabilistic}` | `(Deterministic, Probabilistic)` |

`_infrastore_type_matches` and `_unparameterized_type` move up beside it — a generated
function may only call methods that already exist when it is defined. Other callers
unaffected; please don't move them back.

While it moved, `_infrastore_type_matches` lost its `row_type <: [some type]` return
values (review feedback). Both remaining answers are constants, and the type parameters
decide the subtyping:

```julia
_infrastore_matches_bound(::Type{<:B}, ::Type{B}) where {B} = true
_infrastore_matches_bound(::Type, ::Type) = false

_infrastore_type_matches(::Type{R}, ::Type{Q}) where {R <: TimeSeriesData, Q} =
    _infrastore_matches_bound(R, _infrastore_query_bound(Q))
```

What makes that work is moving the two irregularities out of the comparison and into a
normalization of the *query type*, where each answer is also a constant:

```julia
_infrastore_query_bound(::Type{T}) where {T} = _unparameterized_type(T)
# DST is `Deterministic`'s sibling, not its subtype, so widening to their common parent
# is how "a `Deterministic` query also matches a DST" is stated in the type domain
_infrastore_query_bound(::Type{<:Deterministic}) = AbstractDeterministic
```

A DST query is not widened, so it still matches DST alone. Verified against a
table-driven oracle of the previous semantics: parity across 15 query spellings × 6 row
types, no method ambiguity (Aqua agrees), and every match still folds to a constant.

**One deliberate behavior change**, from @copilot's review: `_unparameterized_type` now
normalizes a `Union` member-wise. It previously returned one unchanged, so
`Union{SingleTimeSeries{Float64, 1}, Probabilistic}` matched *no* rows at all — a silent
wrong answer, and a contradiction of the rule that a parameterized concrete narrows like
its UnionAll. Narrow spelling, but it was wrong rather than merely unsupported. Now
covered by a test.

Also on the probe path:

Also on the probe path:

- Thread the caller's already-resolved manager into `infrastore_has_any` /
  `infrastore_has_time_series` instead of resolving it a second time.
- `_infrastore_owner_id_category` at both probe sites — the probes never send the
  `owner_type` string `_infrastore_owner_args` builds.

### 2. The `has_time_series` family consolidates

Six definitions answered one question in four spellings, three of them forwarding to a
fourth. Three remain, and the query type is a **required** positional — per review, two
positional arguments with defaults is a shape to avoid, since reaching the second means
passing the first:

```julia
has_time_series(owner, ::Type{T}, name = nothing; resolution, interval, features)
has_time_series(owner;                            resolution, interval, features)
has_time_series(owner, name::AbstractString;      resolution, interval, features)
```

The only default left is a trailing one. Every call shape is preserved —
`has_time_series(owner)` alone is 33 call sites, 16 of them downstream — but none now
depends on a defaulted type argument.

**Gone: the type-first `has_time_series(T, owner[, name])`.** An IS3 leftover with no
caller in the workspace outside one line of IS's own serialization test — 145 owner-first
call sites against 1 type-first, and zero in PSY / PNM / POM / IOM / PSCB. It was added
in #357 and never picked up callers in either line. IS4 is breaking, so it is deleted
rather than deprecated. (Note that InfraStore.jl's own `has_time_series` is type-first
and unaffected; it is a different function taking a `Store`.)

**Newly reachable: a filter without a name**, e.g. `has_time_series(c; resolution = Hour(1))`.
The store has always served it and `infrastore_has_time_series` has always accepted
`name = nothing`; no public method passed it. Making the name optional alongside the
other narrowings is what removes the special case.

**The two-route fork is kept**, now as a dispatch on the query shape rather than two
public spellings:

```julia
_has_time_series(mgr, owner, ::Type{T}, ::Nothing, ::Nothing, ::Nothing, ::Nothing) =
    infrastore_has_any(...)          # owner-scoped probe
_has_time_series(mgr, owner, ::Type{T}, name, resolution, interval, features) =
    infrastore_has_time_series(...)  # catalog filter
```

It looks collapsible; it isn't. `has_for_owner` is consistently ~40% faster (848/861/871 ns
vs 1208/1213/1247 ns over three runs), so collapsing would regress the hotter shape. Tests
now pin the routing, so picking the wrong method is a failure rather than a silent
regression. Return-type inference stays `Bool` on every shape.

### On infrastore#55

Read it before choosing the shape here. It adds a derived surrogate `association_id` (a
pure hash of the full identity) plus an id-keyed metadata lookup. It does **not** collapse
this surface: `has_time_series` is a *partial* query — subset features, optional
resolution/interval, abstract query types — while the id needs a complete identity and a
single concrete stored type. What it will offer is a fast path for the fully-specified
case, and that case now funnels through one internal method where it can slot in. I don't
think this PR should wait on it, but happy to be told otherwise.

### Testing

- Full suite: **9277 pass, 2 broken** (pre-existing `@test_broken`), **0 fail**. Formatter clean.
- Heads-up for reviewers: `test/`'s manifest may still be on InfraStore v0.8.0.
  `Pkg.update("InfraStore")` in the test env if the narrowing testset errors.
- Downstream smoke test **not run** — there is no workspace-root project on my machine and
  the local PowerSystems checkout is pinned to a pre-InfraStore IS branch. Checked by
  inspection instead: no psy6 package calls the removed spellings, and every downstream
  extension (PNM's two, IOM's mock) is `(owner, T, name)`, which is unchanged. That is
  reasoning rather than verification.
