### PR TITLE
Support cost curve unit conversions and FuelCurve → CostCurve

### DIFF
--- a/src/InfrastructureSystems.jl
+++ b/src/InfrastructureSystems.jl
@@ -175,7 +175,7 @@ using .RelativeUnits:
     unitful_variant
 # Names not exported from the submodule are pulled in explicitly so the
 # `IS._strip_units(...)` / `IS.convert_cost_coefficient(...)` call sites work.
-using .RelativeUnits: _strip_units, convert_cost_coefficient
+using .RelativeUnits: _strip_units, convert_cost_coefficient, _cost_coeff_ratio
 include("random_seed.jl")
 include("utils/timers.jl")
 include("utils/assert_op.jl")

--- a/src/function_data/function_data.jl
+++ b/src/function_data/function_data.jl
@@ -525,6 +525,66 @@ end
 "Left shift the `FunctionData` by a scalar: (f << c)(x) = (f >> -c)(x) = f(x + c)"
 Base.:<<(fd::FunctionData, c::Real) = fd >> -c
 
+# SCALE THE AXES
+# `scale_y` is spelled `*`; `scale_x` has no natural operator spelling, so both get a named
+# form and the pair is documented together.
+"""
+Check the factor for `scale_x`. Only strictly positive factors are allowed: a negative
+factor would reverse the x-ordering that the piecewise types require, and zero collapses
+the domain to a point.
+"""
+function _check_x_scale_factor(c::Real)
+    (isfinite(c) && c > 0) || throw(
+        ArgumentError(
+            "scale_x requires a finite, strictly positive factor, got $c; " *
+            "use `~f` to flip about the y-axis",
+        ),
+    )
+    return
+end
+
+"Horizontally scale the `LinearFunctionData`: `scale_x(f, c)(x) = f(c * x)`"
+function scale_x(fd::LinearFunctionData, c::Real)
+    _check_x_scale_factor(c)
+    return LinearFunctionData(
+        c * get_proportional_term(fd),
+        get_constant_term(fd),
+    )
+end
+
+"Horizontally scale the `QuadraticFunctionData`: `scale_x(f, c)(x) = f(c * x)`"
+function scale_x(fd::QuadraticFunctionData, c::Real)
+    _check_x_scale_factor(c)
+    return QuadraticFunctionData(
+        c^2 * get_quadratic_term(fd),
+        c * get_proportional_term(fd),
+        get_constant_term(fd),
+    )
+end
+
+"Horizontally scale the `PiecewiseLinearData`: `scale_x(f, c)(x) = f(c * x)`"
+function scale_x(fd::PiecewiseLinearData, c::Real)
+    _check_x_scale_factor(c)
+    return PiecewiseLinearData([(p.x / c, p.y) for p in get_points(fd)])
+end
+
+"Horizontally scale the `PiecewiseStepData`: `scale_x(f, c)(x) = f(c * x)`"
+function scale_x(fd::PiecewiseStepData, c::Real)
+    _check_x_scale_factor(c)
+    x_coords = get_x_coords(fd)
+    new_x = Vector{Float64}(undef, length(x_coords))
+    for i in eachindex(x_coords, new_x)
+        new_x[i] = x_coords[i] / c
+    end
+    return PiecewiseStepData(new_x, get_y_coords(fd))
+end
+
+"""
+Vertically scale the `FunctionData`: `scale_y(f, c)(x) = c * f(x)`. Named companion of
+[`scale_x`](@ref); equivalent to `c * fd`.
+"""
+scale_y(fd::FunctionData, c::Real) = c * fd
+
 # NEGATION
 "Negate the `FunctionData`: (-f)(x) = -f(x)"
 Base.:-(fd::FunctionData) = -1.0 * fd

