### PR TITLE
Build a time series key from the id the store minted

### DIFF
--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -117,6 +117,20 @@ inside `with_deserialization_store(store) do ... end`. `deserialize(::Type{Syste
 binds the store it just opened around its own work, but components are deserialized by the
 parent package, which must wrap that pass the same way.
 
+The store mints that id as it inserts the row, which is why a key exists only once the
+addition has been written. A direct `add_time_series!(sys, owner, ts)` writes on the spot and
+returns the key. An addition staged into a `time_series_transaction` is still buffered, so it
+has no id yet and the call returns `nothing`; open the block with `collect_keys = true` and
+read `added_keys(txn)` once it has flushed:
+
+```julia
+key = time_series_transaction(sys; collect_keys = true) do txn
+    add_time_series!(txn, component, ts)
+    flush!(txn)
+    only(added_keys(txn))
+end
+```
+
 ## Debugging
 
 Inspect a persisted (closed) store with standard HDF5 and SQLite tools. For example,

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -479,7 +479,6 @@ function serialize_single!(
     units::Union{Nothing, AbstractString} = get_units(sts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(sts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(sts),
-    association_id::Integer = 0,
 )
     # `get_array` returns the raw `Array{T, N}` (no TimeArray allocation).
     arr, element_type = _storage_array(get_array(sts))
@@ -493,8 +492,7 @@ function serialize_single!(
     InfraStore.add_time_series!(batch, owner_id, owner_type,
         owner_category, tss_ts; features = features, units = units,
         quantity_kind = quantity_kind,
-        unit_system = _to_store_unit_system(unit_system),
-        association_id = association_id)
+        unit_system = _to_store_unit_system(unit_system))
     # The encoded array is what the batch buffers; its byte size drives auto-flush.
     return sizeof(arr)
 end
@@ -523,7 +521,6 @@ function serialize_non_sequential!(
     units::Union{Nothing, AbstractString} = get_units(nts),
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(nts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(nts),
-    association_id::Integer = 0,
 )
     arr, element_type = _storage_array(get_array(nts))
     tss_ts = InfraStore.NonSequentialTimeSeries(
@@ -535,8 +532,7 @@ function serialize_non_sequential!(
     InfraStore.add_time_series!(batch, owner_id, owner_type,
         owner_category, tss_ts; features = features, units = units,
         quantity_kind = quantity_kind,
-        unit_system = _to_store_unit_system(unit_system),
-        association_id = association_id)
+        unit_system = _to_store_unit_system(unit_system))
     # The staged bytes are the encoded array plus the timestamps the association carries.
     return sizeof(arr) + sizeof(get_timestamps(nts))
 end
@@ -712,7 +708,7 @@ function infrastore_add_time_series!(
     features::Union{Nothing, Dict} = nothing,
 )
     batch = InfraStore.AddBatch()
-    key, _ = _infrastore_stage!(
+    staged, _ = _infrastore_stage!(
         batch,
         mgr,
         Dict{Tuple{Dates.Period, Dates.Period}, Any}(),
@@ -720,7 +716,7 @@ function infrastore_add_time_series!(
         time_series;
         features = features,
     )
-    try
+    added = try
         InfraStore.add_time_series_bulk!(mgr.data_store.inner, batch)
     catch e
         _infrastore_rethrow_duplicate(
@@ -729,7 +725,9 @@ function infrastore_add_time_series!(
             get_name(time_series),
         )
     end
-    return key
+    # The row is written by the time we get here, so the key is built around the id
+    # the catalog actually filed it under.
+    return build_key(staged, only(added).id)
 end
 
 # The store's duplicate-association rejection, which the add paths rely on
@@ -948,14 +946,20 @@ end
 # batch-sized datasets with whole-chunk writes (no per-add read-modify-write).
 
 """
-Commit a staged `AddBatch` to the store as one all-or-nothing bulk add.
+Commit a staged `AddBatch` to the store as one all-or-nothing bulk add, returning
+the store's `InfraStore.AddedTimeSeries` per request, in the order they were staged.
 
 The backend packs the arrays into batch-sized datasets written whole-chunk, so
 this is materially cheaper than the same adds issued one at a time — which is why
 the client-side buffer exists even though the store now has transactions.
+
+Each returned entry carries the `association_id` the catalog minted for that row.
+That id is the reason the write, not the staging, is where a `TimeSeriesKey` can
+first be built: the store owns the id stream, so nothing before this call knows
+what a staged association will be filed under.
 """
 function _infrastore_commit_batch!(mgr::AbstractTimeSeriesManager, batch)
-    try
+    added = try
         InfraStore.add_time_series_bulk!(mgr.data_store.inner, batch)
     catch e
         _infrastore_is_duplicate_error(e) && throw(
@@ -964,16 +968,17 @@ function _infrastore_commit_batch!(mgr::AbstractTimeSeriesManager, batch)
         rethrow()
     end
     flush!(mgr.data_store)
-    return
+    return added
 end
 
 """
 Stage one `(owner, time_series)` association onto `batch`, applying the same
-validation as the per-add path, and return its `TimeSeriesKey`. The write
-happens when the batch is committed. `params_cache` carries the forecast window
-parameters per `(resolution, interval)` group so staged forecasts are checked
-for compatibility against both the store and each other with one catalog query
-per group.
+validation as the per-add path, and return its [`StagedKey`](@ref) together with
+the bytes it buffered. The write happens when the batch is committed, and only
+then does the association have an id to build a `TimeSeriesKey` around — see
+[`build_key`](@ref). `params_cache` carries the forecast window parameters per
+`(resolution, interval)` group so staged forecasts are checked for compatibility
+against both the store and each other with one catalog query per group.
 """
 function _infrastore_stage!(
     batch::InfraStore.AddBatch,
@@ -1006,26 +1011,19 @@ function _infrastore_stage_data!(
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
     feats = _infrastore_features(features)
-    # Taken before staging: the key below carries this id and callers embed it, so
-    # the row has to be written under the very same value rather than one the insert
-    # would mint for itself. Drawn from a block the binding holds, so staging N
-    # series costs one round trip per block rather than N.
-    association_id = InfraStore.next_association_id!(get_data_store(mgr).inner)
     nbytes = serialize_single!(batch, owner_id, owner_type, category, name,
-        time_series; features = feats, association_id = association_id)
-    resolution = get_resolution(time_series)
-    key = StaticTimeSeriesKey(;
+        time_series; features = feats)
+    staged = StagedKey{StaticTimeSeriesKey}((
         owner_id = owner_id,
         owner_category = category,
-        association_id = association_id,
         time_series_type = SingleTimeSeries,
         name = name,
         initial_timestamp = get_initial_timestamp(time_series),
-        resolution = resolution,
+        resolution = get_resolution(time_series),
         length = length(time_series),
         features = _key_features(feats),
-    )
-    return key, nbytes
+    ))
+    return staged, nbytes
 end
 
 function _infrastore_stage_data!(
@@ -1039,19 +1037,17 @@ function _infrastore_stage_data!(
     owner_id, owner_type, category = _infrastore_owner_args(owner)
     name = get_name(time_series)
     feats = _infrastore_features(features)
-    association_id = InfraStore.next_association_id!(get_data_store(mgr).inner)
     nbytes = serialize_non_sequential!(batch, owner_id, owner_type, category, name,
-        time_series; features = feats, association_id = association_id)
-    key = NonSequentialTimeSeriesKey(;
+        time_series; features = feats)
+    staged = StagedKey{NonSequentialTimeSeriesKey}((
         owner_id = owner_id,
         owner_category = category,
-        association_id = association_id,
         time_series_type = NonSequentialTimeSeries,
         name = name,
         length = length(time_series),
         features = _key_features(feats),
-    )
-    return key, nbytes
+    ))
+    return staged, nbytes
 end
 
 # Validate a staged forecast's window parameters against its `(resolution,
@@ -1100,23 +1096,20 @@ function _infrastore_stage_forecast!(
     horizon = get_horizon(ts)
     feats = _infrastore_features(features)
     obj, count = build(initial, resolution, horizon, interval, name)
-    association_id = InfraStore.next_association_id!(get_data_store(mgr).inner)
     InfraStore.add_time_series!(batch, owner_id, owner_type, category, obj;
-        features = feats, association_id = association_id)
+        features = feats)
     # The key names the stored type as its UnionAll (`Probabilistic`, not
     # `Probabilistic{Float64, 2}`), exactly as a key listed back from the catalog does,
     # so the two compare and query alike.
-    stored_type = _unparameterized_type(typeof(ts))
-    key = ForecastKey(;
+    staged = StagedKey{ForecastKey}((
         owner_id = owner_id, owner_category = category,
-        association_id = association_id,
-        time_series_type = stored_type, name = name,
+        time_series_type = _unparameterized_type(typeof(ts)), name = name,
         initial_timestamp = initial, resolution = resolution,
         horizon = horizon, interval = interval, count = count,
-        features = _key_features(feats))
+        features = _key_features(feats)))
     # `obj.data` is the encoded dense array the batch buffers; its byte size drives
     # auto-flush.
-    return key, sizeof(obj.data)
+    return staged, sizeof(obj.data)
 end
 
 function _infrastore_stage_data!(
@@ -2006,12 +1999,11 @@ for T in (
 end
 
 # Build the matching IS `TimeSeriesKey` from a catalog row — a
-# `list_time_series` metadata row (the only row kind that carries
-# `association_id`; a bare `list_keys`/`list_array_groups` row does not, so
-# every caller lists through `list_time_series` instead). The key is the
-# single descriptor for a stored association; forecast-only fields
-# (percentiles, scenario_count) are not carried — they come from the data on
-# read.
+# `list_time_series` metadata row (the only row kind that carries the store's
+# `id`; a bare `list_keys`/`list_array_groups` row does not, so every caller
+# lists through `list_time_series` instead). The key is the single descriptor
+# for a stored association; forecast-only fields (percentiles, scenario_count)
+# are not carried — they come from the data on read.
 _key_from_row(row) = _key_from_row(_infrastore_is_type(row.time_series_type), row)
 
 _row_features(row) = Dict{String, Any}(string(k) => v for (k, v) in row.features)
@@ -2020,7 +2012,7 @@ _key_from_row(::Type{T}, row) where {T <: NonSequentialTimeSeries} =
     NonSequentialTimeSeriesKey(;
         owner_id = row.owner_id,
         owner_category = row.owner_category,
-        association_id = row.association_id,
+        association_id = row.id,
         time_series_type = T,
         name = row.name,
         length = row.length,
@@ -2031,7 +2023,7 @@ _key_from_row(::Type{T}, row) where {T <: StaticTimeSeries} =
     StaticTimeSeriesKey(;
         owner_id = row.owner_id,
         owner_category = row.owner_category,
-        association_id = row.association_id,
+        association_id = row.id,
         time_series_type = T,
         name = row.name,
         initial_timestamp = row.initial_timestamp,
@@ -2044,7 +2036,7 @@ _key_from_row(::Type{T}, row) where {T <: Forecast} =
     ForecastKey(;
         owner_id = row.owner_id,
         owner_category = row.owner_category,
-        association_id = row.association_id,
+        association_id = row.id,
         time_series_type = T,
         name = row.name,
         initial_timestamp = row.initial_timestamp,
@@ -2062,16 +2054,15 @@ is meaningful only against that store — resolve it against the same artifact t
 document was exported from.
 """
 function get_time_series_key(store::Store, association_id::Int)
-    row = try
-        InfraStore.get_time_series_metadata(store.inner, Int64(association_id))
-    catch e
-        e isa InfraStore.NotFoundError || rethrow()
-        throw(
-            ArgumentError(
-                "association_id=$association_id: no association in this store carries this id",
-            ),
-        )
-    end
+    # `nothing`, not a raised error: the store treats a stale reference as an answer
+    # to "does this still resolve?". Resolving one is past that question, so the miss
+    # becomes an error here.
+    row = InfraStore.get_metadata_by_id(store.inner, Int64(association_id))
+    isnothing(row) && throw(
+        ArgumentError(
+            "association_id=$association_id: no association in this store carries this id",
+        ),
+    )
     return _key_from_row(row)
 end
 

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -139,6 +139,11 @@ A batch that grows past `auto_flush_threshold` staged additions or
 mid-block, so an arbitrarily large block holds a bounded amount of data in memory.
 Flushed work stays inside the transaction and rolls back with it.
 
+`add_time_series!` through the yielded context returns `nothing`: an addition has no
+key until the store writes it and mints its association id. Pass `collect_keys = true`
+to keep one key per written addition, and read them with [`added_keys`](@ref) after
+the block — or call `flush!(txn)` first to see the ones staged so far.
+
 ```julia
 time_series_transaction(data) do txn
     for (component, profile) in profiles
@@ -208,8 +213,13 @@ function add_time_series!(
 )
     # A block opened for just this call, so the components land as one batch,
     # atomically. The transaction's dispatch stores the array once and validates
-    # each component against `data`.
-    return time_series_transaction(data) do txn
+    # each component against `data`. The keys come from the context rather than the
+    # block's return value: they exist only once the block has committed, which is
+    # after the block itself has run.
+    return _transaction_added_keys(
+        data.time_series_manager,
+        owner -> _validate(data, owner),
+    ) do txn
         add_time_series!(txn, components, time_series; features = features)
     end
 end

--- a/src/time_series_context.jl
+++ b/src/time_series_context.jl
@@ -42,8 +42,20 @@ mutable struct TimeSeriesContext{M <: AbstractTimeSeriesManager, V}
     mgr::M
     "Created on the first stage; a context that never adds never allocates one."
     batch::Union{Nothing, InfraStore.AddBatch}
-    "Keys for the buffered additions, in stage order."
-    keys::Vector{ConcreteTimeSeriesKey}
+    """
+    The buffered additions, in stage order, as everything their keys need bar the
+    association id — which the store mints on insert, so a staged addition has none
+    until [`flush!`](@ref) writes it.
+    """
+    staged::Vector{StagedKey}
+    """
+    Keys for the additions this block has written, in stage order, built from the ids
+    the store minted for them. Only collected when `collect_keys` is set; a bulk
+    ingest that never asks for its keys should not pay to retain one per series.
+    """
+    added::Vector{ConcreteTimeSeriesKey}
+    "Whether to retain a key per written addition in `added`."
+    collect_keys::Bool
     "Forecast window parameters per `(resolution, interval)` group."
     params_cache::Dict{
         Tuple{Dates.Period, Dates.Period},
@@ -74,6 +86,7 @@ function TimeSeriesContext(
     owner_validator = no_owner_validation;
     auto_flush_threshold::Int = AUTO_FLUSH_THRESHOLD,
     auto_flush_bytes::Int = AUTO_FLUSH_BYTES,
+    collect_keys::Bool = false,
 )
     auto_flush_threshold >= 1 ||
         throw(ArgumentError("auto_flush_threshold must be positive: $auto_flush_threshold"))
@@ -82,7 +95,9 @@ function TimeSeriesContext(
     return TimeSeriesContext(
         mgr,
         nothing,
+        StagedKey[],
         ConcreteTimeSeriesKey[],
+        collect_keys,
         Dict{Tuple{Dates.Period, Dates.Period}, Union{Nothing, ForecastParameters}}(),
         false,
         false,
@@ -96,7 +111,7 @@ end
 """
 Whether `context` has additions buffered but not yet written.
 """
-has_staged_data(context::TimeSeriesContext) = !isempty(context.keys)
+has_staged_data(context::TimeSeriesContext) = !isempty(context.staged)
 
 function _throw_if_closed(context::TimeSeriesContext)
     context.closed && throw(
@@ -129,9 +144,11 @@ function begin_transaction!(context::TimeSeriesContext)
     return
 end
 
+# A fresh vector rather than `empty!`: `flush!` holds the staged entries it is about
+# to write, and emptying them in place would clear that reference too.
 function _reset_buffer!(context::TimeSeriesContext)
     context.batch = nothing
-    empty!(context.keys)
+    context.staged = StagedKey[]
     empty!(context.params_cache)
     context.staged_bytes = 0
     return
@@ -144,17 +161,36 @@ buffered.
 Any operation needing the arrays physically present — a read, a reader build, a
 removal — flushes first. Inside a transactional context that is free of consequence:
 the write lands in the open transaction and rolls back with it.
+
+This is also where a staged addition becomes a [`TimeSeriesKey`](@ref): the store
+mints the association ids as it inserts, and hands them back in stage order, so the
+keys are built here and nowhere earlier. See [`added_keys`](@ref).
 """
 function flush!(context::TimeSeriesContext)
     _throw_if_closed(context)
-    isempty(context.keys) && return
+    isempty(context.staged) && return
     batch = context.batch
+    staged = context.staged
     # Reset before writing so a failed write cannot leave the entries buffered a
     # second time, and so the context stays usable for further additions.
     _reset_buffer!(context)
-    _infrastore_commit_batch!(context.mgr, batch)
+    added = _infrastore_commit_batch!(context.mgr, batch)
+    context.collect_keys && append!(
+        context.added,
+        (build_key(entry, item.id) for (entry, item) in zip(staged, added)),
+    )
     return
 end
+
+"""
+The keys for every addition `context` has written so far, in stage order.
+
+A staged addition has no key until the store writes it and mints its association id,
+so this covers what has been flushed — everything, once the block has committed — and
+is empty unless the context was opened with `collect_keys = true`. Call
+[`flush!`](@ref) first to include additions still buffered.
+"""
+added_keys(context::TimeSeriesContext) = context.added
 
 """
 Flush buffered additions, commit the transaction, and close `context`.
@@ -183,6 +219,8 @@ the caller needs to see.
 """
 function discard!(context::TimeSeriesContext)
     _reset_buffer!(context)
+    # The rollback below unwrites the rows these name, ids included.
+    empty!(context.added)
     context.closed = true
     context.transactional || return
     try

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -131,6 +131,11 @@ A batch that grows past `auto_flush_threshold` staged additions or
 mid-block, so an arbitrarily large block holds a bounded amount of data in memory.
 Flushed work stays inside the transaction and rolls back with it.
 
+`add_time_series!` through the yielded context returns `nothing`: an addition has no
+key until the store writes it and mints its association id. Pass `collect_keys = true`
+to keep one key per written addition, and read them with [`added_keys`](@ref) after
+the block — or call `flush!(txn)` first to see the ones staged so far.
+
 ```julia
 time_series_transaction(mgr) do txn
     for (component, profile) in profiles
@@ -149,6 +154,7 @@ function _time_series_transaction(
     owner_validator::Function;
     auto_flush_threshold::Int = AUTO_FLUSH_THRESHOLD,
     auto_flush_bytes::Int = AUTO_FLUSH_BYTES,
+    collect_keys::Bool = false,
 )
     _throw_if_read_only(mgr)
     context = TimeSeriesContext(
@@ -156,7 +162,28 @@ function _time_series_transaction(
         owner_validator;
         auto_flush_threshold = auto_flush_threshold,
         auto_flush_bytes = auto_flush_bytes,
+        collect_keys = collect_keys,
     )
+    return _run_transaction(func, context)
+end
+
+# The keys an add produced exist only once the store has written the rows and minted
+# their ids, which happens in `commit!` — after `func` has already returned. So a
+# caller that wants them runs the block for its effect and reads them off the context
+# afterwards, rather than through the block's own return value.
+function _transaction_added_keys(
+    func::Function,
+    mgr::TimeSeriesManager,
+    owner_validator::Function;
+    kwargs...,
+)
+    _throw_if_read_only(mgr)
+    context = TimeSeriesContext(mgr, owner_validator; collect_keys = true, kwargs...)
+    _run_transaction(func, context)
+    return added_keys(context)
+end
+
+function _run_transaction(func::Function, context::TimeSeriesContext)
     begin_transaction!(context)
     # `commit!` must stay inside the protected region: buffered additions are only
     # written (and validated by the store) at the final flush it performs, so a bad
@@ -192,6 +219,12 @@ end
 """
 Add a time series through an open transaction, buffering it into the block's one
 bulk write. If the block throws, the addition is rolled back with the rest of it.
+
+Returns `nothing`. The addition has no key yet: the store mints the association id
+as it inserts the row, which has not happened while the addition is still buffered.
+Open the block with `collect_keys = true` and read [`added_keys`](@ref) once it has
+flushed, or use the direct `add_time_series!(mgr, owner, ts)`, which writes on the
+spot and hands back the key.
 """
 function add_time_series!(
     context::TimeSeriesContext,
@@ -201,13 +234,16 @@ function add_time_series!(
 )
     _throw_if_closed(context)
     context.owner_validator(owner)
-    return _stage_on_context!(context, owner, time_series; features = features)
+    _stage_on_context!(context, owner, time_series; features = features)
+    return
 end
 
 """
 Add the same time series to multiple components through an open transaction. Only
-one copy of the array is stored, but each component gets its own association row
-(and so its own key), so this returns one `ConcreteTimeSeriesKey` per component.
+one copy of the array is stored, but each component gets its own association row —
+and so its own key, available through [`added_keys`](@ref) once the block flushes.
+
+Returns `nothing`, as the single-owner method does and for the same reason.
 """
 function add_time_series!(
     context::TimeSeriesContext,
@@ -223,13 +259,11 @@ function add_time_series!(
         ),
     )
     first_component, rest = peeled
-    keys = ConcreteTimeSeriesKey[add_time_series!(
-        context, first_component, time_series; features = features,
-    )]
+    add_time_series!(context, first_component, time_series; features = features)
     for component in rest
-        push!(keys, add_time_series!(context, component, time_series; features = features))
+        add_time_series!(context, component, time_series; features = features)
     end
-    return keys
+    return
 end
 
 function _stage_on_context!(
@@ -238,7 +272,7 @@ function _stage_on_context!(
     time_series::TimeSeriesData;
     features::Union{Nothing, Dict} = nothing,
 )
-    key, nbytes = _infrastore_stage!(
+    staged, nbytes = _infrastore_stage!(
         _batch!(context),
         context.mgr,
         context.params_cache,
@@ -246,16 +280,16 @@ function _stage_on_context!(
         time_series;
         features = features,
     )
-    push!(context.keys, key)
+    push!(context.staged, staged)
     # `nbytes` is the exact size of the encoded array the batch copied at stage
     # time (computed where the array is materialized — never derived by walking
     # the source objects, which costs more than the rest of the stage combined).
     context.staged_bytes += nbytes
-    if length(context.keys) >= context.auto_flush_threshold ||
+    if length(context.staged) >= context.auto_flush_threshold ||
        context.staged_bytes >= context.auto_flush_bytes
         flush!(context)
     end
-    return key
+    return
 end
 
 function clear_time_series!(mgr::TimeSeriesManager)

--- a/src/time_series_structs.jl
+++ b/src/time_series_structs.jl
@@ -186,6 +186,32 @@ const ConcreteTimeSeriesKey =
     Union{StaticTimeSeriesKey, NonSequentialTimeSeriesKey, ForecastKey}
 
 """
+Everything a [`TimeSeriesKey`](@ref) needs except its `association_id`, held for the
+span between staging an addition onto a batch and the store writing it.
+
+The catalog mints the id on insert, so a staged addition does not have one yet — and
+a key is a value, immutable, never patched after the fact. Staging therefore produces
+this instead, and [`build_key`](@ref) turns it into the real key once the write hands
+back the id it was filed under. `K` is the concrete key type the fields belong to, so
+the built key's type is known from the staged one alone.
+"""
+struct StagedKey{K <: TimeSeriesKey, NT <: NamedTuple}
+    fields::NT
+end
+
+StagedKey{K}(fields::NT) where {K <: TimeSeriesKey, NT <: NamedTuple} =
+    StagedKey{K, NT}(fields)
+
+"""
+    build_key(staged::StagedKey, association_id) -> ConcreteTimeSeriesKey
+
+The key `staged` describes, filed under `association_id` — the id the store minted for
+its row.
+"""
+build_key(staged::StagedKey{K}, association_id::Integer) where {K} =
+    K(; staged.fields..., association_id = Int(association_id))
+
+"""
 Provides counts of time series including attachments to components and supplemental
 attributes.
 """

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -2278,8 +2278,12 @@ end
     data = Dict(initial_time => rand(horizon_count), other_time => rand(horizon_count))
     forecast = IS.Deterministic("fx", data, resolution)
 
-    key = IS.time_series_transaction(sys) do txn
-        return IS.add_time_series!(txn, component, forecast)
+    # A staged addition has no key until the store writes it and mints the id, so the
+    # block flushes and reads the keys back off the transaction.
+    key = IS.time_series_transaction(sys; collect_keys = true) do txn
+        IS.add_time_series!(txn, component, forecast)
+        IS.flush!(txn)
+        return only(IS.added_keys(txn))
     end
 
     @test IS.get_owner_id(key) == IS.get_id(component)
@@ -6317,6 +6321,86 @@ end
     end
     names = Set(IS.get_name(k) for k in IS.get_time_series_keys(component))
     @test names == union(Set("ts_$i" for i in 1:7), Set("bytes_$i" for i in 1:7))
+end
+
+@testset "Test staged additions take their ids from the store" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+    initial_time = Dates.DateTime("2020-09-01")
+    resolution = Dates.Hour(1)
+    make_ts(name) = IS.SingleTimeSeries(;
+        data = TimeSeries.TimeArray(
+            range(initial_time; length = 8, step = resolution), collect(1.0:8.0),
+        ),
+        name = name,
+    )
+
+    # A staged addition has no id until the store writes it, so there is no key to
+    # hand back at stage time.
+    IS.time_series_transaction(sys) do txn
+        @test isnothing(IS.add_time_series!(txn, component, make_ts("staged")))
+    end
+
+    # Without `collect_keys` the context keeps none, so a bulk ingest does not retain
+    # a key per series.
+    IS.time_series_transaction(sys) do txn
+        IS.add_time_series!(txn, component, make_ts("uncollected"))
+        IS.flush!(txn)
+        @test isempty(IS.added_keys(txn))
+    end
+
+    # With it, the keys appear as the block flushes -- including the auto-flushes -- and
+    # carry the ids the catalog actually filed the rows under.
+    keys = IS.time_series_transaction(
+        sys;
+        collect_keys = true,
+        auto_flush_threshold = 2,
+    ) do txn
+        for i in 1:5
+            IS.add_time_series!(txn, component, make_ts("collected_$i"))
+        end
+        # Auto-flushes at 2 and 4 have resolved four of the five.
+        @test length(IS.added_keys(txn)) == 4
+        IS.flush!(txn)
+        return copy(IS.added_keys(txn))
+    end
+    @test length(keys) == 5
+    @test IS.get_name.(keys) == ["collected_$i" for i in 1:5]
+
+    stored = Dict(
+        IS.get_association_id(k) => k for k in IS.get_time_series_keys(component)
+    )
+    for key in keys
+        @test stored[IS.get_association_id(key)] == key
+    end
+end
+
+@testset "Test a rolled-back block leaves no keys behind" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+    ts = IS.SingleTimeSeries(;
+        data = TimeSeries.TimeArray(
+            range(Dates.DateTime("2020-09-01"); length = 8, step = Dates.Hour(1)),
+            collect(1.0:8.0),
+        ),
+        name = "rolled",
+    )
+
+    context = nothing
+    @test_throws ErrorException IS.time_series_transaction(
+        sys; collect_keys = true, auto_flush_threshold = 1,
+    ) do txn
+        context = txn
+        IS.add_time_series!(txn, component, ts)
+        # The auto-flush has already minted an id and built its key.
+        @test length(IS.added_keys(txn)) == 1
+        error("boom")
+    end
+    # The rollback unwrote the row, so the key naming it is dropped with it.
+    @test isempty(IS.added_keys(context))
+    @test isempty(IS.get_time_series_keys(component))
 end
 
 @testset "Test time series context nesting and reuse" begin


### PR DESCRIPTION
infrastore removed `next_association_id!`, and with it every way for a caller to
name a catalog id. Only the OpenAPI row import supplies one now; every add lets
the catalog assign and reports what it chose. The three staging sites reserved an
id before staging so the key they returned could carry it, and there is no longer
a mechanism behind that.

So the key is built after the write instead of before it. `_infrastore_stage_data!`
returns a `StagedKey` — every field the key needs bar the `association_id`, with
the concrete key type as a parameter so the built key's type is known from the
staged one alone — and `build_key` turns it into the real key once the bulk add
hands back the id the row was filed under. A key stays a value: immutable, never
patched after the fact.

That moves when a key exists, which is visible to callers. A direct
`add_time_series!(mgr, owner, ts)` writes on the spot and still returns the key.
The same call through an open transaction returns `nothing`, because the addition
is still buffered and has no id. A caller that wants the keys opens the block with
`collect_keys = true` and reads `added_keys(txn)` after the flush; the context
collects them as it flushes, auto-flushes included, and drops them on a rollback
along with the rows they name. A bulk ingest that never asks retains none, which
is why the collection is opt-in.

`_transaction_added_keys` exists for the same reason: the multi-component
`add_time_series!(data, components, ts)` cannot take its keys from the block's
return value, since they do not exist until `commit!` runs after the block.

`get_time_series_key` follows the store's renames. `get_time_series_metadata` is
`get_metadata_by_id`, which answers a miss with `nothing` rather than raising —
the store treats a stale reference as a question worth answering, and resolving
one is past that question, so the miss becomes an `ArgumentError` here. Catalog
rows spell the id `id`, not `association_id`.

## Testing

`julia --project=test test/runtests.jl`: 9332 passed, 0 failed, 0 errors, against
infrastore `dt/association-ids`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ABLNRwKQQhLuArGp6oJyE2