--- a/src/production_variable_cost_curve.jl
+++ b/src/production_variable_cost_curve.jl
@@ -283,6 +283,120 @@ get_time_series_key(::FuelCurve) = _fuel_curve_no_ts_key()
 get_time_series_key(::FuelCurve{<:ValueCurve{<:TimeSeriesFunctionData}}) =
     _fuel_curve_no_ts_key()
 
+# ── Unit conversion ───────────────────────────────────────────────────────────
+# A change of power units rescales the x-axis: if `ρ` is the ratio such that
+# `x_from = ρ * x_to`, the converted curve represents `f_to(x_to) = f_from(ρ * x_to)`,
+# which is exactly `scale_x(curve, ρ)`. `ρ` comes from the same `_cost_coeff_ratio`
+# dispatch table that backs `convert_cost_coefficient`.
+#
+# Only the x-axis moves. These y-axes are absolute currency or fuel rates (\$/h, MBTU/h)
+# that carry no power units, so nothing rescales them. Note that `scale_x` still changes
+# the stored y *data* of an `IncrementalCurve`/`AverageRateCurve` — those y-axes are rates
+# per unit of x (\$/MWh), so x's units sit in the denominator and must convert with it.
+# That factor is the chain rule inside `scale_x`, not a y-scaling of the curve.
+
+"""
+$(TYPEDSIGNATURES)
+
+Convert `curve` to the `to` unit system, returning a curve of the same outer type whose
+`U` parameter is `typeof(to)`. `system_base_power` and `device_base_power` supply the
+conversion factors; `InfrastructureSystems` has no notion of components, so callers pass
+them explicitly (domain packages are expected to add a component-aware convenience
+method).
+
+The `fuel_cost` of a [`FuelCurve`](@ref) is in currency per unit of fuel and is left
+alone. Time-series-backed value curves cannot be rescaled and raise an `ArgumentError`.
+"""
+function convert_power_units(
+    curve::CostCurve{T, U},
+    to::AbstractUnitSystem,
+    system_base_power::Float64,
+    device_base_power::Float64,
+) where {T, U}
+    ratio = _cost_coeff_ratio(U(), to, system_base_power, device_base_power)
+    return CostCurve(
+        scale_x(get_value_curve(curve), ratio),
+        to,
+        scale_x(get_vom_cost(curve), ratio),
+    )
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Convert a [`FuelCurve`](@ref) to the `to` unit system. Only the value curve and `vom_cost`
+are rescaled — both are functions of the production quantity on the x-axis.
+
+`fuel_cost` is currency per unit of fuel, and `startup_fuel_offtake` is fuel consumed as a
+function of *downtime*: its x-axis is a duration and its y-axis is a fuel quantity, so a
+change of power units touches neither. Both carry over unchanged.
+"""
+function convert_power_units(
+    curve::FuelCurve{T, U},
+    to::AbstractUnitSystem,
+    system_base_power::Float64,
+    device_base_power::Float64,
+) where {T, U}
+    ratio = _cost_coeff_ratio(U(), to, system_base_power, device_base_power)
+    # `startup_fuel_offtake` is fuel vs. downtime — neither axis is in power units.
+    return FuelCurve(
+        scale_x(get_value_curve(curve), ratio),
+        to,
+        get_fuel_cost(curve),
+        get_startup_fuel_offtake(curve),
+        scale_x(get_vom_cost(curve), ratio),
+    )
+end
+
+# Converting to the unit system a curve is already in is the identity, dispatched rather
+# than branched. Written per concrete type to stay unambiguous against the methods above.
+convert_power_units(curve::CostCurve{T, U}, ::U, ::Float64, ::Float64) where {T, U} = curve
+convert_power_units(curve::FuelCurve{T, U}, ::U, ::Float64, ::Float64) where {T, U} = curve
+
+# ── FuelCurve → CostCurve ─────────────────────────────────────────────────────
+
+_scalar_fuel_cost(fuel_cost::Float64) = fuel_cost
+_scalar_fuel_cost(::TimeSeriesKey) = throw(
+    ArgumentError(
+        "cannot convert a FuelCurve with a time-series-backed fuel_cost to a CostCurve; " *
+        "resolve the fuel cost for the timestep of interest first",
+    ),
+)
+
+_check_no_startup_fuel(startup::LinearCurve) = _check_no_startup_fuel(
+    get_function_data(startup),
+)
+function _check_no_startup_fuel(fd::LinearFunctionData)
+    (iszero(get_proportional_term(fd)) && iszero(get_constant_term(fd))) || throw(
+        ArgumentError(
+            "cannot convert a FuelCurve with a nonzero startup_fuel_offtake to a " *
+            "CostCurve: a CostCurve has nowhere to record startup fuel, so the " *
+            "startup cost would be silently lost",
+        ),
+    )
+    return
+end
+
+"""
+$(TYPEDSIGNATURES)
+
+Convert a [`FuelCurve`](@ref) with a scalar `fuel_cost` into the equivalent
+[`CostCurve`](@ref) by multiplying the value curve through by the fuel cost. The unit
+system and the (already-in-currency) `vom_cost` carry over unchanged.
+
+Throws an `ArgumentError` if `fuel_cost` is a [`TimeSeriesKey`](@ref) rather than a
+scalar, or if `startup_fuel_offtake` is nonzero — a `CostCurve` cannot represent it.
+"""
+function CostCurve(curve::FuelCurve{T, U}) where {T, U}
+    fuel_cost = _scalar_fuel_cost(get_fuel_cost(curve))
+    _check_no_startup_fuel(get_startup_fuel_offtake(curve))
+    return CostCurve(
+        fuel_cost * get_value_curve(curve),
+        U(),
+        get_vom_cost(curve),
+    )
+end
+
 # ── Serialization ─────────────────────────────────────────────────────────────
 # The U type parameter has no corresponding field, so we serialize it under the
 # conventional "power_units" key (preserving the field name from the previous

--- a/src/value_curve.jl
+++ b/src/value_curve.jl
@@ -164,6 +164,95 @@ Base.zero(::Union{AverageRateCurve, Type{AverageRateCurve}}) =
 Base.zero(::Union{ValueCurve, Type{ValueCurve}}) =
     Base.zero(InputOutputCurve)
 
+# SCALING
+# Both operations are defined in terms of the *input-output* function `f` the curve
+# represents, not in terms of its raw `function_data`: `IncrementalCurve` stores `f'` and
+# `AverageRateCurve` stores `f(x)/x`, so an x-scaling picks up a chain-rule factor on y for
+# those two. Anchoring on `f` is what makes the operations composable across subtypes.
+
+# `initial_input` and `input_at_zero` are absolute y-quantities, so they scale with y and
+# are untouched by an x-scaling.
+_scale_optional(::Nothing, ::Real) = nothing
+_scale_optional(x::Float64, c::Real) = c * x
+
+"Vertically scale the `InputOutputCurve`: `(c * curve)` represents `c * f(x)`"
+Base.:*(c::Real, curve::InputOutputCurve) =
+    InputOutputCurve(
+        c * get_function_data(curve),
+        _scale_optional(get_input_at_zero(curve), c),
+    )
+
+"Vertically scale the `IncrementalCurve`: `(c * curve)` represents `c * f(x)`"
+Base.:*(c::Real, curve::IncrementalCurve) =
+    IncrementalCurve(
+        c * get_function_data(curve),
+        _scale_optional(get_initial_input(curve), c),
+        _scale_optional(get_input_at_zero(curve), c),
+    )
+
+"Vertically scale the `AverageRateCurve`: `(c * curve)` represents `c * f(x)`"
+Base.:*(c::Real, curve::AverageRateCurve) =
+    AverageRateCurve(
+        c * get_function_data(curve),
+        _scale_optional(get_initial_input(curve), c),
+        _scale_optional(get_input_at_zero(curve), c),
+    )
+
+# commutativity
+"Vertically scale the `ValueCurve`: `(curve * c)` = `(c * curve)` represents `c * f(x)`"
+Base.:*(curve::ValueCurve, c::Real) = c * curve
+
+"""
+Horizontally scale the `InputOutputCurve`: the result represents `f(c * x)`, where `f` is
+the input-output function of `curve`.
+"""
+scale_x(curve::InputOutputCurve, c::Real) =
+    InputOutputCurve(
+        scale_x(get_function_data(curve), c),
+        get_input_at_zero(curve),
+    )
+
+"""
+Horizontally scale the `IncrementalCurve`: the result represents `f(c * x)`, where `f` is
+the input-output function of `curve`. Since this curve stores `f'`, the stored data picks
+up a chain-rule factor of `c` on the y-axis as well.
+"""
+scale_x(curve::IncrementalCurve, c::Real) =
+    IncrementalCurve(
+        c * scale_x(get_function_data(curve), c),
+        get_initial_input(curve),
+        get_input_at_zero(curve),
+    )
+
+"""
+Horizontally scale the `AverageRateCurve`: the result represents `f(c * x)`, where `f` is
+the input-output function of `curve`. Since this curve stores `f(x)/x`, the stored data
+picks up a factor of `c` on the y-axis as well.
+"""
+scale_x(curve::AverageRateCurve, c::Real) =
+    AverageRateCurve(
+        c * scale_x(get_function_data(curve), c),
+        get_initial_input(curve),
+        get_input_at_zero(curve),
+    )
+
+"Vertically scale the `ValueCurve`; named companion of [`scale_x`](@ref)"
+scale_y(curve::ValueCurve, c::Real) = c * curve
+
+# Time-series-backed curves hold a `TimeSeriesKey`, not data to scale. Mirrors how
+# `is_convex`/`is_concave` refuse them: resolve to a static curve per timestep first.
+_no_scaling_for_ts(op::AbstractString, curve::ValueCurve) = throw(
+    ArgumentError(
+        "$op is not defined for the time-series-backed $(nameof(typeof(curve))); " *
+        "resolve to a static curve with `build_static_curve` first",
+    ),
+)
+
+Base.:*(::Real, curve::ValueCurve{<:TimeSeriesFunctionData}) =
+    _no_scaling_for_ts("Scaling", curve)
+scale_x(curve::ValueCurve{<:TimeSeriesFunctionData}, ::Real) =
+    _no_scaling_for_ts("scale_x", curve)
+
 # CONVERSIONS: InputOutputCurve{LinearFunctionData} to InputOutputCurve{QuadraticFunctionData}
 InputOutputCurve{QuadraticFunctionData}(data::InputOutputCurve{LinearFunctionData}) =
     InputOutputCurve{QuadraticFunctionData}(

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -509,3 +509,208 @@ end
     @test io_piecewise(3.0) == 7.0
     @test io_piecewise(5.0) == 11.0
 end
+
+# Helpers for the scaling / unit-conversion testsets below. `FunctionData` has no
+# `isapprox`, so compare the defining terms elementwise.
+_fd_terms(fd::IS.LinearFunctionData) =
+    [IS.get_proportional_term(fd), IS.get_constant_term(fd)]
+_fd_terms(fd::IS.QuadraticFunctionData) =
+    [IS.get_quadratic_term(fd), IS.get_proportional_term(fd), IS.get_constant_term(fd)]
+_fd_terms(fd::Union{IS.PiecewiseLinearData, IS.PiecewiseStepData}) =
+    vcat(IS.get_x_coords(fd), IS.get_y_coords(fd))
+
+fd_approx(a::T, b::T) where {T <: IS.FunctionData} =
+    all(isapprox.(_fd_terms(a), _fd_terms(b)))
+fd_approx(::IS.FunctionData, ::IS.FunctionData) = false  # differing shapes never match
+
+function ts_input_output_curve()
+    key = IS.ForecastKey(;
+        time_series_type = IS.Deterministic,
+        name = "cost",
+        initial_timestamp = Dates.DateTime("2020-01-01"),
+        resolution = Dates.Hour(1),
+        horizon = Dates.Hour(24),
+        interval = Dates.Hour(24),
+        count = 1,
+        features = Dict{String, Any}(),
+    )
+    return IS.TimeSeriesInputOutputCurve(IS.TimeSeriesQuadraticFunctionData(key))
+end
+
+@testset "ValueCurve scaling (scale_x, scale_y)" begin
+    ratio = 4.0
+    # scale_x is defined on the input-output function a curve represents, so it must
+    # commute with conversion to InputOutputCurve for every representation.
+    for curve in (
+        IS.IncrementalCurve(IS.LinearFunctionData(4, 6), 4.0),
+        IS.AverageRateCurve(IS.LinearFunctionData(2, 3), 4.0),
+        IS.IncrementalCurve(IS.PiecewiseStepData([1, 2, 4], [10, 20]), 5.0),
+        IS.AverageRateCurve(IS.PiecewiseStepData([1, 2, 4], [10, 20]), 5.0),
+    )
+        via_scale = IS.InputOutputCurve(IS.scale_x(curve, ratio))
+        via_convert = IS.scale_x(IS.InputOutputCurve(curve), ratio)
+        @test fd_approx(IS.get_function_data(via_scale), IS.get_function_data(via_convert))
+    end
+
+    # An InputOutputCurve evaluates as f(c * x)
+    io = IS.InputOutputCurve(IS.QuadraticFunctionData(2, 3, 4))
+    io_scaled = IS.scale_x(io, ratio)
+    for x in (0.5, 1.0, 2.0)
+        @test io_scaled(x) ≈ io(ratio * x)
+    end
+    @test IS.scale_x(io, 1.0) == io
+
+    # Piecewise input-output data keeps its y-coordinates; only x moves
+    pw_io = IS.InputOutputCurve(IS.PiecewiseLinearData([(1, 1), (3, 5), (5, 10)]))
+    pw_io_scaled = IS.scale_x(pw_io, ratio)
+    @test IS.get_x_coords(IS.get_function_data(pw_io_scaled)) ≈ [0.25, 0.75, 1.25]
+    @test IS.get_y_coords(IS.get_function_data(pw_io_scaled)) ==
+          IS.get_y_coords(IS.get_function_data(pw_io))
+
+    # Vertical scaling also scales initial_input and input_at_zero, and skips `nothing`
+    inc = IS.IncrementalCurve(IS.LinearFunctionData(4, 6), 4.0, 2.0)
+    inc_scaled = 3.0 * inc
+    @test IS.get_initial_input(inc_scaled) == 12.0
+    @test IS.get_input_at_zero(inc_scaled) == 6.0
+    @test IS.get_function_data(inc_scaled) == 3.0 * IS.get_function_data(inc)
+    @test inc * 3.0 == inc_scaled
+    @test IS.scale_y(inc, 3.0) == inc_scaled
+    @test IS.get_input_at_zero(2.0 * IS.InputOutputCurve(IS.LinearFunctionData(1, 1))) ===
+          nothing
+    @test IS.get_initial_input(
+        2.0 * IS.IncrementalCurve(IS.LinearFunctionData(1, 1),
+            nothing),
+    ) === nothing
+
+    # Time-series-backed curves have no data to scale
+    ts_vc = ts_input_output_curve()
+    @test_throws ArgumentError IS.scale_x(ts_vc, 2.0)
+    @test_throws ArgumentError 2.0 * ts_vc
+end
+
+@testset "convert_power_units for CostCurve and FuelCurve" begin
+    sb, db = 100.0, 50.0
+    # The cost of producing a given *physical* quantity must not change with the units
+    # it is expressed in: x_NU MW == x_NU/sb system-base pu == x_NU/db device-base pu.
+    denominators = Dict(IS.NU => 1.0, IS.SU => sb, IS.DU => db)
+
+    cc = IS.CostCurve(IS.QuadraticCurve(2.0, 3.0, 4.0), IS.NU, IS.LinearCurve(7.0, 1.0))
+    for to in (IS.NU, IS.SU, IS.DU)
+        converted = IS.convert_power_units(cc, to, sb, db)
+        @test converted isa IS.CostCurve
+        @test IS.get_power_units(converted) == to
+        for mw in (10.0, 55.0)
+            x = mw / denominators[to]
+            @test IS.get_value_curve(converted)(x) ≈ IS.get_value_curve(cc)(mw)
+            @test IS.get_vom_cost(converted)(x) ≈ IS.get_vom_cost(cc)(mw)
+        end
+    end
+
+    # Round trips through every intermediate unit system return the original curve
+    for mid in (IS.NU, IS.SU, IS.DU)
+        there = IS.convert_power_units(cc, mid, sb, db)
+        back = IS.convert_power_units(there, IS.NU, sb, db)
+        @test fd_approx(IS.get_function_data(back), IS.get_function_data(cc))
+        @test IS.get_vom_cost(back) == IS.get_vom_cost(cc)
+    end
+
+    # Converting to the unit system a curve already carries is the identity
+    @test IS.convert_power_units(cc, IS.NU, sb, db) === cc
+    cc_su = IS.CostCurve(IS.LinearCurve(5.0), IS.SU)
+    @test IS.convert_power_units(cc_su, IS.SU, sb, db) === cc_su
+
+    # Piecewise and incremental representations convert too
+    pw = IS.CostCurve(
+        IS.PiecewiseIncrementalCurve(1.0, [1.0, 2.0, 4.0], [10.0, 20.0]),
+        IS.NU,
+    )
+    pw_su = IS.convert_power_units(pw, IS.SU, sb, db)
+    @test IS.get_x_coords(IS.get_function_data(pw_su)) ≈ [0.01, 0.02, 0.04]
+    @test IS.get_y_coords(IS.get_function_data(pw_su)) ≈ [1000.0, 2000.0]
+    @test IS.get_initial_input(pw_su) == IS.get_initial_input(pw)
+
+    # FuelCurve: fuel_cost is currency per unit of fuel and is unit-system agnostic
+    fc = IS.FuelCurve(
+        IS.QuadraticCurve(2.0, 3.0, 4.0),
+        IS.NU,
+        12.5,
+        IS.LinearCurve(3.0),
+        IS.LinearCurve(7.0),
+    )
+    fc_su = IS.convert_power_units(fc, IS.SU, sb, db)
+    @test fc_su isa IS.FuelCurve
+    @test IS.get_power_units(fc_su) == IS.SU
+    @test IS.get_fuel_cost(fc_su) == 12.5
+    for mw in (10.0, 55.0)
+        @test IS.get_value_curve(fc_su)(mw / sb) ≈ IS.get_value_curve(fc)(mw)
+        @test IS.get_vom_cost(fc_su)(mw / sb) ≈ IS.get_vom_cost(fc)(mw)
+    end
+    # startup_fuel_offtake is fuel consumed as a function of downtime: its x-axis is a
+    # duration and its y-axis a fuel quantity, so a change of power units must not touch
+    # it. Guards against it being swept up with the power-indexed fields.
+    @test IS.get_startup_fuel_offtake(fc_su) == IS.get_startup_fuel_offtake(fc)
+    for to in (IS.NU, IS.SU, IS.DU)
+        @test IS.get_startup_fuel_offtake(IS.convert_power_units(fc, to, sb, db)) ==
+              IS.get_startup_fuel_offtake(fc)
+    end
+    @test IS.convert_power_units(fc, IS.NU, sb, db) === fc
+
+    # A time-series-backed fuel_cost is fine (it carries no power units); a
+    # time-series-backed value curve is not
+    fc_ts_cost = IS.FuelCurve(
+        IS.LinearCurve(5.0),
+        IS.NU,
+        IS.get_time_series_key(ts_input_output_curve()),
+    )
+    @test IS.get_power_units(IS.convert_power_units(fc_ts_cost, IS.SU, sb, db)) == IS.SU
+    @test_throws ArgumentError IS.convert_power_units(
+        IS.CostCurve(ts_input_output_curve(), IS.NU), IS.SU, sb, db,
+    )
+end
+
+@testset "CostCurve from FuelCurve" begin
+    # Multiplying through by a scalar fuel cost gives the equivalent CostCurve
+    fc = IS.FuelCurve(IS.QuadraticCurve(2.0, 3.0, 4.0), IS.NU, 12.5, IS.LinearCurve(0.0),
+        IS.LinearCurve(7.0))
+    cc = IS.CostCurve(fc)
+    @test cc isa IS.CostCurve
+    @test IS.get_power_units(cc) == IS.NU
+    for mw in (10.0, 55.0)
+        @test IS.get_value_curve(cc)(mw) ≈ 12.5 * IS.get_value_curve(fc)(mw)
+    end
+    # vom_cost is already in currency, so it carries over untouched
+    @test IS.get_vom_cost(cc) == IS.get_vom_cost(fc)
+
+    # The unit system is preserved
+    for units in (IS.NU, IS.SU, IS.DU)
+        @test IS.get_power_units(
+            IS.CostCurve(IS.FuelCurve(IS.LinearCurve(5.0), units, 2.0)),
+        ) == units
+    end
+
+    # Incremental representation: initial_input scales with the rest of the curve
+    inc = IS.FuelCurve(IS.PiecewiseIncrementalCurve(1.0, [1.0, 2.0, 4.0], [10.0, 20.0]),
+        IS.NU, 3.0)
+    inc_cc = IS.CostCurve(inc)
+    @test IS.get_initial_input(inc_cc) == 3.0
+    @test IS.get_y_coords(IS.get_function_data(inc_cc)) == [30.0, 60.0]
+
+    # Nonzero startup_fuel_offtake cannot be represented and must not vanish silently
+    @test_throws ArgumentError IS.CostCurve(
+        IS.FuelCurve(IS.LinearCurve(5.0), IS.NU, 2.0, IS.LinearCurve(1.0),
+            IS.LinearCurve(0.0)),
+    )
+    @test_throws ArgumentError IS.CostCurve(
+        IS.FuelCurve(IS.LinearCurve(5.0), IS.NU, 2.0, IS.LinearCurve(0.0, 1.0),
+            IS.LinearCurve(0.0)),
+    )
+
+    # A time-series-backed fuel cost is not a scalar
+    @test_throws ArgumentError IS.CostCurve(
+        IS.FuelCurve(
+            IS.LinearCurve(5.0),
+            IS.NU,
+            IS.get_time_series_key(ts_input_output_curve()),
+        ),
+    )
+end

--- a/test/test_function_data.jl
+++ b/test/test_function_data.jl
@@ -1269,3 +1269,59 @@ end
     @test IS.is_convex(IS.InputOutputCurve(convex_pic))
     @test IS.is_convex(IS.InputOutputCurve(convex_pac))
 end
+
+@testset "Test FunctionData scale_x and scale_y" begin
+    # scale_x(f, c)(x) = f(c * x), verified pointwise on the callable types
+    ld = IS.LinearFunctionData(5, 1)         # f(x) = 5x + 1
+    ld_scaled = IS.scale_x(ld, 2.0)          # f(2x) = 10x + 1
+    @test ld_scaled isa IS.LinearFunctionData
+    @test IS.get_proportional_term(ld_scaled) == 10.0
+    @test IS.get_constant_term(ld_scaled) == 1.0
+
+    qd = IS.QuadraticFunctionData(2, 3, 4)   # f(x) = 2x^2 + 3x + 4
+    qd_scaled = IS.scale_x(qd, 3.0)          # f(3x) = 18x^2 + 9x + 4
+    @test qd_scaled isa IS.QuadraticFunctionData
+    @test IS.get_quadratic_term(qd_scaled) == 18.0
+    @test IS.get_proportional_term(qd_scaled) == 9.0
+    @test IS.get_constant_term(qd_scaled) == 4.0
+
+    for (fd, c) in Iterators.product((ld, qd), (0.5, 2.0, 7.3))
+        scaled = IS.scale_x(fd, c)
+        for x in (-2.0, 0.0, 1.5, 40.0)
+            @test scaled(x) ≈ fd(c * x)
+        end
+    end
+
+    # Piecewise: x-coordinates divide by c, y-coordinates are untouched
+    pld = IS.PiecewiseLinearData([(1, 1), (3, 5), (5, 10)])
+    pld_scaled = IS.scale_x(pld, 2.0)
+    @test pld_scaled isa IS.PiecewiseLinearData
+    @test IS.get_x_coords(pld_scaled) == [0.5, 1.5, 2.5]
+    @test IS.get_y_coords(pld_scaled) == IS.get_y_coords(pld)
+
+    psd = IS.PiecewiseStepData([1, 3, 5], [2, 2.5])
+    psd_scaled = IS.scale_x(psd, 2.0)
+    @test psd_scaled isa IS.PiecewiseStepData
+    @test IS.get_x_coords(psd_scaled) == [0.5, 1.5, 2.5]
+    @test IS.get_y_coords(psd_scaled) == IS.get_y_coords(psd)
+
+    # Identity and composition: scale_x(scale_x(f, a), b) == scale_x(f, a * b)
+    for fd in get_test_function_data()
+        @test IS.scale_x(fd, 1.0) == fd
+        @test IS.scale_x(IS.scale_x(fd, 2.0), 3.0) == IS.scale_x(fd, 6.0)
+        @test IS.scale_x(IS.scale_x(fd, 4.0), 1 / 4.0) == fd
+    end
+
+    # Only finite, strictly positive factors: a negative factor would reverse the
+    # x-ordering the piecewise types require
+    for fd in get_test_function_data()
+        for bad in (-1.0, 0.0, Inf, NaN)
+            @test_throws ArgumentError IS.scale_x(fd, bad)
+        end
+    end
+
+    # scale_y is a named alias of `*`
+    for fd in get_test_function_data()
+        @test IS.scale_y(fd, 3.0) == 3.0 * fd
+    end
+end


### PR DESCRIPTION
Closes #501. The missing primitive was a horizontal scale — a power-unit change is exactly `f(x) -> f(rho * x)` — so `scale_x` is added at each layer (all four `FunctionData` shapes, then `ValueCurve`, where it is defined on the input-output function a curve represents rather than its raw `function_data`, so `IncrementalCurve`/`AverageRateCurve` correctly pick up a chain-rule factor on their stored y data), alongside `scale_y` as a named alias of `*`; on top of those, `convert_power_units(curve, to, system_base_power, device_base_power)` for `CostCurve`/`FuelCurve` reuses the existing `_cost_coeff_ratio` table that backs `convert_cost_coefficient` so no new conversion math is introduced, and `CostCurve(::FuelCurve)` multiplies the value curve through by a scalar `fuel_cost`, erroring on a time-series-backed fuel cost and on a nonzero `startup_fuel_offtake` that a `CostCurve` would otherwise silently drop. Note for reviewers: a stacked follow-up (loss curves, PowerSystems.jl#1728) changes `convert_power_units` to take the x-axis ratio directly instead of the two base powers, and removes `_cost_coeff_ratio` in favor of PowerSystems owning that arithmetic — so treat this signature as short-lived, and say the word if you would rather review the two together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)