### PR TITLE
Address time series by association id

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,7 +40,7 @@ PowerCoreOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPI
 PowerTimeSeriesOpenAPIModels = {url = "https://github.com/Sienna-Platform/PowerOpenAPIModels.git", rev = "main", subdir = "PowerTimeSeriesOpenAPIModels.jl"}
 
 [compat]
-InfraStore = "0.10"
+InfraStore = "0.11"
 DataFrames = "^1.7"
 DataStructures = "^0.18, ^0.19"
 Dates = "1"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -65,6 +65,24 @@ So a `read_by_window` of 1.16 µs/op is 1.39 s ÷ 1,200,000, of which 1.04 s is
 twelve real reads of 9.2 MB each. The I/O is present and dominant; it is spread
 over 100,000 components per read.
 
+`read_by_timestamp_grouped` sweeps the same values through the group accessors —
+`get_static_time_series_group_values` / `..._group_entries`, one concrete array
+per group per timestamp taken through a function barrier — instead of
+`get_static_time_series_value`, which returns one entry at a time out of a
+container the reader cannot type and so dispatches dynamically and boxes every
+value.
+
+**Do not read the two rows against each other as an A/B.** The grouped sweep
+re-reads timestamps the per-value sweep just touched, so its storage reads are
+warm and its total is flattered; the asymmetry is fixed run to run, so each row
+still gates its own regression fine. To compare the access paths, subtract each
+row's own `*_storage_read` and compare what is left. At 100k entries that is
+**0.083 µs/value against 0.0008** — the per-value accessor's dispatch and boxing,
+which is also 91 MB of allocation per sweep against 19 MB, and which grows with
+the entry count as the box traffic outgrows the cache (0.023 µs/value at 5k,
+0.086 at 100k; the grouped path is flat at 0.0004 µs at every size). Consumers
+sweeping at scale should use the group accessors.
+
 These are **first-touch** reads — each timestep is read once, never re-read,
 which is how a simulation walks forward through time. Re-sweeping the same
 windows is ~3× cheaper (0.36 µs/op for `det`), and that warm number is the one

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -33,7 +33,7 @@ every section precedes measurement. A combo the store rejects is recorded as an
 | `ingest` | `bulk_add` of every time series type × element type: `SingleTimeSeries`, `NonSequentialTimeSeries`, `Deterministic` × {float64, ntuple2, linear, quadratic, pwl}, plus `Probabilistic` and `Scenarios` (float64) | `BENCH_N` |
 | `sweep` | the simulation inner loop — every component read at one timestamp (`StaticTimeSeriesReader`) or one window (`ForecastReader`). float64 at full scale; pwl exercises the structured-payload decode that PSY's time-varying cost curves read through | `BENCH_SWEEP_N` (pwl at `BENCH_N`) |
 | `has` | `has_time_series` with the full identity (type, name, resolution, two features), hits and misses. `n` counts **associations**: `BENCH_SWEEP_N ÷ 10` components × 10 associations each (2 names × 5 scenario values, plus a `model_year` feature) | `BENCH_SWEEP_N` |
-| `reads` | per-series read canary: `get_full`, `get_sliced`, `get_window`, float64 only | `BENCH_N` |
+| `reads` | per-series read canary: `get_full`, `get_sliced`, `get_window`, and `get_metadata` — the keyed catalog fetch, one primary-key row lookup with no array read, against `get_full`'s filtered resolve plus read. float64 only | `BENCH_N` |
 | `dst` | `transform_single_time_series!` to `DeterministicSingleTimeSeries` plus the window sweep over the result — the PowerSimulations feed path | `BENCH_N` |
 | `serialize` | `to_json` / `from_json` round-trip including the store artifacts, verified with one read from the reloaded system | `BENCH_N` |
 | `remove` | `remove_time_series!` of every series, one call per component | `BENCH_N` |

--- a/benchmark/bench.jl
+++ b/benchmark/bench.jl
@@ -140,7 +140,7 @@ end
 function keys_for(sys, comps)
     by_owner = Dict(
         IS.get_owner_id(md) => IS.get_time_series_key(md)
-        for md in IS.list_metadata(sys)
+        for md in IS.list_time_series_metadata(sys)
     )
     return [by_owner[IS.get_id(c)] for c in comps]
 end

--- a/benchmark/bench.jl
+++ b/benchmark/bench.jl
@@ -133,6 +133,18 @@ function irregular_timestamps(rng, len)
     return stamps
 end
 
+# One key per component, in `comps` order. Resolved out of band on purpose: the
+# keyed accessors measure what a caller *holding* a key pays, and how the key was
+# obtained is not part of that. One store-wide listing rather than n owner-scoped
+# ones, so the setup costs less than the op it feeds.
+function keys_for(sys, comps)
+    by_owner = Dict(
+        IS.get_owner_id(md) => IS.get_time_series_key(md)
+        for md in IS.list_metadata(sys)
+    )
+    return [by_owner[IS.get_id(c)] for c in comps]
+end
+
 # `shared` adds one instance to every component (deduplicated storage).
 # `main_ops = false` skips the add/read rows (the add still runs, un-timed) so a
 # sweep-only section does not duplicate the ingest matrix; `sweep = true`
@@ -196,6 +208,20 @@ function run_static_kind(kind, eltype, n;
                 end,
             )
         end
+
+        # The catalog row by key: one primary-key lookup, no array read. Its
+        # counterpart is `get_full`, which resolves by filter and then reads the
+        # data — this row is what a caller pays to ask what a series *is*.
+        tskeys = keys_for(sys, comps)
+        timed_op(
+            kind,
+            eltype,
+            "get_metadata",
+            n,
+            () -> for i in 1:n
+                IS.get_time_series_metadata(comps[i], tskeys[i])
+            end,
+        )
     end
 
     if sweep
@@ -325,6 +351,19 @@ function run_forecast_kind(kind, eltype, n;
             n,
             () -> for i in 1:n
                 IS.get_time_series(ttype, comps[i], "fc"; start_time = st, count = 1)
+            end,
+        )
+
+        # As above, on a forecast row: the same one-row fetch, with the window
+        # columns (horizon, interval, count) to translate as well.
+        tskeys = keys_for(sys, comps)
+        timed_op(
+            kind,
+            eltype,
+            "get_metadata",
+            n,
+            () -> for i in 1:n
+                IS.get_time_series_metadata(comps[i], tskeys[i])
             end,
         )
     end

--- a/benchmark/bench.jl
+++ b/benchmark/bench.jl
@@ -240,6 +240,19 @@ function run_static_kind(kind, eltype, n;
                 () -> sweep_static!(reader[], RES, T0, LEN, io_time))
         # µs per actual storage read, against µs per value in the row above.
         swept && report(kind, eltype, "timestamp_storage_read", LEN, io_time[], 0, "ok")
+
+        # The same values through the group accessors. Do NOT read this against
+        # `read_by_timestamp` above as an A/B: this sweep re-reads timestamps
+        # that one just touched, so its storage reads are warm and its total is
+        # flattered. The asymmetry is fixed run to run, so the row still gates a
+        # regression fine; to compare the two access paths, subtract each row's
+        # own `*_storage_read` and compare what is left.
+        gio_time = Ref(0.0)
+        gswept =
+            built && timed_op(kind, eltype, "read_by_timestamp_grouped", n * LEN,
+                () -> sweep_static_grouped!(reader[], RES, T0, LEN, gio_time))
+        gswept && report(kind, eltype, "timestamp_storage_read_grouped", LEN,
+            gio_time[], 0, "ok")
     end
     return
 end
@@ -266,6 +279,40 @@ function sweep_static!(reader, resolution, t0, len, io_time)
         end
     end
     return nread
+end
+
+# The by-timestamp sweep through the group accessors: one concrete array per
+# group per timestamp, taken through a function barrier, rather than one value at
+# a time out of a container the reader cannot type. `get_static_time_series_value`
+# dispatches dynamically and boxes its result on every call, which is both a cost
+# per value and one that grows with the entry count as the box traffic outgrows
+# the cache; this path pays neither.
+function sweep_static_grouped!(reader, resolution, t0, len, io_time)
+    ngroups = IS.get_num_static_time_series_groups(reader)
+    nread = 0
+    for k in 0:(len - 1)
+        io_time[] += @elapsed IS.read_static_time_series_values!(reader,
+            t0 + resolution * k)
+        for g in 1:ngroups
+            nread += consume_group(
+                IS.get_static_time_series_group_values(reader, g),
+                IS.get_static_time_series_group_entries(reader, g),
+            )
+        end
+    end
+    return nread
+end
+
+# The barrier itself: specialized on the group's concrete element type, so a
+# value is a plain load. Every static kind here holds one value per column, so a
+# vector group is the only shape this has to serve.
+function consume_group(vals::AbstractVector, entries)
+    n = 0
+    for i in eachindex(entries)
+        vals[i] === nothing && error("missing value at entry $i")
+        n += 1
+    end
+    return n
 end
 
 # By-window reads over every component via a prebuilt ForecastReader. See

--- a/benchmark/report.jl
+++ b/benchmark/report.jl
@@ -72,6 +72,7 @@ const OP_ORDER = [
     "get_full",
     "get_sliced",
     "get_window",
+    "get_metadata",
     "build_static_reader",
     "read_by_timestamp",
     "timestamp_storage_read",

--- a/benchmark/report.jl
+++ b/benchmark/report.jl
@@ -76,6 +76,8 @@ const OP_ORDER = [
     "build_static_reader",
     "read_by_timestamp",
     "timestamp_storage_read",
+    "read_by_timestamp_grouped",
+    "timestamp_storage_read_grouped",
     "build_forecast_reader",
     "read_by_window",
     "window_storage_read",

--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -100,22 +100,29 @@ file-format reference.
 
 ## Identifying and retrieving a time series
 
-Address a stored time series by its [`InfrastructureSystems.TimeSeriesKey`](@ref) — a `StaticTimeSeriesKey` or
-`ForecastKey` — which captures `name`, `resolution`, `features`, and the concrete type
-(forecasts additionally capture `horizon`, `interval`, and `count`). Combined with the owner,
-this is the unique identity of an association:
+The surface splits in two. **Identify** with
+[`InfrastructureSystems.list_metadata`](@ref), which returns a
+[`InfrastructureSystems.TimeSeriesMetadata`](@ref) row per matching association — `name`,
+`resolution`, `features`, `initial_timestamp`, and for a forecast `horizon`, `interval` and
+`count`. **Act** with the row's
+[`InfrastructureSystems.TimeSeriesKey`](@ref), which is the association's store-minted
+`association_id` and nothing else:
 
 ```julia
-keys = get_time_series_keys(owner)      # enumerate the owner's associations
-ts = get_time_series(owner, keys[1])    # retrieve one by its key
+rows = list_metadata(owner)                 # enumerate; each row carries its attributes
+get_name(rows[1])                           # a column of the row, read from the catalog
+ts = get_time_series(owner, rows[1])        # a row is accepted anywhere a key is
+key = get_time_series_key(rows[1])          # store this in your own model
 ```
 
-A key serializes to nothing but its `association_id`, the store-minted surrogate for the
-whole association; every other field is a copy of something the catalog already holds.
-Rebuilding one therefore needs that catalog, so any deserialization that may meet a key runs
-inside `with_deserialization_store(store) do ... end`. `deserialize(::Type{SystemData}, ...)`
-binds the store it just opened around its own work, but components are deserialized by the
-parent package, which must wrap that pass the same way.
+A key carries only the id because everything else is a copy of something the catalog already
+holds, and a copy can only disagree with it: `rename_time_series!` and a reassignment both
+change catalog columns while preserving the id. Take the attributes from a row, whose age you
+know, rather than from a handle you may have held for a while.
+
+A key serializes to its `association_id`, its time series kind, and its value element type —
+all three facts the store never rewrites — so it rebuilds itself without the catalog that
+minted it. Nothing has to be scoped around a deserialization that may meet one.
 
 The store mints that id as it inserts the row, which is why a key exists only once the
 addition has been written. A direct `add_time_series!(sys, owner, ts)` writes on the spot and

--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -101,7 +101,7 @@ file-format reference.
 ## Identifying and retrieving a time series
 
 The surface splits in two. **Identify** with
-[`InfrastructureSystems.list_metadata`](@ref), which returns a
+[`InfrastructureSystems.list_time_series_metadata`](@ref), which returns a
 [`InfrastructureSystems.TimeSeriesMetadata`](@ref) row per matching association — `name`,
 `resolution`, `features`, `initial_timestamp`, and for a forecast `horizon`, `interval` and
 `count`. **Act** with the row's
@@ -109,10 +109,10 @@ The surface splits in two. **Identify** with
 `association_id` and nothing else:
 
 ```julia
-rows = list_metadata(owner)                 # enumerate; each row carries its attributes
-get_name(rows[1])                           # a column of the row, read from the catalog
-ts = get_time_series(owner, rows[1])        # a row is accepted anywhere a key is
-key = get_time_series_key(rows[1])          # store this in your own model
+rows = list_time_series_metadata(owner)  # enumerate; each row carries its attributes
+get_name(rows[1])                        # a column of the row, read from the catalog
+ts = get_time_series(owner, rows[1])     # a row is accepted anywhere a key is
+key = get_time_series_key(rows[1])       # store this in your own model
 ```
 
 A key carries only the id because everything else is a copy of something the catalog already

--- a/src/InfrastructureSystems.jl
+++ b/src/InfrastructureSystems.jl
@@ -18,7 +18,9 @@ function set_value end
 export get_value, set_value
 
 # Time-series accessor exports. These getters/setters are defined on the time
-# series data types and on the `TimeSeriesKey` hierarchy.
+# series data types and on `TimeSeriesMetadata`, the catalog row. A
+# `TimeSeriesKey` answers only `get_association_id` and `get_time_series_type`:
+# everything else is a column the store owns, read from a row.
 export get_count
 export get_features
 export get_horizon

--- a/src/abstract_time_series.jl
+++ b/src/abstract_time_series.jl
@@ -15,6 +15,10 @@ Return the value element type of a time series, i.e. the `T` of `TimeSeriesData{
 """
 Base.eltype(::TimeSeriesData{T}) where {T} = T
 
+# The type-level form. A `TimeSeriesKey{T}` carries the time series type rather
+# than an instance of it, so serializing the element type needs this one.
+Base.eltype(::Type{<:TimeSeriesData{T}}) where {T} = T
+
 # Subtypes must implement
 # - Base.length
 # - check_time_series_data

--- a/src/cost_aliases.jl
+++ b/src/cost_aliases.jl
@@ -228,23 +228,26 @@ Base.show(io::IO, vc::PiecewiseAverageCurve) =
     end
 
 # ── Time-series cost aliases ──────────────────────────────────────────────────
-# Helper: format a TimeSeriesKey or Nothing for compact show output.
-_ts_key_repr(key::TimeSeriesKey) = repr(get_name(key))
+# Helper: format a TimeSeriesKey or Nothing for compact show output. A key names
+# an association id, not a name — showing the name would mean a store query from
+# inside `show`, which must not touch the catalog.
+_ts_key_repr(key::TimeSeriesKey) = "association_id=$(get_association_id(key))"
+
 _ts_key_repr(::Nothing) = "nothing"
 
 """
     TimeSeriesLinearCurve
 
 A time-series-backed linear input-output curve. Alias for
-`TimeSeriesInputOutputCurve{TimeSeriesFunctionData{LinearFunctionData}}`.
+`TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{LinearFunctionData}}`.
 """
 const TimeSeriesLinearCurve =
-    TimeSeriesInputOutputCurve{TimeSeriesFunctionData{LinearFunctionData}}
+    TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{LinearFunctionData}}
 
-is_cost_alias(::Union{TimeSeriesLinearCurve, Type{TimeSeriesLinearCurve}}) = true
+is_cost_alias(::Union{TimeSeriesLinearCurve, Type{<:TimeSeriesLinearCurve}}) = true
 simple_type_name(::TimeSeriesLinearCurve) = "TimeSeriesLinearCurve"
 
-TimeSeriesInputOutputCurve{TimeSeriesFunctionData{LinearFunctionData}}(
+TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{LinearFunctionData}}(
     key::TimeSeriesKey,
 ) = TimeSeriesInputOutputCurve(TimeSeriesFunctionData{LinearFunctionData}(key))
 
@@ -259,15 +262,15 @@ Base.show(io::IO, vc::TimeSeriesLinearCurve) =
     TimeSeriesQuadraticCurve
 
 A time-series-backed quadratic input-output curve. Alias for
-`TimeSeriesInputOutputCurve{TimeSeriesFunctionData{QuadraticFunctionData}}`.
+`TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{QuadraticFunctionData}}`.
 """
 const TimeSeriesQuadraticCurve =
-    TimeSeriesInputOutputCurve{TimeSeriesFunctionData{QuadraticFunctionData}}
+    TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{QuadraticFunctionData}}
 
-is_cost_alias(::Union{TimeSeriesQuadraticCurve, Type{TimeSeriesQuadraticCurve}}) = true
+is_cost_alias(::Union{TimeSeriesQuadraticCurve, Type{<:TimeSeriesQuadraticCurve}}) = true
 simple_type_name(::TimeSeriesQuadraticCurve) = "TimeSeriesQuadraticCurve"
 
-TimeSeriesInputOutputCurve{TimeSeriesFunctionData{QuadraticFunctionData}}(
+TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{QuadraticFunctionData}}(
     key::TimeSeriesKey,
 ) = TimeSeriesInputOutputCurve(TimeSeriesFunctionData{QuadraticFunctionData}(key))
 
@@ -282,17 +285,17 @@ Base.show(io::IO, vc::TimeSeriesQuadraticCurve) =
     TimeSeriesPiecewisePointCurve
 
 A time-series-backed piecewise linear input-output curve. Alias for
-`TimeSeriesInputOutputCurve{TimeSeriesFunctionData{PiecewiseLinearData}}`.
+`TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{PiecewiseLinearData}}`.
 """
 const TimeSeriesPiecewisePointCurve =
-    TimeSeriesInputOutputCurve{TimeSeriesFunctionData{PiecewiseLinearData}}
+    TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{PiecewiseLinearData}}
 
 is_cost_alias(
-    ::Union{TimeSeriesPiecewisePointCurve, Type{TimeSeriesPiecewisePointCurve}},
+    ::Union{TimeSeriesPiecewisePointCurve, Type{<:TimeSeriesPiecewisePointCurve}},
 ) = true
 simple_type_name(::TimeSeriesPiecewisePointCurve) = "TimeSeriesPiecewisePointCurve"
 
-TimeSeriesInputOutputCurve{TimeSeriesFunctionData{PiecewiseLinearData}}(
+TimeSeriesInputOutputCurve{<:TimeSeriesFunctionData{PiecewiseLinearData}}(
     key::TimeSeriesKey,
 ) = TimeSeriesInputOutputCurve(TimeSeriesFunctionData{PiecewiseLinearData}(key))
 
@@ -307,29 +310,29 @@ Base.show(io::IO, vc::TimeSeriesPiecewisePointCurve) =
     TimeSeriesPiecewiseIncrementalCurve
 
 A time-series-backed piecewise incremental curve. Alias for
-`TimeSeriesIncrementalCurve{TimeSeriesFunctionData{PiecewiseStepData}}`.
+`TimeSeriesIncrementalCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}`.
 """
 const TimeSeriesPiecewiseIncrementalCurve =
-    TimeSeriesIncrementalCurve{TimeSeriesFunctionData{PiecewiseStepData}}
+    TimeSeriesIncrementalCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}
 
 is_cost_alias(
     ::Union{
         TimeSeriesPiecewiseIncrementalCurve,
-        Type{TimeSeriesPiecewiseIncrementalCurve},
+        Type{<:TimeSeriesPiecewiseIncrementalCurve},
     },
 ) = true
 simple_type_name(
     ::TimeSeriesPiecewiseIncrementalCurve,
 ) = "TimeSeriesPiecewiseIncrementalCurve"
 
-TimeSeriesIncrementalCurve{TimeSeriesFunctionData{PiecewiseStepData}}(
+TimeSeriesIncrementalCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}(
     key::TimeSeriesKey,
     initial_input::Union{Nothing, TimeSeriesKey},
 ) = TimeSeriesIncrementalCurve(
     TimeSeriesFunctionData{PiecewiseStepData}(key), initial_input,
 )
 
-TimeSeriesIncrementalCurve{TimeSeriesFunctionData{PiecewiseStepData}}(
+TimeSeriesIncrementalCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}(
     key::TimeSeriesKey,
     initial_input::Union{Nothing, TimeSeriesKey},
     input_at_zero::Union{Nothing, TimeSeriesKey},
@@ -351,27 +354,27 @@ Base.show(io::IO, vc::TimeSeriesPiecewiseIncrementalCurve) =
     TimeSeriesPiecewiseAverageCurve
 
 A time-series-backed piecewise average rate curve. Alias for
-`TimeSeriesAverageRateCurve{TimeSeriesFunctionData{PiecewiseStepData}}`.
+`TimeSeriesAverageRateCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}`.
 """
 const TimeSeriesPiecewiseAverageCurve =
-    TimeSeriesAverageRateCurve{TimeSeriesFunctionData{PiecewiseStepData}}
+    TimeSeriesAverageRateCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}
 
 is_cost_alias(
     ::Union{
         TimeSeriesPiecewiseAverageCurve,
-        Type{TimeSeriesPiecewiseAverageCurve},
+        Type{<:TimeSeriesPiecewiseAverageCurve},
     },
 ) = true
 simple_type_name(::TimeSeriesPiecewiseAverageCurve) = "TimeSeriesPiecewiseAverageCurve"
 
-TimeSeriesAverageRateCurve{TimeSeriesFunctionData{PiecewiseStepData}}(
+TimeSeriesAverageRateCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}(
     key::TimeSeriesKey,
     initial_input::Union{Nothing, TimeSeriesKey},
 ) = TimeSeriesAverageRateCurve(
     TimeSeriesFunctionData{PiecewiseStepData}(key), initial_input,
 )
 
-TimeSeriesAverageRateCurve{TimeSeriesFunctionData{PiecewiseStepData}}(
+TimeSeriesAverageRateCurve{<:TimeSeriesFunctionData{PiecewiseStepData}}(
     key::TimeSeriesKey,
     initial_input::Union{Nothing, TimeSeriesKey},
     input_at_zero::Union{Nothing, TimeSeriesKey},

--- a/src/deterministic_single_time_series.jl
+++ b/src/deterministic_single_time_series.jl
@@ -12,7 +12,7 @@ real forecast data is unavailable.
 
 This type is never instantiated — it exists only to name the stored type in queries
 (`get_time_series`, `has_time_series`, `remove_time_series!`, the
-`list_metadata` filters) and in the rows it returns. Reads always
+`list_time_series_metadata` filters) and in the rows it returns. Reads always
 materialize the shared array into a regular [`Deterministic`](@ref).
 """
 struct DeterministicSingleTimeSeries{T, N} <: AbstractDeterministic{T} end

--- a/src/deterministic_single_time_series.jl
+++ b/src/deterministic_single_time_series.jl
@@ -12,7 +12,7 @@ real forecast data is unavailable.
 
 This type is never instantiated — it exists only to name the stored type in queries
 (`get_time_series`, `has_time_series`, `remove_time_series!`, the
-`get_time_series_keys` filters) and in the resulting `TimeSeriesKey`s. Reads always
+`list_metadata` filters) and in the rows it returns. Reads always
 materialize the shared array into a regular [`Deterministic`](@ref).
 """
 struct DeterministicSingleTimeSeries{T, N} <: AbstractDeterministic{T} end

--- a/src/function_data/time_series_function_data.jl
+++ b/src/function_data/time_series_function_data.jl
@@ -1,10 +1,14 @@
 """
-    TimeSeriesFunctionData{T <: StaticFunctionData} <: FunctionData
+    TimeSeriesFunctionData{T <: StaticFunctionData, U <: TimeSeriesData{T}} <: FunctionData
 
 A parametric `FunctionData` variant whose numerical data lives in a time series rather than
-inline. The type parameter `T` specifies the static [`FunctionData`](@ref) subtype that the
-time series elements correspond to — same shape, but instead of holding numbers directly, it
-holds a [`TimeSeriesKey`](@ref) that points to a time series of `T` values.
+inline. `T` is the static [`FunctionData`](@ref) subtype the time series elements correspond
+to and `U` is the time series type holding them — same shape as a `T`, but instead of the
+numbers it holds a [`TimeSeriesKey`](@ref) naming where they are.
+
+`U` is bounded by `TimeSeriesData{T}`, so the two parameters cannot disagree: a
+`TimeSeriesFunctionData{PiecewiseLinearData}` can only wrap a key naming a series of
+`PiecewiseLinearData`. Write the one-parameter form — `U` is inferred from the key.
 
 Use these when cost function parameters change at each simulation timestep (e.g.,
 time-varying market offers).
@@ -18,9 +22,24 @@ to retrieve the key.
 - `TimeSeriesPiecewiseLinearData` = `TimeSeriesFunctionData{PiecewiseLinearData}`
 - `TimeSeriesPiecewiseStepData` = `TimeSeriesFunctionData{PiecewiseStepData}`
 """
-@kwdef struct TimeSeriesFunctionData{T <: StaticFunctionData} <: FunctionData
-    time_series_key::ConcreteTimeSeriesKey
+@kwdef struct TimeSeriesFunctionData{T <: StaticFunctionData, U <: TimeSeriesData{T}} <:
+              FunctionData
+    time_series_key::TimeSeriesKey{U}
 end
+
+# `U` follows from the key, so the one-parameter spelling every alias and call
+# site already uses keeps working. The bound `U <: TimeSeriesData{T}` then does
+# the checking: a key naming a series of some other element type cannot be
+# wrapped as this `T`, which a two-field struct could only have discovered on
+# read.
+TimeSeriesFunctionData{T}(key::TimeSeriesKey{U}) where {T, U} =
+    TimeSeriesFunctionData{T, U}(key)
+
+# `@kwdef` generates its keyword constructor for the fully-applied type only, so
+# the one-parameter spelling needs its own — deserialization reaches the struct
+# by keyword.
+TimeSeriesFunctionData{T}(; time_series_key::TimeSeriesKey{U}) where {T, U} =
+    TimeSeriesFunctionData{T, U}(time_series_key)
 
 "Time-series-backed variant of [`LinearFunctionData`](@ref)."
 const TimeSeriesLinearFunctionData = TimeSeriesFunctionData{LinearFunctionData}
@@ -58,11 +77,15 @@ is_time_series_backed(::FunctionData) = false
 is_time_series_backed(::TimeSeriesFunctionData) = true
 
 """
-    get_underlying_function_data_type(::Type{TimeSeriesFunctionData{T}}) -> Type{T}
+    get_underlying_function_data_type(::Type{<:TimeSeriesFunctionData{T}}) -> Type{T}
 
 Return the concrete `FunctionData` type that the time series elements correspond to.
 """
-get_underlying_function_data_type(::Type{TimeSeriesFunctionData{T}}) where {T} = T
+get_underlying_function_data_type(::Type{<:TimeSeriesFunctionData{T}}) where {T} = T
+
+"The time series type holding the values — the `U` of `TimeSeriesFunctionData{T, U}`."
+get_time_series_type(::Type{<:TimeSeriesFunctionData{T, U}}) where {T, U} = U
+get_time_series_type(fd::TimeSeriesFunctionData) = get_time_series_type(typeof(fd))
 
 # Instance convenience
 get_underlying_function_data_type(fd::TimeSeriesFunctionData) =
@@ -74,7 +97,7 @@ function Base.show(io::IO, ::MIME"text/plain", fd::TimeSeriesFunctionData)
     underlying = get_underlying_function_data_type(fd)
     print(
         io,
-        "TimeSeriesFunctionData{$underlying} backed by time series \"$(get_name(ts_key))\" ",
-        "of $underlying",
+        "TimeSeriesFunctionData{$underlying} backed by the time series at ",
+        "association_id=$(get_association_id(ts_key)) of $underlying",
     )
 end

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -542,29 +542,6 @@ function serialize_non_sequential!(
     return sizeof(arr) + sizeof(get_timestamps(nts))
 end
 
-"""
-    get_non_sequential(store, owner_id, owner_category, name; features=nothing, time_range=nothing) -> NonSequentialTimeSeries
-
-Reconstruct a `NonSequentialTimeSeries` (timestamps + decoded array) from the InfraStore
-store. A non-sequential series is addressed by name + features (it has no resolution).
-`time_range`, if given, is a half-open `[start, stop)` window on the (irregular) timestamp
-axis, sliced server-side — the same pushdown `_infrastore_read_single` uses for a
-`SingleTimeSeries` grid window.
-"""
-function get_non_sequential(
-    store::Store,
-    owner_id::Integer,
-    owner_category::InfraStore.OwnerCategory,
-    name::AbstractString;
-    features::Union{Nothing, Dict} = nothing,
-    time_range::Union{Nothing, Tuple{Dates.DateTime, Dates.DateTime}} = nothing,
-)
-    nts = InfraStore.get_time_series(InfraStore.NonSequentialTimeSeries, store.inner,
-        owner_id,
-        owner_category, name; features = features, time_range = time_range)
-    return _non_sequential_from_store(nts, name)
-end
-
 # Rebuild the IS `NonSequentialTimeSeries` from whatever the store handed back,
 # however the read was addressed.
 _non_sequential_from_store(nts, name::AbstractString) = NonSequentialTimeSeries(
@@ -856,20 +833,6 @@ function infrastore_get_time_series(
     return _infrastore_read_single(owner, key; start_time = start_time, len = len)
 end
 
-_window_length(::Nothing, index::Integer, total::Integer) = total - index + 1
-_window_length(len::Integer, ::Integer, ::Integer) = len
-
-# Step count of the requested `[index, index + n)` window on a series of `total` steps.
-# Errors rather than clamping: the store clamps an out-of-grid range silently, so the
-# window is validated here against the key before the sliced read is issued.
-function _validate_window(index::Integer, len, total::Integer)
-    n = _window_length(len, index, total)
-    if index < 1 || n < 1 || index + n - 1 > total
-        throw(ArgumentError("requested index=$index len=$n exceeds range $total"))
-    end
-    return n
-end
-
 # ---- Key addressing --------------------------------------------------------
 # `association_id` is the identity of a stored association: the store mints it,
 # never reissues it, and every other field a `TimeSeriesKey` carries is a
@@ -886,14 +849,20 @@ end
 # this is a comparison against the key, ahead of any store access: no probe, no
 # round trip, and the same check on every path.
 #
-# How far that reaches is bounded by the core's id-addressed surface:
-# `read_by_ids` (whole series, no slicing), `remove_by_ids!`, and
-# `get_metadata_by_id`. A whole-series read and a removal are therefore each one
-# id-addressed call. A *sliced* read has no id-addressed entry point — the store
-# needs a time range, and `read_by_ids` takes none — so there the id resolves the
-# row and the row's own attributes drive the read. The id stays the only thing
-# the caller supplies, but it costs a second round trip until `read_by_ids`
-# grows a time range.
+# Every keyed accessor is therefore **one** store call. `read_by_id` takes the
+# slice as well as the id: it resolves `start_time` / `len` / `count` against the
+# row its own primary-key lookup returned, so IS neither computes a time range
+# nor fetches a grid to compute one from. `remove_by_ids!` is the same for
+# removal, and `get_metadata_by_id` remains for the catalog-row accessors (the
+# content hash) that want the row rather than the data.
+#
+# The window arithmetic and its bounds checks live in the core, which is what
+# makes the single call possible: the store resolves `start_time` / `len` /
+# `count` against the row it just looked up, and refuses a window that does not
+# fit rather than clamping to one that does. IS's own copy of that arithmetic is
+# gone: the by-name reads resolve a key first and then take the same one-call
+# keyed path, so there is exactly one read path and one place the window is
+# resolved.
 
 # The catalog row `id` names. `nothing` from the core means the row is gone, which
 # is an error here: the caller is already committed to acting on it.
@@ -925,21 +894,45 @@ function _check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey)
     )
 end
 
-# The store an owner's manager holds, and the row `key`'s id resolves to in it,
-# for the paths the core cannot serve by id alone. The owner is confirmed first,
-# so a mismatched call costs no store access.
+# The store an owner's manager holds, and the row `key`'s id resolves to in it —
+# for the catalog-row accessors, which want the row itself rather than the data.
+# The owner is confirmed first, so a mismatched call costs no store access.
 function _store_and_association(owner::TimeSeriesOwners, key::TimeSeriesKey)
     store = _get_time_series_manager_or_throw(owner).data_store
     _check_association_owner(owner, key)
     return (store, _resolve_association(store, key))
 end
 
-# The one association `id` names, read whole in a single id-addressed call — no
-# catalog round trip, and no attribute off the key. `read_by_ids` takes no time
-# range, so this is the unsliced path only; it throws the core's `NotFoundError`
-# when the id dangles, which the public accessors map to an `ArgumentError`.
-_read_association_by_id(store::Store, key::TimeSeriesKey) =
-    only(InfraStore.read_by_ids(store.inner, [Int64(get_association_id(key))]))
+# The association `key` names, or the window of it the accessor's arguments name,
+# in ONE id-addressed call: no catalog round trip, and no attribute off the key.
+# The core resolves the window against the row its primary-key lookup returned
+# and rejects one that does not fit; it throws `NotFoundError` for a dangling id,
+# which the public accessors map to an `ArgumentError`.
+function _read_association_by_id(
+    owner::TimeSeriesOwners,
+    key::TimeSeriesKey;
+    start_time = nothing,
+    len = nothing,
+    count = nothing,
+)
+    _check_association_owner(owner, key)
+    store = _get_time_series_manager_or_throw(owner).data_store
+    try
+        return InfraStore.read_by_id(
+            store.inner, Int64(get_association_id(key));
+            start_time = start_time, len = len, count = count,
+        )
+    catch e
+        # `catch`-block exception inspection: the window checks moved into the
+        # core with the read, so the caller's out-of-range `start_time` / `len` /
+        # `count` now arrives as the store's own error. Its message is the
+        # specific one — which grid, which index, how many are stored — so it is
+        # carried through; only the type is remapped, to keep the accessors'
+        # public `ArgumentError` contract.
+        e isa InfraStore.InvalidParameterError && throw(ArgumentError(e.msg))
+        rethrow()
+    end
+end
 
 # Rebuild the IS `SingleTimeSeries` from whatever the store handed back, however
 # the read was addressed.
@@ -950,36 +943,21 @@ _single_from_store(sts, name::AbstractString) = SingleTimeSeries(
     unit_system = _from_store_unit_system(sts.unit_system),
 )
 
-# Key-addressed SingleTimeSeries read. Unsliced, the id is the whole request. A
-# window needs the `(initial_timestamp, resolution, length)` grid to validate
-# against and a time range to push down, neither of which `read_by_ids` takes,
-# so it resolves the row and reads the half-open
-# `[start, start + n·resolution)` window server-side — only the requested steps
-# are read and decoded.
+# Key-addressed SingleTimeSeries read: one call, whether or not it slices. The
+# store resolves `(start_time, len)` against the grid on the row its own
+# primary-key lookup returned, refuses a window that does not fit, and reads the
+# half-open `[start, start + n·resolution)` steps — only those are read and
+# decoded.
 function _infrastore_read_single(
     owner::TimeSeriesOwners,
     key::StaticTimeSeriesKey;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
-    store = _get_time_series_manager_or_throw(owner).data_store
-    _check_association_owner(owner, key)
-    if isnothing(start_time) && isnothing(len)
-        sts = _read_association_by_id(store, key)::InfraStore.SingleTimeSeries
-        return _single_from_store(sts, sts.name)
-    end
-    row = _resolve_association(store, key)
-    initial_timestamp = row.initial_timestamp
-    resolution = row.resolution
-    start = isnothing(start_time) ? initial_timestamp : start_time
-    index = compute_time_array_index(initial_timestamp, start, resolution)
-    n = _validate_window(index, len, row.length)
-    sts =
-        InfraStore.get_time_series(InfraStore.SingleTimeSeries, store.inner, row.owner_id,
-            row.owner_category, row.name;
-            resolution = resolution, features = _row_features(row),
-            time_range = (start, start + resolution * n))
-    return _single_from_store(sts, row.name)
+    sts = _read_association_by_id(
+        owner, key; start_time = start_time, len = len,
+    )::InfraStore.SingleTimeSeries
+    return _single_from_store(sts, sts.name)
 end
 
 """
@@ -1005,59 +983,22 @@ function infrastore_get_time_series(
     return _infrastore_read_non_sequential(owner, key; start_time = start_time, len = len)
 end
 
-# Key-addressed NonSequentialTimeSeries read. Only `start_time` pushes down: `len` is a
-# POINT COUNT, and turning it into an end timestamp needs to know which irregular
-# timestamps exist — which is what the read is for. The store has no sentinel for "no upper
-# bound" (`typemax(DateTime)` overflows the FFI's millisecond range check), so the suffix
-# read stands one in and `len` slices the result client-side.
-const _FAR_FUTURE_DATETIME = Dates.DateTime(9999, 12, 31, 23, 59, 59)
+# Key-addressed NonSequentialTimeSeries read: one call, whether or not it slices.
+# `len` is a POINT COUNT, and turning it into an end timestamp needs to know which
+# irregular timestamps exist — which is exactly what the store's own row carries,
+# so it does that itself. IS used to read the whole suffix (behind a far-future
+# sentinel, since the store has no "no upper bound") and slice client-side; now
+# only the requested points cross.
 function _infrastore_read_non_sequential(
     owner::TimeSeriesOwners,
     key::NonSequentialTimeSeriesKey;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
-    store = _get_time_series_manager_or_throw(owner).data_store
-    _check_association_owner(owner, key)
-    if isnothing(start_time) && isnothing(len)
-        raw = _read_association_by_id(store, key)::InfraStore.NonSequentialTimeSeries
-        return _non_sequential_from_store(raw, raw.name)
-    end
-    row = _resolve_association(store, key)
-    name = row.name
-    time_range = if isnothing(start_time)
-        nothing
-    else
-        (start_time, _FAR_FUTURE_DATETIME)
-    end
-    nts = get_non_sequential(
-        store, row.owner_id, row.owner_category, name;
-        features = _row_features(row), time_range = time_range,
-    )
-
-    # Slice the values directly (not via a TimeArray) so FunctionData / N-D series slice
-    # too. With `start_time` given, `nts` is already the store-side suffix, so this narrows
-    # what the store returned; the exact-match check below still rejects a `start_time`
-    # that is not one of the series' timestamps.
-    timestamps = get_timestamps(nts)
-    full = get_array(nts)
-    total = size(full, 1)
-    start = if isnothing(start_time)
-        timestamps[1]
-    else
-        start_time
-    end
-    index = searchsortedfirst(timestamps, start)
-    (index <= total && timestamps[index] == start) ||
-        throw(ArgumentError("start_time=$start is not a timestamp in the series"))
-    n = _validate_window(index, len, total)
-    colons = ntuple(_ -> Colon(), ndims(full) - 1)
-    vals = full[index:(index + n - 1), colons...]
-    # A slice is the same values over a shorter window, so it keeps the label.
-    return NonSequentialTimeSeries(
-        String(name), timestamps[index:(index + n - 1)], vals;
-        units = get_units(nts), quantity_kind = get_quantity_kind(nts),
-        unit_system = get_unit_system(nts))
+    nts = _read_association_by_id(
+        owner, key; start_time = start_time, len = len,
+    )::InfraStore.NonSequentialTimeSeries
+    return _non_sequential_from_store(nts, nts.name)
 end
 
 # ---- Bulk staging ----------------------------------------------------------
@@ -1311,80 +1252,6 @@ _infrastore_stage_data!(
     "transform_single_time_series!.",
 )
 
-# 1-based index of the forecast window that starts at `start_time`, on the grid
-# `initial_timestamp + k·interval`. `compute_time_array_index` does the period
-# arithmetic, so calendar intervals (`Month`, `Year`) work like fixed ones. A
-# single-window forecast carries a zero interval: its only window starts at
-# `initial_timestamp`, which is then the only valid `start_time` — the zero-interval
-# case must not skip the alignment check, or a misaligned request would silently
-# read the window at `initial_timestamp`.
-function _forecast_window_index(initial_timestamp, interval, start_time)
-    start_time == initial_timestamp && return 1
-    (start_time < initial_timestamp || iszero(Dates.value(interval))) &&
-        _throw_misaligned(initial_timestamp, interval, start_time)
-    return try
-        compute_time_array_index(initial_timestamp, start_time, interval)
-    catch e
-        # `catch`-block exception inspection: the period arithmetic reports an
-        # off-grid timestamp as an ArgumentError; name the window contract instead.
-        if e isa ArgumentError
-            _throw_misaligned(initial_timestamp, interval, start_time)
-        else
-            rethrow()
-        end
-    end
-end
-
-# Kept out of line so the aligned path — every forecast read after the first window —
-# never pays for formatting the message.
-@noinline function _throw_misaligned(initial_timestamp, interval, start_time)
-    throw(
-        ArgumentError(
-            "start_time=$start_time is not a forecast window timestamp " *
-            "(initial_timestamp=$initial_timestamp, interval=$(Dates.canonicalize(interval)))",
-        ),
-    )
-end
-
-# Translate IS's `start_time` / `count` window selection into the core's
-# half-open `[start, end)` `time_range`, validated against the forecast's stored
-# window grid (`initial_timestamp + k·interval`, `total_count` windows). Returns
-# `nothing` when no slice is requested (read every window). Throws ArgumentError
-# on a misaligned `start_time` or an out-of-range / oversized request — the store
-# would otherwise silently truncate an over-request rather than error. The
-# computed range is pushed into `get_time_series`, so the store slices the
-# windows server-side instead of returning all of them for us to discard.
-function _forecast_time_range(initial_timestamp, interval, total_count, start_time, count)
-    isnothing(start_time) && isnothing(count) && return nothing
-
-    start_idx = if isnothing(start_time)
-        1
-    else
-        _forecast_window_index(initial_timestamp, interval, start_time)
-    end
-    if start_idx < 1 || start_idx > total_count
-        throw(ArgumentError(
-            "start_time=$start_time is out of range (count=$total_count)"))
-    end
-    n = _window_length(count, start_idx, total_count)
-    if n < 1 || start_idx + n - 1 > total_count
-        throw(
-            ArgumentError(
-                "requested count=$n from start_time=$start_time exceeds the " *
-                "$total_count stored forecast windows"),
-        )
-    end
-
-    # A single-window forecast carries a zero interval, so the arithmetic below would
-    # collapse to a zero-width `[initial, initial)` range that selects nothing. The
-    # request is already validated, so read the whole (single-window) series.
-    iszero(Dates.value(interval)) && return nothing
-
-    start_ts = initial_timestamp + interval * (start_idx - 1)
-    end_ts = initial_timestamp + interval * (start_idx - 1 + n)  # exclusive
-    return (start_ts, end_ts)
-end
-
 # Assemble forecast windows into a `SortedDict` with a concrete value type. Building it
 # from a generator yields `SortedDict{Any, Any}`, which `Deterministic`'s `convert_data`
 # then coerces to `Vector{Float64}` — corrupting FunctionData windows. Materializing
@@ -1404,10 +1271,13 @@ function _assemble_forecast_windows(initial_timestamp, interval, count, window)
 end
 
 """Reconstruct a forecast from the InfraStore store (matches the STORED type),
-honoring `start_time` / `count` slicing on the window axis. Pass `key` to address
-the forecast by its `association_id` instead of resolving one by name; the `name`
-argument is then only a label for error messages, and every lookup attribute
-comes off the row the id resolves to."""
+honoring `start_time` / `count` slicing on the window axis.
+
+Pass `key` to address the forecast by its `association_id`, which is one store
+call: `read_by_id` resolves the window on the row its own primary-key lookup
+returned, so nothing here computes a time range or fetches a grid to compute one
+from, and the `name` argument goes unused. Without a key the forecast is resolved
+by name first, and that resolution is the extra call."""
 function _infrastore_get_forecast(
     owner, name;
     time_series_type::Type{<:Forecast} = Forecast,
@@ -1419,68 +1289,30 @@ function _infrastore_get_forecast(
     key::Union{Nothing, ForecastKey} = nothing,
     features::Union{Nothing, Dict} = nothing,
 )
+    if !isnothing(key)
+        raw = _read_association_by_id(
+            owner, key; start_time = start_time, count = count,
+        )
+        return _forecast_from_store(raw, String(raw.name), len)
+    end
     # Resolve the unique forecast of the requested type matching a possibly-partial
-    # (subset) feature / resolution / interval query, then read it by its exact stored
-    # attributes. `interval` matters when one series name carries several forecasts
-    # that differ only by interval (`transform_single_time_series!` with
-    # `delete_existing = false`); without it the lookup is ambiguous. The type is part
-    # of the lookup too: one name can carry a Deterministic and a Probabilistic.
-    #
-    # A caller-supplied key skips that query: its `association_id` names the row
-    # directly, and the key rebuilt from that row — not the caller's snapshot of it —
-    # is what every lookup below is driven from.
-    store, matched = if isnothing(key)
-        mgr = _get_time_series_manager_or_throw(owner)
-        (
-            mgr.data_store,
-            infrastore_get_time_series_key(
-                owner, time_series_type, name;
-                resolution = resolution, interval = interval, features = features,
-            ),
-        )
-    else
-        s, row = _store_and_association(owner, key)
-        (s, _key_from_row(row))
-    end
-    owner_id = get_owner_id(matched)
-    category = get_owner_category(matched)
-    name = get_name(matched)
-    feats = get_features(matched)
-    resolution = get_resolution(matched)
-    # `len` truncates each window to its first `len` steps; validate it against the
-    # horizon here rather than letting the slice fail with a BoundsError (or silently
-    # return empty windows for `len = 0`), matching the static read path.
-    if !isnothing(len)
-        horizon_count = get_horizon_count(matched)
-        (len < 1 || len > horizon_count) && throw(
-            ArgumentError(
-                "requested len=$len is outside the forecast horizon of " *
-                "$horizon_count steps",
-            ),
-        )
-    end
-    # Pin every store lookup below to the resolved forecast's exact interval.
-    # One name can carry several forecasts differing only by interval, and the
-    # typed lookups match on attributes, so without this they would match more
-    # than one. (A single-window forecast carries a zero interval, stored as-is.)
-    tr = _forecast_time_range(get_initial_timestamp(matched), get_interval(matched),
-        get_count(matched), start_time, count)
-    # The resolved key names the stored concrete type; it selects the
-    # reconstruction method (function barrier — the key's type is not known
-    # statically).
-    forecast = _reconstruct_forecast(
-        get_time_series_type(matched),
-        store,
-        owner_id,
-        category,
-        String(name),
-        resolution,
-        get_interval(matched),
-        feats,
-        tr,
-        len,
+    # (subset) feature / resolution / interval query, then read the key that names.
+    # `interval` matters when one series name carries several forecasts that differ
+    # only by interval (`transform_single_time_series!` with `delete_existing =
+    # false`); without it the lookup is ambiguous. The type is part of the lookup
+    # too: one name can carry a Deterministic and a Probabilistic. Resolving to a
+    # key and reading that is one query plus the keyed read, and it keeps a single
+    # read path — an attribute-addressed forecast read would need the interval
+    # pinned to avoid matching more than one of those siblings, which the id
+    # cannot match at all.
+    matched = infrastore_get_time_series_key(
+        owner, time_series_type, name;
+        resolution = resolution, interval = interval, features = features,
     )
-    return forecast
+    return _infrastore_get_forecast(
+        owner, name;
+        key = matched, start_time = start_time, len = len, count = count,
+    )
 end
 
 # `len`, when given, truncates a window to its first `len` horizon steps (the
@@ -1520,23 +1352,60 @@ _check_member_window_type(::ElementEncoding, forecast_type, name, element_type) 
 
 # Reconstruct a forecast read from the store as its user-facing type. Every
 # InfraStore read below is already sliced to the requested window range.
-function _reconstruct_forecast(
-    ::Type{<:Probabilistic},
-    store::Store,
-    owner_id,
-    category,
-    name::String,
-    resolution,
-    interval,
-    feats,
-    time_range,
-    len,
-)
-    # `.data` is the canonical (percentile_count, horizon_count, count) array.
-    p = InfraStore.get_time_series(InfraStore.Probabilistic, store.inner, owner_id,
-        category, name;
-        resolution = resolution, interval = interval, features = feats,
-        time_range = time_range)
+# ---- Forecast decoding -----------------------------------------------------
+# Decoding is split from fetching so both addressings share it: the keyed read
+# hands over what one `read_by_id` returned, the by-name read what an
+# attribute-addressed `get_time_series` returned, and the same methods below
+# turn either into the IS forecast. Dispatch is on the `InfraStore` struct the
+# store built, which already names the stored type.
+
+# Per-window horizon step count of a decoded forecast, for validating `len`
+# against the shape actually returned rather than against a catalog row.
+_store_horizon_count(d::InfraStore.Deterministic) = size(d.data, 1)
+_store_horizon_count(p::InfraStore.Probabilistic) = size(p.data, 2)
+_store_horizon_count(s::InfraStore.Scenarios) = size(s.data, 2)
+
+# `len` truncates each window to its first `len` steps; validated against the
+# horizon here rather than letting the slice fail with a BoundsError (or
+# silently return empty windows for `len = 0`), matching the static read path.
+_check_forecast_len(_raw, ::Nothing) = nothing
+
+function _check_forecast_len(raw, len::Int)
+    horizon_count = _store_horizon_count(raw)
+    (len < 1 || len > horizon_count) && throw(
+        ArgumentError(
+            "requested len=$len is outside the forecast horizon of $horizon_count steps",
+        ),
+    )
+    return nothing
+end
+
+# A DeterministicSingleTimeSeries is an internal storage optimization: it shares
+# the underlying SingleTimeSeries array instead of materializing the overlapping
+# windows. On read it is always returned as a regular `Deterministic` — the
+# InfraStore store expands the shared array into the canonical
+# (horizon_count, count) window matrix (honoring the requested window) — so there
+# is no DST method here, and none is reachable.
+#
+# This does NOT cost the storage optimization on a copy: `copy_time_series!`
+# clones the association row inside the store, so the stored type survives
+# without ever round-tripping through these Julia objects.
+function _forecast_from_store(d::InfraStore.Deterministic, name::String, len)
+    _check_forecast_len(d, len)
+    # Resolved once per read: the tag is the same for every window.
+    encoding = _element_encoding(d.element_type)
+    window(i) =
+        _truncate_window(_forecast_window(d.data, encoding, d.element_type, i), len)
+    data = _assemble_forecast_windows(d.initial_timestamp, d.interval, d.count, window)
+    return Deterministic(; name = name, data = data,
+        resolution = d.resolution, interval = d.interval, units = d.units,
+        quantity_kind = d.quantity_kind,
+        unit_system = _from_store_unit_system(d.unit_system))
+end
+
+# `.data` is the canonical (percentile_count, horizon_count, count) array.
+function _forecast_from_store(p::InfraStore.Probabilistic, name::String, len)
+    _check_forecast_len(p, len)
     _check_member_window_type(
         _element_encoding(p.element_type), Probabilistic, name, p.element_type,
     )
@@ -1551,68 +1420,9 @@ function _reconstruct_forecast(
     )
 end
 
-_reconstruct_forecast(::Type{<:Deterministic}, args...) =
-    _reconstruct_deterministic(InfraStore.Deterministic, args...)
-
-# A DeterministicSingleTimeSeries is an internal storage optimization: it shares
-# the underlying SingleTimeSeries array instead of materializing the overlapping
-# windows. On read it is always returned as a regular `Deterministic` — the
-# InfraStore store expands the shared array into the canonical
-# (horizon_count, count) window matrix (honoring `time_range`), so the
-# reconstruction is identical to the `Deterministic` method.
-#
-# This does NOT cost the storage optimization on a copy: `copy_time_series!`
-# clones the association row inside the store, so the stored type survives
-# without ever round-tripping through these Julia objects.
-_reconstruct_forecast(::Type{<:DeterministicSingleTimeSeries}, args...) =
-    _reconstruct_deterministic(InfraStore.DeterministicSingleTimeSeries, args...)
-
-_reconstruct_forecast(::Type{T}, args...) where {T} =
-    error("unreachable: unexpected stored forecast type $T")
-
-function _reconstruct_deterministic(
-    store_type,
-    store::Store,
-    owner_id,
-    category,
-    name::String,
-    resolution,
-    interval,
-    feats,
-    time_range,
-    len,
-)
-    d = InfraStore.get_time_series(store_type, store.inner, owner_id, category, name;
-        resolution = resolution, interval = interval, features = feats,
-        time_range = time_range)
-    # Resolved once per read: the tag is the same for every window.
-    encoding = _element_encoding(d.element_type)
-    window(i) =
-        _truncate_window(_forecast_window(d.data, encoding, d.element_type, i), len)
-    data = _assemble_forecast_windows(d.initial_timestamp, d.interval, d.count, window)
-    return Deterministic(; name = name, data = data,
-        resolution = d.resolution, interval = d.interval, units = d.units,
-        quantity_kind = d.quantity_kind,
-        unit_system = _from_store_unit_system(d.unit_system))
-end
-
-function _reconstruct_forecast(
-    ::Type{<:Scenarios},
-    store::Store,
-    owner_id,
-    category,
-    name::String,
-    resolution,
-    interval,
-    feats,
-    time_range,
-    len,
-)
-    # `.data` is the canonical (scenario_count, horizon_count, count) array.
-    s_ts = InfraStore.get_time_series(InfraStore.Scenarios, store.inner, owner_id,
-        category, name;
-        resolution = resolution, interval = interval, features = feats,
-        time_range = time_range)
+# `.data` is the canonical (scenario_count, horizon_count, count) array.
+function _forecast_from_store(s_ts::InfraStore.Scenarios, name::String, len)
+    _check_forecast_len(s_ts, len)
     _check_member_window_type(
         _element_encoding(s_ts.element_type), Scenarios, name, s_ts.element_type,
     )
@@ -1626,6 +1436,9 @@ function _reconstruct_forecast(
         unit_system = _from_store_unit_system(s_ts.unit_system),
     )
 end
+
+_forecast_from_store(raw, name::String, _len) =
+    error("unreachable: $name resolved to unexpected stored data $(typeof(raw))")
 
 # ---- ForecastReader --------------------------------------------------------
 # A timestamp-oriented reader over the forecasts matching a filter. It carries the

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -426,23 +426,34 @@ function infrastore_remove_time_series!(
     owner::TimeSeriesOwners,
     key::TimeSeriesKey,
 )
-    # `owner` is an argument in its own right, so it is confirmed against the
-    # catalog row before anything is deleted.
-    _check_association_owner(owner, store, key)
+    # `owner` is an argument in its own right, so the removal is scoped to it:
+    # the store confirms the row belongs to `owner` and deletes it in one
+    # transaction. Checking here first would be a race — an id survives a
+    # reassignment, so a row confirmed by one call can move before the next one
+    # deletes it, and the removal would retire the new owner's series.
     try
-        InfraStore.remove_by_ids!(store.inner, [Int64(get_association_id(key))])
+        InfraStore.remove_by_ids!(
+            store.inner, [Int64(get_association_id(key))];
+            owner = _infrastore_owner_id_category(owner),
+        )
     catch e
         # `catch`-block exception inspection: the core reports both conditions
         # through its own error types, which IS maps to the errors callers
-        # dispatch on. `InvalidParameterError` out of a removal is the core's
-        # orphaned-DST guard, which fires only for a SingleTimeSeries backing one.
+        # dispatch on. The core's orphaned-DST guard is an
+        # `InvalidParameterError`, but it is not the only one a removal can
+        # raise — an id the core rejects outright is another — and only the guard
+        # fires for a `SingleTimeSeries`. So the specific message is claimed only
+        # for that case; every other `InvalidParameterError` keeps the core's own
+        # message, which names what actually went wrong, under the `ArgumentError`
+        # type the accessors contract for.
         if e isa InfraStore.InvalidParameterError
-            throw(
+            get_time_series_type(key) <: SingleTimeSeries && throw(
                 ArgumentError(
                     "Cannot remove the SingleTimeSeries named by " *
                     "association_id=$(get_association_id(key)) because it is " *
                     "attached to a DeterministicSingleTimeSeries."),
             )
+            throw(ArgumentError(e.msg))
         elseif e isa InfraStore.NotFoundError
             throw(
                 ArgumentError(
@@ -450,6 +461,8 @@ function infrastore_remove_time_series!(
                     "is no longer in this store: $(summary(key)) on " *
                     "$(summary(owner)) may already have been removed."),
             )
+        elseif e isa InfraStore.OwnerMismatchError
+            throw(_not_this_owners_key(owner, key, e))
         end
         rethrow()
     end
@@ -563,7 +576,13 @@ function _infrastore_get_time_series_via_key(
         interval = interval,
         features = features,
     )
-    return get_time_series(owner, key; start_time = start_time, len = len, count = count)
+    # The key came out of this owner's own listing, so the read is addressed by
+    # the store: re-checking the owner would be a round trip that could only
+    # confirm what the resolution already established.
+    return _get_time_series_by_key(
+        _owner_store(owner), key;
+        start_time = start_time, len = len, count = count,
+    )
 end
 
 # `StaticTimeSeries` (and any static subtype without its own route): resolve through the
@@ -629,39 +648,57 @@ function infrastore_get_time_series(
         resolution = resolution,
         features = features,
     )
-    return _infrastore_read_single(owner, key; start_time = start_time, len = len)
+    # Store-addressed: `infrastore_get_time_series_key` resolved the key out of
+    # this owner's own listing, so its ownership is settled.
+    return _infrastore_read_single(
+        _owner_store(owner), key; start_time = start_time, len = len,
+    )
 end
 
 # ---- Key addressing --------------------------------------------------------
 # `association_id` is the identity of a stored association: the store mints it,
-# never reissues it, and every other field a `TimeSeriesKey` carries is a
-# snapshot of the catalog row it names. So a key is addressed by its id alone —
-# its `name`, `resolution`, `interval` and `features` are display state, never
-# lookup arguments. A key handed to an accessor is otherwise taken as valid:
-# nothing probes it for staleness first, and a dangling id surfaces as an error
-# from the call that was already committed to acting on it.
+# never reissues it, and it is the whole of a `TimeSeriesKey`. So a key is
+# addressed by its id alone — a name, resolution, interval or feature set is a
+# column of the catalog row, never a lookup argument. A key handed to an accessor
+# is otherwise taken as valid: nothing probes it for staleness first, and a
+# dangling id surfaces as an error from the call that was already committed to
+# acting on it.
 #
-# The exception is the owner. `owner` is an argument in its own right, so every
-# accessor confirms the key belongs to it before doing anything — without that,
+# The exception is the owner. `owner` is an argument in its own right, so an
+# accessor that takes both holds the key to it — without that,
 # `remove_time_series!(sys, wrong_component, key)` would quietly delete a series
-# off some other component. The key carries `owner_id` and `owner_category`, so
-# this is a comparison against the key, ahead of any store access: no probe, no
-# round trip, and the same check on every path.
+# off some other component. A key carries no owner (an owner cached on one would
+# be a field to go stale when a series is reassigned, which is the whole reason a
+# key is only its id), so the owner is passed INTO the store call rather than
+# checked beside it: `read_by_id(...; owner)` and `remove_by_ids!(...; owner)`
+# confirm and act as one operation, raising `OwnerMismatchError`, which the
+# accessors map to their public `ArgumentError`.
 #
-# Every keyed accessor is therefore **one** store call. `read_by_id` takes the
-# slice as well as the id: it resolves `start_time` / `len` / `count` against the
-# row its own primary-key lookup returned, so IS neither computes a time range
-# nor fetches a grid to compute one from. `remove_by_ids!` is the same for
-# removal, and `get_metadata_by_id` remains for the catalog-row accessors (the
-# content hash) that want the row rather than the data.
+# Checking first in a call of IS's own would be both slower and wrong. Slower
+# because a `get_metadata_by_id` is a second round trip on every keyed accessor.
+# Wrong because an id survives a reassignment: between the call that confirmed the
+# owner and the call that acts, the row can move to another owner, and the removal
+# then retires *that* owner's series — exactly what checking the owner was for.
+# Every keyed accessor is therefore back to **one** store call, and the race is
+# closed rather than narrowed.
 #
-# The window arithmetic and its bounds checks live in the core, which is what
-# makes the single call possible: the store resolves `start_time` / `len` /
-# `count` against the row it just looked up, and refuses a window that does not
-# fit rather than clamping to one that does. IS's own copy of that arithmetic is
-# gone: the by-name reads resolve a key first and then take the same one-call
-# keyed path, so there is exactly one read path and one place the window is
-# resolved.
+# The by-name reads resolve their key out of a `list_metadata` scoped to one
+# owner, which is where ownership is established; they take the `Store`-addressed
+# read below, which sets no guard. Re-guarding would only re-confirm what the
+# listing already said.
+#
+# `read_by_id` takes the slice as well as the id: it resolves `start_time` / `len`
+# / `count` against the row its own primary-key lookup returned, so IS neither
+# computes a time range nor fetches a grid to compute one from. `remove_by_ids!`
+# is the same for removal, and `get_metadata_by_id` remains the catalog-row
+# accessor (the content hash) for callers that want the row rather than the data —
+# there the row IS the answer, so checking its owner is not a second call.
+#
+# The window arithmetic and its bounds checks live in the core: the store resolves
+# `start_time` / `len` / `count` against the row it just looked up, and refuses a
+# window that does not fit rather than clamping to one that does. IS's own copy of
+# that arithmetic is gone, so there is exactly one read path and one place the
+# window is resolved.
 
 # The catalog row `id` names. `nothing` from the core means the row is gone, which
 # is an error here: the caller is already committed to acting on it.
@@ -677,33 +714,42 @@ function _resolve_association(store::Store, key::TimeSeriesKey)
     return row
 end
 
-# Confirm the association `key` names is attached to `owner`, against the catalog
-# row rather than a copy on the key. The category matters as well as the id, since
-# a component and a supplemental attribute can share an integer id.
-#
-# The row is the authority: an owner cached on the key would be one more field to
-# go stale when a series is reassigned, which is the whole reason a key carries
-# only its id.
-_check_association_owner(owner::TimeSeriesOwners, store::Store, key::TimeSeriesKey) =
-    _check_association_owner(owner, key, _resolve_association(store, key))
+# The `ArgumentError` a key that does not belong to `owner` raises, whether the
+# store said so (the guarded read and removal) or the row did (the catalog-row
+# accessors, which hold the row already). `detail` is what said it.
+_not_this_owners_key(owner::TimeSeriesOwners, key::TimeSeriesKey, detail) = ArgumentError(
+    "TimeSeriesKey (association_id=$(get_association_id(key))) does not name a " *
+    "time series of $(summary(owner)): $(detail). Pass the owner it belongs to, " *
+    "or look one up on this owner with list_metadata.",
+)
 
+# Confirm the association `key` names is attached to `owner`, against a catalog
+# row the caller has already fetched. The category matters as well as the id,
+# since a component and a supplemental attribute can share an integer id.
+#
+# Only for the accessors that want the row itself. Anything that *acts* on the
+# association passes `owner` into the store call instead — see
+# `_read_association_by_id` — because a check and an act in two calls have a
+# window between them that a reassignment fits through.
 function _check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey, row)
     owner_id, category = _infrastore_owner_id_category(owner)
     (row.owner_id == owner_id && row.owner_category == category) && return row
     throw(
-        ArgumentError(
-            "TimeSeriesKey (association_id=$(get_association_id(key))) names " *
-            "'$(row.name)', which belongs to owner id=$(row.owner_id), not to " *
-            "$(summary(owner)); pass the owner it belongs to, or look one up on this " *
-            "owner with list_metadata.",
+        _not_this_owners_key(
+            owner, key,
+            "it names '$(row.name)', which belongs to owner id=$(row.owner_id)",
         ),
     )
 end
 
+"The store the owner's time series manager holds."
+_owner_store(owner::TimeSeriesOwners) =
+    _get_time_series_manager_or_throw(owner).data_store
+
 # The store an owner's manager holds, and the row `key`'s id resolves to in it —
 # for the catalog-row accessors, which want the row itself rather than the data.
 function _store_and_association(owner::TimeSeriesOwners, key::TimeSeriesKey)
-    store = _get_time_series_manager_or_throw(owner).data_store
+    store = _owner_store(owner)
     return (store, _check_association_owner(owner, key, _resolve_association(store, key)))
 end
 
@@ -712,19 +758,49 @@ end
 # The core resolves the window against the row its primary-key lookup returned
 # and rejects one that does not fit; it throws `NotFoundError` for a dangling id,
 # which the public accessors map to an `ArgumentError`.
-function _read_association_by_id(
+#
+# Addressed by `Store`, so nothing is held to an owner — this is the read for a
+# key whose owner is already established (one resolved from that owner's own
+# listing). The `TimeSeriesOwners` method below is the guarded one.
+_read_association_by_id(
+    store::Store,
+    key::TimeSeriesKey;
+    start_time = nothing,
+    len = nothing,
+    count = nothing,
+) = _read_association_by_id(
+    store, key, nothing; start_time = start_time, len = len, count = count,
+)
+
+# The owner-guarded read. `owner` goes INTO the store call: the core takes the
+# row's owner off the very row it materializes the values from, so the guard is
+# free and cannot disagree with what is read. A `get_metadata_by_id` here instead
+# would be both a second round trip and a weaker answer — it describes the row as
+# it was, and an id survives a reassignment.
+_read_association_by_id(
     owner::TimeSeriesOwners,
     key::TimeSeriesKey;
     start_time = nothing,
     len = nothing,
     count = nothing,
+) = _read_association_by_id(
+    _owner_store(owner), key, owner;
+    start_time = start_time, len = len, count = count,
 )
-    store = _get_time_series_manager_or_throw(owner).data_store
-    _check_association_owner(owner, store, key)
+
+function _read_association_by_id(
+    store::Store,
+    key::TimeSeriesKey,
+    owner::Union{Nothing, TimeSeriesOwners};
+    start_time = nothing,
+    len = nothing,
+    count = nothing,
+)
     try
         return InfraStore.read_by_id(
             store.inner, Int64(get_association_id(key));
             start_time = start_time, len = len, count = count,
+            owner = isnothing(owner) ? nothing : _infrastore_owner_id_category(owner),
             types = _IS_ELEMENT_TYPES,
         )
     catch e
@@ -735,6 +811,8 @@ function _read_association_by_id(
         # carried through; only the type is remapped, to keep the accessors'
         # public `ArgumentError` contract.
         e isa InfraStore.InvalidParameterError && throw(ArgumentError(e.msg))
+        e isa InfraStore.OwnerMismatchError &&
+            throw(_not_this_owners_key(owner, key, e.msg))
         rethrow()
     end
 end
@@ -747,19 +825,19 @@ _single_from_store(sts, name::AbstractString) = SingleTimeSeries(
     unit_system = _from_store_unit_system(sts.unit_system),
 )
 
-# Key-addressed SingleTimeSeries read: one call, whether or not it slices. The
-# store resolves `(start_time, len)` against the grid on the row its own
-# primary-key lookup returned, refuses a window that does not fit, and reads the
-# half-open `[start, start + n·resolution)` steps — only those are read and
-# decoded.
+# Key-addressed SingleTimeSeries read: one store call, whether or not it slices
+# (plus the owner check, when addressed by owner). The store resolves
+# `(start_time, len)` against the grid on the row its own primary-key lookup
+# returned, refuses a window that does not fit, and reads the half-open
+# `[start, start + n·resolution)` steps — only those are read and decoded.
 function _infrastore_read_single(
-    owner::TimeSeriesOwners,
+    target::KeyedReadTarget,
     key::TimeSeriesKey{<:SingleTimeSeries};
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
     sts = _read_association_by_id(
-        owner, key; start_time = start_time, len = len,
+        target, key; start_time = start_time, len = len,
     )::InfraStore.SingleTimeSeries
     return _single_from_store(sts, sts.name)
 end
@@ -784,7 +862,9 @@ function infrastore_get_time_series(
     # then read it by its exact stored attributes.
     key = infrastore_get_time_series_key(
         owner, NonSequentialTimeSeries, name; features = features)
-    return _infrastore_read_non_sequential(owner, key; start_time = start_time, len = len)
+    return _infrastore_read_non_sequential(
+        _owner_store(owner), key; start_time = start_time, len = len,
+    )
 end
 
 # Key-addressed NonSequentialTimeSeries read: one call, whether or not it slices.
@@ -794,13 +874,13 @@ end
 # sentinel, since the store has no "no upper bound") and slice client-side; now
 # only the requested points cross.
 function _infrastore_read_non_sequential(
-    owner::TimeSeriesOwners,
+    target::KeyedReadTarget,
     key::TimeSeriesKey{<:NonSequentialTimeSeries};
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
     nts = _read_association_by_id(
-        owner, key; start_time = start_time, len = len,
+        target, key; start_time = start_time, len = len,
     )::InfraStore.NonSequentialTimeSeries
     return _non_sequential_from_store(nts, nts.name)
 end
@@ -1057,14 +1137,31 @@ function _assemble_forecast_windows(initial_timestamp, interval, count, window)
     return data
 end
 
+# Key-addressed forecast read: the forecast `key` names, reconstructed as its
+# STORED type, honoring `start_time` / `count` on the window axis and `len` on
+# the horizon. `read_by_id` resolves the window on the row its own primary-key
+# lookup returned, so nothing here computes a time range or fetches a grid to
+# compute one from. Addressed by owner (checked) or by store (already-owned key),
+# like the static readers.
+function _infrastore_read_forecast(
+    target::KeyedReadTarget,
+    key::TimeSeriesKey{<:Forecast};
+    start_time::Union{Nothing, Dates.DateTime} = nothing,
+    len::Union{Nothing, Int} = nothing,
+    count::Union{Nothing, Int} = nothing,
+)
+    raw = _read_association_by_id(
+        target, key; start_time = start_time, count = count,
+    )
+    return _forecast_from_store(raw, String(raw.name), len)
+end
+
 """Reconstruct a forecast from the InfraStore store (matches the STORED type),
 honoring `start_time` / `count` slicing on the window axis.
 
-Pass `key` to address the forecast by its `association_id`, which is one store
-call: `read_by_id` resolves the window on the row its own primary-key lookup
-returned, so nothing here computes a time range or fetches a grid to compute one
-from, and the `name` argument goes unused. Without a key the forecast is resolved
-by name first, and that resolution is the extra call."""
+The forecast is resolved by name against `owner`'s own listing and then read by
+the key that resolution returns — two store calls, and the second does not
+re-check an ownership the listing established."""
 function _infrastore_get_forecast(
     owner, name = nothing;
     time_series_type::Type{<:Forecast} = Forecast,
@@ -1073,32 +1170,24 @@ function _infrastore_get_forecast(
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    key::Union{Nothing, TimeSeriesKey{<:Forecast}} = nothing,
     features::Union{Nothing, Dict} = nothing,
 )
-    if !isnothing(key)
-        raw = _read_association_by_id(
-            owner, key; start_time = start_time, count = count,
-        )
-        return _forecast_from_store(raw, String(raw.name), len)
-    end
     # Resolve the unique forecast of the requested type matching a possibly-partial
     # (subset) feature / resolution / interval query, then read the key that names.
     # `interval` matters when one series name carries several forecasts that differ
     # only by interval (`transform_single_time_series!` with `delete_existing =
     # false`); without it the lookup is ambiguous. The type is part of the lookup
     # too: one name can carry a Deterministic and a Probabilistic. Resolving to a
-    # key and reading that is one query plus the keyed read, and it keeps a single
-    # read path — an attribute-addressed forecast read would need the interval
-    # pinned to avoid matching more than one of those siblings, which the id
-    # cannot match at all.
+    # key and reading that keeps a single read path — an attribute-addressed
+    # forecast read would need the interval pinned to avoid matching more than one
+    # of those siblings, which the id cannot match at all.
     matched = infrastore_get_time_series_key(
         owner, time_series_type, name;
         resolution = resolution, interval = interval, features = features,
     )
-    return _infrastore_get_forecast(
-        owner, name;
-        key = matched, start_time = start_time, len = len, count = count,
+    return _infrastore_read_forecast(
+        _owner_store(owner), matched;
+        start_time = start_time, len = len, count = count,
     )
 end
 
@@ -1157,6 +1246,24 @@ function _check_forecast_len(raw, len::Int)
     return nothing
 end
 
+# A `Deterministic`'s decoded values are the `(horizon_count, count)` matrix whose
+# columns are its windows. A read hands back a higher-rank array when the row's
+# `element_type` did not decode to the values it was packed from — the packing
+# axis is still there, and slicing a column off it would either fail or, worse,
+# hand back the wrong numbers. That is a storage inconsistency, so it is named
+# here rather than left to surface as a bare `BoundsError` from the slice.
+_check_deterministic_window_shape(::AbstractMatrix, ::String, _element_type) = nothing
+
+_check_deterministic_window_shape(data::AbstractArray, name::String, element_type) =
+    throw(
+        ArgumentError(
+            "Deterministic '$name' read back as a $(ndims(data))-dimensional array " *
+            "with element type $(something(element_type, "f64")); a Deterministic's " *
+            "windows are the columns of a (horizon_count, count) matrix. Its stored " *
+            "element type does not describe the values it holds.",
+        ),
+    )
+
 # A DeterministicSingleTimeSeries is an internal storage optimization: it shares
 # the underlying SingleTimeSeries array instead of materializing the overlapping
 # windows. On read it is always returned as a regular `Deterministic` — the
@@ -1169,6 +1276,7 @@ end
 # without ever round-tripping through these Julia objects.
 function _forecast_from_store(d::InfraStore.Deterministic, name::String, len)
     _check_forecast_len(d, len)
+    _check_deterministic_window_shape(d.data, name, d.element_type)
     # Resolved once per read: the tag is the same for every window.
     # `d.data` is `(horizon_count, count)` of values, decoded by the read, so a
     # window is a column of it. Materialized, not a view: the window becomes the
@@ -1740,22 +1848,43 @@ _infrastore_is_type(s::Symbol) =
 # for deserializing a key that travels as (id, type).
 _time_series_type_from_name(name::AbstractString) = _infrastore_is_type(Symbol(name))
 
-# The IS value element type a row's `element_type` decodes to — the `T` of a
+# The IS counterpart of a store value type. The four composite ones are the
+# types `InfraStore.DEFAULT_ELEMENT_TYPES` decodes into and IS substitutes its
+# own `FunctionData` for; everything else — the scalar dtypes, and the `NTuple`s
+# a `tuple(N,f64)` row decodes to — is already the type IS uses.
+_is_element_type(::Type{InfraStore.LinearFunction}) = LinearFunctionData
+_is_element_type(::Type{InfraStore.QuadraticFunction}) = QuadraticFunctionData
+_is_element_type(::Type{InfraStore.PiecewiseLinear}) = PiecewiseLinearData
+_is_element_type(::Type{InfraStore.PiecewiseStep}) = PiecewiseStepData
+_is_element_type(::Type{T}) where {T} = T
+
+# The IS value element type a catalog row's values decode to — the `T` of a
 # `TimeSeriesData{T}`, and so of the `TimeSeriesKey{<:TimeSeriesData{T}}` naming
-# the series. A composite tag names one of IS's `FunctionData`; anything else
-# decodes to raw numbers, whose element type is the dtype the store holds them in.
-function _element_value_type(element_type)
-    isnothing(element_type) && return Float64
-    kind = InfraStore._element_kind(element_type)
-    if kind === :tuple
-        m = match(InfraStore._TUPLE_TAG, element_type)
-        m === nothing || return NTuple{parse(Int, m.captures[1]), Float64}
-    elseif kind !== nothing && haskey(_IS_ELEMENT_TYPES, kind)
-        return _IS_ELEMENT_TYPES[kind]
-    end
-    dtype = InfraStore._physical_dtype_of(element_type)
-    return isnothing(dtype) ? Float64 : dtype
-end
+# the series.
+#
+# Read off the row's own `time_series_type`, which the store has already resolved
+# its `element_type` string into (`InfraStore.SingleTimeSeries{PiecewiseLinear,
+# 1}` for a `piecewise_linear` row). That leaves only store type -> IS type to
+# translate, over types InfraStore exports, and keeps the `element_type`
+# vocabulary — which spellings are composite, which dtype each names — inside the
+# store, where it is owned: IS never parses the tag, so a spelling added or
+# respelled there needs no matching edit here.
+#
+# A row whose type the store left unparameterized is one whose `element_type`
+# this version of the store does not recognize; its values come back as the raw
+# numbers they are stored as, which is `Float64` unless something says otherwise.
+_element_value_type(::Type{<:InfraStore.SingleTimeSeries{T}}) where {T} =
+    _is_element_type(T)
+_element_value_type(::Type{<:InfraStore.NonSequentialTimeSeries{T}}) where {T} =
+    _is_element_type(T)
+_element_value_type(::Type{<:InfraStore.Deterministic{T}}) where {T} =
+    _is_element_type(T)
+_element_value_type(::Type{<:InfraStore.DeterministicSingleTimeSeries{T}}) where {T} =
+    _is_element_type(T)
+_element_value_type(::Type{<:InfraStore.Probabilistic{T}}) where {T} =
+    _is_element_type(T)
+_element_value_type(::Type{<:InfraStore.Scenarios{T}}) where {T} = _is_element_type(T)
+_element_value_type(::Type) = Float64
 
 # Build the matching IS `TimeSeriesKey` from a catalog row — a `list_metadata`
 # row, which is the store's one listing shape and carries the `id` a key is
@@ -1768,7 +1897,7 @@ end
 # free — it is a property of the stored array, not of the reference.
 function _key_from_row(row)
     kind = _infrastore_is_type(row.time_series_type)
-    value_type = _element_value_type(row.element_type)
+    value_type = _element_value_type(row.time_series_type)
     return TimeSeriesKey{kind{value_type}}(row.id)
 end
 
@@ -1784,6 +1913,7 @@ function _metadata_from_row(row)
     return TimeSeriesMetadata(
         key,
         Int(row.owner_id),
+        String(row.owner_type),
         row.owner_category,
         String(row.name),
         row.initial_timestamp,
@@ -1792,7 +1922,14 @@ function _metadata_from_row(row)
         row.interval,
         isnothing(row.count) ? nothing : Int(row.count),
         isnothing(row.length) ? nothing : Int(row.length),
+        row.percentiles,
         _row_features(row),
+        String(row.element_type),
+        row.data_hash,
+        row.units,
+        row.quantity_kind,
+        _from_store_unit_system(row.unit_system),
+        row.component_field,
     )
 end
 
@@ -1815,29 +1952,30 @@ function get_time_series_key(store::Store, association_id::Integer)
     return _key_from_row(row)
 end
 
-# All matching associations for one owner, as `TimeSeriesKey` objects. The core
+# Every matching catalog row, as IS `TimeSeriesMetadata`. The core
 # `list_metadata` query filters owner / name / resolution / interval / features
 # (periods are canonicalized to ISO-8601 on both write and query, so a regular
 # `Hour(1)` matches a stored `Minute(60)`); an abstract `time_series_type` (or
 # `Deterministic`, which also matches a DST) is not a catalog filter column, so
 # it is applied as a residual on the already-narrowed rows.
+#
+# This is the ONE place a `time_series_type` filter is translated, which is why
+# both the owner-scoped and the store-wide entry points route through it: the
+# store's filter column takes the store's own types, and every IS caller — public
+# or internal — names IS's. Any remaining keyword (`owner_id`, `owner_category`,
+# `name`, `resolution`, `interval`, `name_glob`, `component_field`, `zoneless`)
+# is a filter the store takes as-is and is forwarded untouched.
 function _infrastore_list_metadata(
-    store::Store,
-    owner_id::Integer,
-    owner_category::InfraStore.OwnerCategory;
+    store::Store;
     time_series_type = nothing,
-    name = nothing,
-    resolution = nothing,
-    interval = nothing,
     features::Union{Nothing, Dict} = nothing,
+    kwargs...,
 )
     type_filter = _infrastore_pushable_type(time_series_type)
     feats = _infrastore_features(features)
     rows =
-        InfraStore.list_metadata(store.inner; owner_id = owner_id,
-            owner_category = owner_category, time_series_type = type_filter,
-            name = name, resolution = resolution, interval = interval,
-            features = feats)
+        InfraStore.list_metadata(store.inner; time_series_type = type_filter,
+            features = feats, kwargs...)
     out = TimeSeriesMetadata[]
     for row in rows
         if !isnothing(time_series_type)
@@ -1866,9 +2004,10 @@ function infrastore_owner_list_metadata(
     mgr = _get_time_series_manager_or_throw(owner)
     store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
-    return _infrastore_list_metadata(store, owner_id, category;
+    return _infrastore_list_metadata(store;
+        owner_id = owner_id, owner_category = category,
         time_series_type = time_series_type, name = name, resolution = resolution,
-        interval = interval, features = _infrastore_features(features))
+        interval = interval, features = features)
 end
 
 # Single matching time series key; throws when zero or more than one match.
@@ -1985,14 +2124,13 @@ function infrastore_group_by_hash(
 )
     # Keyed by the 64-char hex form of the content hash (the public contract).
     groups = Dict{String, Vector{Tuple{TimeSeriesOwners, TimeSeriesKey}}}()
-    for row in InfraStore.list_metadata(store.inner)
-        _infrastore_is_type(row.time_series_type) <: DeterministicSingleTimeSeries &&
-            continue
-        owner = id_to_owner(Int(row.owner_id), row.owner_category)
+    for md in list_metadata(store)
+        get_time_series_type(md) <: DeterministicSingleTimeSeries && continue
+        owner = id_to_owner(get_owner_id(md), get_owner_category(md))
         pairs = get!(
             () -> Tuple{TimeSeriesOwners, TimeSeriesKey}[], groups,
-            bytes2hex(row.data_hash))
-        push!(pairs, (owner, _key_from_row(row)))
+            get_data_hash(md))
+        push!(pairs, (owner, get_time_series_key(md)))
     end
     only_shared && filter!(x -> length(x.second) > 1, groups)
     return groups
@@ -2009,26 +2147,25 @@ function infrastore_get_time_series_multiple(
 )
     metas = infrastore_owner_list_metadata(owner; time_series_type = type, name = name,
         resolution = resolution, interval = interval)
+    store = _owner_store(owner)
     Channel() do channel
         for m in metas
-            ts = _infrastore_read_key(owner, get_time_series_key(m))
+            ts = _infrastore_read_key(store, get_time_series_key(m))
             (isnothing(filter_func) || filter_func(ts)) && put!(channel, ts)
         end
     end
 end
 
-# Read one series by its already-resolved key — no catalog re-resolution.
-_infrastore_read_key(owner::TimeSeriesOwners, key::TimeSeriesKey{<:Forecast}) =
-    _infrastore_get_forecast(owner; key = key)
+# Read one series by its already-resolved key — no catalog re-resolution, and
+# store-addressed, since every key here came from the owner's own listing.
+_infrastore_read_key(store::Store, key::TimeSeriesKey{<:Forecast}) =
+    _infrastore_read_forecast(store, key)
 
-_infrastore_read_key(
-    owner::TimeSeriesOwners,
-    key::TimeSeriesKey{<:NonSequentialTimeSeries},
-) =
-    _infrastore_read_non_sequential(owner, key)
+_infrastore_read_key(store::Store, key::TimeSeriesKey{<:NonSequentialTimeSeries}) =
+    _infrastore_read_non_sequential(store, key)
 
-_infrastore_read_key(owner::TimeSeriesOwners, key::TimeSeriesKey{<:SingleTimeSeries}) =
-    _infrastore_read_single(owner, key)
+_infrastore_read_key(store::Store, key::TimeSeriesKey{<:SingleTimeSeries}) =
+    _infrastore_read_single(store, key)
 
 # ---- Store-wide aggregates -------------------------------------------------
 

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -140,289 +140,82 @@ get_owner_category(
     ::Union{SupplementalAttribute, Type{<:SupplementalAttribute}},
 ) = InfraStore.SupplementalAttribute
 
-# ---- Element encoding ------------------------------------------------------
-# Scalars store as a 1-D array; structured elements as a `(length, k)` Float64 array.
-# Every encoder returns the store's canonical `element_type` tag, a first-class catalog
-# column, so reads reconstruct from it rather than from the opaque `ext` payload.
+# ---- Element values ---------------------------------------------------------
+#
+# The store owns the `element_type` encodings and InfraStore.jl implements them
+# (`docs/src/reference/element-types.md`, pinned by
+# `conformance/element_type_vectors.json`). IS supplies only the two ends: how to
+# write one of *its* `FunctionData` values into a row, and which of its types to
+# build when reading one back.
+#
+# Encoding is open dispatch — three methods per type — so an IS value goes into a
+# store constructor directly and is packed at the ABI boundary. Decoding is a
+# lookup, because it starts from a tag string, so it is a table.
 
-# Julia scalar element type -> canonical dtype spelling. Only the widths the
-# store supports; anything else is an unsupported element type, not a silent
-# widening.
-const _INFRASTORE_DTYPE_NAMES = Dict{Type, String}(
-    Float64 => "f64",
-    Float32 => "f32",
-    Int64 => "i64",
-    Int32 => "i32",
-    Int16 => "i16",
-    Int8 => "i8",
-    UInt64 => "u64",
-    UInt32 => "u32",
-    UInt16 => "u16",
-    UInt8 => "u8",
-    Bool => "bool",
+InfraStore.element_type_tag(::AbstractVector{<:LinearFunctionData}) = "linear_function"
+InfraStore.element_row_width(::AbstractVector{<:LinearFunctionData}) = 2
+function InfraStore.write_element_row!(row, fd::LinearFunctionData)
+    row[1] = get_proportional_term(fd)
+    row[2] = get_constant_term(fd)
+    return
+end
+
+InfraStore.element_type_tag(::AbstractVector{<:QuadraticFunctionData}) =
+    "quadratic_function"
+InfraStore.element_row_width(::AbstractVector{<:QuadraticFunctionData}) = 3
+function InfraStore.write_element_row!(row, fd::QuadraticFunctionData)
+    row[1] = get_quadratic_term(fd)
+    row[2] = get_proportional_term(fd)
+    row[3] = get_constant_term(fd)
+    return
+end
+
+InfraStore.element_type_tag(::AbstractVector{<:PiecewiseLinearData}) = "piecewise_linear"
+InfraStore.element_row_width(values::AbstractVector{<:PiecewiseLinearData}) =
+    1 + 2 * maximum(fd -> length(get_points(fd)), values; init = 0)
+function InfraStore.write_element_row!(row, fd::PiecewiseLinearData)
+    pts = get_points(fd)
+    row[1] = length(pts)
+    for (k, p) in enumerate(pts)
+        row[2k] = p.x
+        row[2k + 1] = p.y
+    end
+    return
+end
+
+InfraStore.element_type_tag(::AbstractVector{<:PiecewiseStepData}) = "piecewise_step"
+function InfraStore.element_row_width(values::AbstractVector{<:PiecewiseStepData})
+    widest = maximum(fd -> length(get_x_coords(fd)), values; init = 0)
+    return max(2 * widest, 1)
+end
+function InfraStore.write_element_row!(row, fd::PiecewiseStepData)
+    xs = get_x_coords(fd)
+    ys = get_y_coords(fd)
+    n = length(xs)
+    row[1] = n
+    row[2:(1 + n)] .= xs
+    row[(2 + n):(1 + n + length(ys))] .= ys
+    return
+end
+
+"""
+The IS types a store read decodes composite element values into.
+
+Their constructor signatures are the ones InfraStore.jl's codec calls, so a read
+lands directly in IS's own `FunctionData` with no conversion between.
+"""
+const _IS_ELEMENT_TYPES = (
+    linear_function = LinearFunctionData,
+    quadratic_function = QuadraticFunctionData,
+    piecewise_linear = PiecewiseLinearData,
+    piecewise_step = PiecewiseStepData,
 )
-
-function _element_type_name(::Type{T}) where {T}
-    name = get(_INFRASTORE_DTYPE_NAMES, T, nothing)
-    isnothing(name) &&
-        error("InfraStore backend does not support time series element type $T yet")
-    return name
-end
-
-_storage_array(v::AbstractVector{<:Real}) =
-    (collect(v), _element_type_name(eltype(v)))
-
-# N-D per-step scalars (`SingleTimeSeries{T, N}` / `NonSequentialTimeSeries{T, N}` with
-# `N > 1`): the store takes the array whole, with dim 1 as the time axis, and the read
-# side (`_decode_stored_values`) hands it back unchanged.
-_storage_array(v::AbstractArray{<:Real}) =
-    (collect(v), _element_type_name(eltype(v)))
-
-# Encoded width `k` of a vector of structured elements, without encoding it. The forecast
-# encoder needs the widest window's `k` before it allocates, so this is the single source
-# of truth every `_storage_array` below allocates from.
-_storage_width(::AbstractVector{LinearFunctionData}) = 2
-
-_storage_width(::AbstractVector{QuadraticFunctionData}) = 3
-
-_storage_width(v::AbstractVector{PiecewiseLinearData}) =
-    1 + 2 * maximum(length(get_points(fd)) for fd in v; init = 0)
-
-function _storage_width(v::AbstractVector{PiecewiseStepData})
-    max_n = maximum(length(get_x_coords(fd)) for fd in v; init = 0)
-    iszero(max_n) && return 1
-    return 2 * max_n
-end
-
-_storage_width(::AbstractVector{NTuple{N, Float64}}) where {N} = N
-
-_storage_width(v::AbstractVector) =
-    error("InfraStore backend does not support time series element type $(eltype(v)) yet")
-
-function _storage_array(v::AbstractVector{LinearFunctionData})
-    mat = Matrix{Float64}(undef, length(v), _storage_width(v))
-    for (i, fd) in enumerate(v)
-        mat[i, 1] = get_proportional_term(fd)
-        mat[i, 2] = get_constant_term(fd)
-    end
-    return (mat, "linear_function")
-end
-
-function _storage_array(v::AbstractVector{QuadraticFunctionData})
-    mat = Matrix{Float64}(undef, length(v), _storage_width(v))
-    for (i, fd) in enumerate(v)
-        mat[i, 1] = get_quadratic_term(fd)
-        mat[i, 2] = get_proportional_term(fd)
-        mat[i, 3] = get_constant_term(fd)
-    end
-    return (mat, "quadratic_function")
-end
-
-# Ragged: each step has a variable number of (x, y) points. Store as a
-# `(len, 1 + 2*max_points)` matrix padded with zeros; column 1 of each row is the
-# point count, so `shape[0]` stays the timestep count.
-function _storage_array(v::AbstractVector{PiecewiseLinearData})
-    mat = zeros(Float64, length(v), _storage_width(v))
-    for (i, fd) in enumerate(v)
-        pts = get_points(fd)
-        mat[i, 1] = length(pts)
-        for (j, p) in enumerate(pts)
-            mat[i, 2j] = p.x
-            mat[i, 2j + 1] = p.y
-        end
-    end
-    return (mat, "piecewise_linear")
-end
-
-# Ragged like PiecewiseLinearData, but the x- and y-coordinates have different
-# lengths (`n` x-coords, `n - 1` y-coords/slopes). Store as a `(len, 2*max_n)`
-# matrix: column 1 of each row is the x-coord count `n`, then the `n` x-coords,
-# then the `n - 1` y-coords. Each row is self-describing, so decode needs no
-# global width.
-function _storage_array(v::AbstractVector{PiecewiseStepData})
-    mat = zeros(Float64, length(v), _storage_width(v))
-    for (i, fd) in enumerate(v)
-        xs = get_x_coords(fd)
-        ys = get_y_coords(fd)
-        n = length(xs)
-        mat[i, 1] = n
-        for (j, x) in enumerate(xs)
-            mat[i, 1 + j] = x
-        end
-        for (j, y) in enumerate(ys)
-            mat[i, 1 + n + j] = y
-        end
-    end
-    return (mat, "piecewise_step")
-end
-
-# Fixed-arity `NTuple{N, Float64}` values. Dense, so unlike the ragged piecewise
-# encodings every row is full width; the arity travels in the element type so decode
-# rebuilds the tuple without inferring it from the array shape.
-function _storage_array(v::AbstractVector{NTuple{N, Float64}}) where {N}
-    mat = Matrix{Float64}(undef, length(v), N)
-    for (i, tup) in enumerate(v)
-        for j in 1:N
-            mat[i, j] = tup[j]
-        end
-    end
-    return (mat, "tuple($N,f64)")
-end
-
-_storage_array(v::AbstractVector) =
-    error("InfraStore backend does not support time series element type $(eltype(v)) yet")
-
-# ---- Element encodings ------------------------------------------------------
-# One singleton per stored `element_type` tag, so decoding dispatches instead of
-# comparing the tag string per value. `ScalarEncoding` is also the fallback for any tag
-# this binding does not map; `RowEncoding` marks one-element-per-matrix-row layouts,
-# which is the distinction the forecast and reader paths branch on.
-abstract type ElementEncoding end
-abstract type RowEncoding <: ElementEncoding end
-
-struct ScalarEncoding <: ElementEncoding end
-struct LinearFunctionEncoding <: RowEncoding end
-struct QuadraticFunctionEncoding <: RowEncoding end
-struct PiecewiseLinearEncoding <: RowEncoding end
-struct PiecewiseStepEncoding <: RowEncoding end
-
-# Fixed-arity f64 tuples: the arity is part of the encoding, so `_decode_ntuples` gets it
-# as a type parameter instead of re-parsing the tag. The store's grammar allows other
-# dtypes, which this binding does not map (they fall through to `ScalarEncoding`).
-struct TupleEncoding{N} <: RowEncoding end
-
-const _ELEMENT_ENCODINGS = Dict{String, ElementEncoding}(
-    "linear_function" => LinearFunctionEncoding(),
-    "quadratic_function" => QuadraticFunctionEncoding(),
-    "piecewise_linear" => PiecewiseLinearEncoding(),
-    "piecewise_step" => PiecewiseStepEncoding(),
-)
-
-const _TUPLE_ELEMENT_TYPE = r"^tuple\((\d+),f64\)$"
-
-# The IS value element type an `element_type` tag decodes to — the `T` of a
-# `TimeSeriesData{T}`, and so of the `TimeSeriesKey{<:TimeSeriesData{T}}` that
-# names the series. A tag this binding does not map decodes to raw numbers, whose
-# element type is the array's own dtype; `Float64` is the only dtype the store
-# ever pairs with a mapped tag, and the fallback covers the rest.
-_element_value_type(::ScalarEncoding, dtype::Type) = dtype
-_element_value_type(::LinearFunctionEncoding, ::Type) = LinearFunctionData
-_element_value_type(::QuadraticFunctionEncoding, ::Type) = QuadraticFunctionData
-_element_value_type(::PiecewiseLinearEncoding, ::Type) = PiecewiseLinearData
-_element_value_type(::PiecewiseStepEncoding, ::Type) = PiecewiseStepData
-_element_value_type(::TupleEncoding{N}, ::Type) where {N} = NTuple{N, Float64}
-
-# The string -> type barrier. Deliberately the only type-unstable step: every
-# decode reached from here is dispatched and inferrable.
-_element_encoding(::Nothing) = ScalarEncoding()
-
-function _element_encoding(element_type::AbstractString)
-    haskey(_ELEMENT_ENCODINGS, element_type) && return _ELEMENT_ENCODINGS[element_type]
-    m = match(_TUPLE_ELEMENT_TYPE, element_type)
-    isnothing(m) && return ScalarEncoding()
-    return TupleEncoding{parse(Int, m.captures[1])}()
-end
-
-# Rebuild the `NTuple{N, Float64}` vector from rows of a stored/materialized `(len, N)`
-# matrix. Shared by every decode path.
-function _decode_ntuples(mat, len::Integer, n::Integer)
-    out = Vector{NTuple{n, Float64}}(undef, len)
-    for i in 1:len
-        out[i] = ntuple(j -> mat[i, j], n)
-    end
-    return out
-end
-
-# Reconstruct a single `PiecewiseStepData` from row `i` of a stored/materialized
-# `(len, k)` matrix (see `_storage_array`). Shared by every decode path.
-function _decode_pwl_step_row(mat, i::Integer)
-    n = Int(round(mat[i, 1]))
-    xs = [mat[i, 1 + j] for j in 1:n]
-    ys = [mat[i, 1 + n + j] for j in 1:(n - 1)]
-    return PiecewiseStepData(xs, ys)
-end
-
-# Decode an already-materialized static value array (the inverse of `_storage_array`),
-# one method per [`ElementEncoding`]. `len` is the timestep count (`size(arr, 1)`);
-# each encoded element occupies one row of the `(len, k)` matrix.
-_decode_static_values(arr, ::ScalarEncoding, ::Integer) = arr
-
-_decode_static_values(arr, ::LinearFunctionEncoding, len::Integer) =
-    [LinearFunctionData(arr[i, 1], arr[i, 2]) for i in 1:len]
-
-_decode_static_values(arr, ::QuadraticFunctionEncoding, len::Integer) =
-    [QuadraticFunctionData(arr[i, 1], arr[i, 2], arr[i, 3]) for i in 1:len]
-
-function _decode_static_values(arr, ::PiecewiseLinearEncoding, len::Integer)
-    out = Vector{PiecewiseLinearData}(undef, len)
-    for i in 1:len
-        n = Int(round(arr[i, 1]))
-        out[i] = PiecewiseLinearData([(arr[i, 2j], arr[i, 2j + 1]) for j in 1:n])
-    end
-    return out
-end
-
-_decode_static_values(arr, ::PiecewiseStepEncoding, len::Integer) =
-    [_decode_pwl_step_row(arr, i) for i in 1:len]
-
-_decode_static_values(arr, ::TupleEncoding{N}, len::Integer) where {N} =
-    _decode_ntuples(arr, len, N)
-
-# Decode a whole stored static array, whatever its rank. A 1-D array is scalar
-# data (one value per timestep) and is already the answer; a higher-rank array
-# is either encoded elements or N-D per-step scalars, which the encoding
-# distinguishes. Used by the `SingleTimeSeries` and `NonSequentialTimeSeries`
-# read paths, where the backend materializes the array in memory rather than
-# handing back a content hash.
-_decode_stored_values(data::AbstractVector, ::ElementEncoding) = data
-
-_decode_stored_values(data::AbstractArray, encoding::ElementEncoding) =
-    _decode_static_values(data, encoding, size(data, 1))
-
-# ---- Forecast element encoding ---------------------------------------------
-# Forecast windows of scalars store as a `(horizon, count)` array in the window's own
-# element type, tagged with it — matching the static path, so a `Deterministic{Int64}`
-# round-trips as one instead of coming back widened to Float64.
-# FunctionData windows store as `(horizon, count, k)` tagged with the element
-# type; each window column is encoded with the same scheme as a SingleTimeSeries
-# via `_storage_array`.
-
-function _storage_forecast_array(windows::Vector{<:AbstractVector{<:Real}})
-    count = length(windows)
-    horizon = length(first(windows))
-    T = eltype(first(windows))
-    arr = Matrix{T}(undef, horizon, count)
-    for (c, w) in enumerate(windows)
-        copyto!(view(arr, :, c), w)
-    end
-    return (arr, _element_type_name(T))
-end
-
-# FunctionData windows encode row-wise like a SingleTimeSeries (ragged PWL is
-# padded to the widest row); NTuple windows are the same dense per-row layout at
-# constant width. Both carry the element type that drives window reconstruction.
-function _storage_forecast_array(
-    windows::Vector{<:AbstractVector{<:Union{FunctionData, NTuple}}},
-)
-    count = length(windows)
-    horizon = length(first(windows))
-    k = maximum(_storage_width, windows)
-    arr = zeros(Float64, horizon, count, k)
-    element_type = ""
-    for c in 1:count
-        # Encoded one window at a time: holding all `count` matrices before the copy
-        # would double the forecast's peak footprint.
-        mat, element_type = _storage_array(windows[c])
-        @views arr[:, c, 1:size(mat, 2)] .= mat
-    end
-    return (arr, element_type)
-end
 
 # Densify a Probabilistic/Scenarios forecast — a SortedDict of
 # `(horizon_count, dim1)` window matrices — into the `(dim1, horizon_count,
-# count)` array the store's forecast constructors take, in the windows' own element
-# type and tagged with it, so a `Probabilistic{Int64}` round-trips as one (matching
-# the Deterministic and static paths) instead of coming back widened to Float64.
+# count)` array the store's forecast constructors take, in the windows' own
+# element type, so a `Probabilistic{Int64}` round-trips as one instead of coming
+# back widened to Float64.
 function _dense_forecast_array(forecast::Forecast{T}, dim1::Integer) where {T}
     arr = Array{T, 3}(
         undef, dim1, get_horizon_count(forecast), get_count(forecast),
@@ -430,24 +223,8 @@ function _dense_forecast_array(forecast::Forecast{T}, dim1::Integer) where {T}
     for (ix, window) in enumerate(values(get_data(forecast)))
         arr[:, :, ix] = transpose(window)
     end
-    return (arr, _element_type_name(T))
+    return arr
 end
-
-# Decode window `c` (1-based) of a `(horizon, count, k)` forecast array into a Vector of
-# the corresponding FunctionData or NTuple; the per-window `(horizon, k)` slice decodes
-# with the same row-wise scheme as a static array.
-#
-# Only a `RowEncoding` has a `k` axis, so a scalar tag on a 3-D array is a storage
-# inconsistency, not a pass-through: `_forecast_window` routes 2-D (scalar) arrays
-# elsewhere, and a scalar-tagged window would decode wrong. The tag string travels
-# alongside the encoding purely to name it in that error.
-_decode_forecast_window(
-    ::AbstractArray{<:Real, 3}, ::ScalarEncoding, element_type, ::Integer,
-) = error("InfraStore backend cannot decode forecast element_type $element_type")
-
-_decode_forecast_window(
-    arr::AbstractArray{<:Real, 3}, encoding::RowEncoding, _element_type, c::Integer,
-) = _decode_static_values(@view(arr[:, c, :]), encoding, size(arr, 1))
 
 # ---- Operations (thin delegations to InfraStore) ----------------------
 
@@ -497,21 +274,23 @@ function serialize_single!(
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(sts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(sts),
 )
-    # `get_array` returns the raw `Array{T, N}` (no TimeArray allocation).
-    arr, element_type = _storage_array(get_array(sts))
+    # `get_array` returns the raw `Array{T, N}` (no TimeArray allocation). The
+    # store names the element type from the values and packs them itself.
+    values = get_array(sts)
     tss_ts = InfraStore.SingleTimeSeries(
         get_initial_timestamp(sts),
         get_resolution(sts),
-        arr,
-        name;
-        element_type = element_type,
+        values,
+        name,
     )
     InfraStore.add_time_series!(batch, owner_id, owner_type,
         owner_category, tss_ts; features = features, units = units,
         quantity_kind = quantity_kind,
         unit_system = _to_store_unit_system(unit_system))
-    # The encoded array is what the batch buffers; its byte size drives auto-flush.
-    return sizeof(arr)
+    # Drives auto-flush. A composite element type is packed wider than the values
+    # measure here, which under-counts the buffer — the threshold is a heuristic,
+    # and one that errs toward flushing late rather than toward a wrong answer.
+    return sizeof(values)
 end
 
 """
@@ -539,26 +318,20 @@ function serialize_non_sequential!(
     quantity_kind::Union{Nothing, AbstractString} = get_quantity_kind(nts),
     unit_system::Union{Nothing, AbstractUnitSystem} = get_unit_system(nts),
 )
-    arr, element_type = _storage_array(get_array(nts))
-    tss_ts = InfraStore.NonSequentialTimeSeries(
-        get_timestamps(nts),
-        arr,
-        name;
-        element_type = element_type,
-    )
+    values = get_array(nts)
+    tss_ts = InfraStore.NonSequentialTimeSeries(get_timestamps(nts), values, name)
     InfraStore.add_time_series!(batch, owner_id, owner_type,
         owner_category, tss_ts; features = features, units = units,
         quantity_kind = quantity_kind,
         unit_system = _to_store_unit_system(unit_system))
     # The staged bytes are the encoded array plus the timestamps the association carries.
-    return sizeof(arr) + sizeof(get_timestamps(nts))
+    return sizeof(values) + sizeof(get_timestamps(nts))
 end
 
 # Rebuild the IS `NonSequentialTimeSeries` from whatever the store handed back,
 # however the read was addressed.
 _non_sequential_from_store(nts, name::AbstractString) = NonSequentialTimeSeries(
-    String(name), nts.timestamps,
-    _decode_stored_values(nts.data, _element_encoding(nts.element_type));
+    String(name), nts.timestamps, nts.data;
     units = nts.units, quantity_kind = nts.quantity_kind,
     unit_system = _from_store_unit_system(nts.unit_system),
 )
@@ -938,6 +711,7 @@ function _read_association_by_id(
         return InfraStore.read_by_id(
             store.inner, Int64(get_association_id(key));
             start_time = start_time, len = len, count = count,
+            types = _IS_ELEMENT_TYPES,
         )
     catch e
         # `catch`-block exception inspection: the window checks moved into the
@@ -954,8 +728,7 @@ end
 # Rebuild the IS `SingleTimeSeries` from whatever the store handed back, however
 # the read was addressed.
 _single_from_store(sts, name::AbstractString) = SingleTimeSeries(
-    String(name), sts.initial_timestamp, sts.resolution,
-    _decode_stored_values(sts.data, _element_encoding(sts.element_type));
+    String(name), sts.initial_timestamp, sts.resolution, sts.data;
     units = sts.units, quantity_kind = sts.quantity_kind,
     unit_system = _from_store_unit_system(sts.unit_system),
 )
@@ -1184,10 +957,10 @@ function _infrastore_stage_data!(
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
     ) do initial, resolution, horizon, interval, name
-        arr, element_type = _dense_forecast_array(ts, length(get_percentiles(ts)))
         prob = InfraStore.Probabilistic(initial, resolution, horizon, interval,
-            get_count(ts), Float64.(get_percentiles(ts)), arr, name;
-            element_type = element_type, units = get_units(ts),
+            get_count(ts), Float64.(get_percentiles(ts)),
+            _dense_forecast_array(ts, length(get_percentiles(ts))), name;
+            units = get_units(ts),
             quantity_kind = get_quantity_kind(ts),
             unit_system = _to_store_unit_system(get_unit_system(ts)))
         return (prob, get_count(ts))
@@ -1207,11 +980,12 @@ function _infrastore_stage_data!(
     ) do initial, resolution, horizon, interval, name
         # (horizon_count, count) for scalars; (horizon_count, count, k) tagged
         # with the element type for FunctionData and NTuple windows.
+        # `(horizon_count, count)` of whatever the windows hold; a composite
+        # element type is packed across a further axis by the store.
         windows = collect(values(get_data(ts)))
-        arr, element_type = _storage_forecast_array(windows)
         det = InfraStore.Deterministic(initial, resolution, horizon, interval,
-            length(windows), arr, name;
-            element_type = element_type, units = get_units(ts),
+            length(windows), reduce(hcat, windows), name;
+            units = get_units(ts),
             quantity_kind = get_quantity_kind(ts),
             unit_system = _to_store_unit_system(get_unit_system(ts)))
         return (det, length(windows))
@@ -1229,9 +1003,8 @@ function _infrastore_stage_data!(
     return _infrastore_stage_forecast!(
         batch, mgr, params_cache, owner, ts; features = features,
     ) do initial, resolution, horizon, interval, name
-        arr, element_type = _dense_forecast_array(ts, get_scenario_count(ts))
         scen = InfraStore.Scenarios(initial, resolution, horizon, interval,
-            get_count(ts), arr, name; element_type = element_type,
+            get_count(ts), _dense_forecast_array(ts, get_scenario_count(ts)), name;
             units = get_units(ts), quantity_kind = get_quantity_kind(ts),
             unit_system = _to_store_unit_system(get_unit_system(ts)))
         return (scen, get_count(ts))
@@ -1321,17 +1094,6 @@ _truncate_window(w, ::Nothing) = w
 _truncate_window(w::AbstractVector, len::Int) = w[1:len]
 _truncate_window(w::AbstractMatrix, len::Int) = w[1:len, :]
 
-# Extract window `i` from a stored deterministic-forecast array. Scalar windows
-# are columns of a 2D `(horizon_count, count)` array; encoded FunctionData
-# windows carry trailing coefficient dims (3D). The stored `element_type` names
-# a scalar dtype in the 2-D case (and a DST inherits the metadata of the
-# SingleTimeSeries it shares), so key the decode on the array rank instead.
-_forecast_window(data::AbstractMatrix, ::ElementEncoding, _element_type, i) = data[:, i]
-
-_forecast_window(
-    data::AbstractArray{<:Any, 3}, encoding::ElementEncoding, element_type, i,
-) = _decode_forecast_window(data, encoding, element_type, i)
-
 # A Probabilistic/Scenarios window is stored `(member, horizon)` and transposed to the
 # `(horizon, member)` matrix IS hands users.
 _member_window(data::AbstractArray{<:Any, 3}, i) = permutedims(@view data[:, :, i])
@@ -1340,15 +1102,16 @@ _member_window(data::AbstractArray{<:Any, 3}, i) = permutedims(@view data[:, :, 
 # handed back in its own element type (any scalar dtype), but an encoded element type
 # (FunctionData / NTuple rows, written by another InfraStore client) has no IS member
 # window shape, so name it rather than let the reconstruction mis-slice it.
-_check_member_window_type(::ScalarEncoding, _type, _name, _element_type) = nothing
-
-_check_member_window_type(::ElementEncoding, forecast_type, name, element_type) = throw(
-    ArgumentError(
-        "$forecast_type '$name' is stored with element type $element_type; IS reads " *
-        "$forecast_type windows as per-member scalar matrices only. It was likely " *
-        "written by another InfraStore client.",
-    ),
-)
+function _check_member_window_type(forecast_type, name, element_type)
+    InfraStore.is_composite_element_type(element_type) || return nothing
+    throw(
+        ArgumentError(
+            "$forecast_type '$name' is stored with element type $element_type; IS reads " *
+            "$forecast_type windows as per-member scalar matrices only. It was likely " *
+            "written by another InfraStore client.",
+        ),
+    )
+end
 
 # Reconstruct a forecast read from the store as its user-facing type. Every
 # InfraStore read below is already sliced to the requested window range.
@@ -1393,9 +1156,11 @@ end
 function _forecast_from_store(d::InfraStore.Deterministic, name::String, len)
     _check_forecast_len(d, len)
     # Resolved once per read: the tag is the same for every window.
-    encoding = _element_encoding(d.element_type)
-    window(i) =
-        _truncate_window(_forecast_window(d.data, encoding, d.element_type, i), len)
+    # `d.data` is `(horizon_count, count)` of values, decoded by the read, so a
+    # window is a column of it. Materialized, not a view: the window becomes the
+    # `Vector` a `Deterministic`'s SortedDict holds, and a `SubArray` there would
+    # keep the whole forecast array alive behind every window.
+    window(i) = _truncate_window(d.data[:, i], len)
     data = _assemble_forecast_windows(d.initial_timestamp, d.interval, d.count, window)
     return Deterministic(; name = name, data = data,
         resolution = d.resolution, interval = d.interval, units = d.units,
@@ -1406,9 +1171,7 @@ end
 # `.data` is the canonical (percentile_count, horizon_count, count) array.
 function _forecast_from_store(p::InfraStore.Probabilistic, name::String, len)
     _check_forecast_len(p, len)
-    _check_member_window_type(
-        _element_encoding(p.element_type), Probabilistic, name, p.element_type,
-    )
+    _check_member_window_type(Probabilistic, name, p.element_type)
     window(i) = _truncate_window(_member_window(p.data, i), len)
     data = _assemble_forecast_windows(p.initial_timestamp, p.interval, p.count, window)
     # The positional constructor infers `{T, N}` from the windows; the keyword form pins
@@ -1423,9 +1186,7 @@ end
 # `.data` is the canonical (scenario_count, horizon_count, count) array.
 function _forecast_from_store(s_ts::InfraStore.Scenarios, name::String, len)
     _check_forecast_len(s_ts, len)
-    _check_member_window_type(
-        _element_encoding(s_ts.element_type), Scenarios, name, s_ts.element_type,
-    )
+    _check_member_window_type(Scenarios, name, s_ts.element_type)
     window(i) = _truncate_window(_member_window(s_ts.data, i), len)
     data = _assemble_forecast_windows(
         s_ts.initial_timestamp, s_ts.interval, s_ts.count, window,
@@ -1458,17 +1219,21 @@ _tss_forecast_type(::Type{<:Scenarios}) = InfraStore.Scenarios
 # Orient + decode one raw window into IS's canonical per-window value, matching a single
 # `get_time_series(...).data[timestamp]`. Dispatched on the forecast type, mirroring
 # `_tss_forecast_type` above.
-_decode_forecast_reader_window(::Type{<:Probabilistic}, raw, ::ElementEncoding) =
+#
+# A reader hands back the stored packing — it is the per-timestamp path, where a
+# decode per group would be a cost in the loop it exists to make cheap — so this
+# is where the element type is resolved for a reader window.
+_decode_forecast_reader_window(::Type{<:Probabilistic}, raw, _element_type) =
     permutedims(raw)
 
-_decode_forecast_reader_window(::Type{<:Scenarios}, raw, ::ElementEncoding) =
-    permutedims(raw)
+_decode_forecast_reader_window(::Type{<:Scenarios}, raw, _element_type) = permutedims(raw)
 
-_decode_forecast_reader_window(
-    ::Type{<:AbstractDeterministic}, raw, encoding::ElementEncoding,
-) = _decode_stored_values(raw, encoding)
+_decode_forecast_reader_window(::Type{<:AbstractDeterministic}, raw, element_type) =
+    InfraStore.decode_element_values(
+        raw, something(element_type, "f64"); types = _IS_ELEMENT_TYPES,
+    )
 
-_decode_forecast_reader_window(::Type{T}, raw, ::ElementEncoding) where {T <: Forecast} =
+_decode_forecast_reader_window(::Type{T}, raw, _element_type) where {T <: Forecast} =
     throw(ArgumentError("InfraStore backend cannot decode a window of forecast type $T"))
 
 """
@@ -1500,7 +1265,7 @@ mutable struct ForecastReader{T <: Forecast}
     `element_type` once at build, so a per-timestamp read dispatches instead of
     re-interpreting the tag string.
     """
-    element_encodings::Vector{ElementEncoding}
+    element_types::Vector{Union{Nothing, String}}
     "Per-slot materialized window cache; reset on each read."
     windows::Vector{Any}
     has_read::Bool
@@ -1531,15 +1296,15 @@ function infrastore_build_forecast_reader(
     metas = _infrastore_reader_metadata(store, Int64[e.id for e in tss_entries])
     n = length(tss_entries)
     entries = Vector{ForecastReaderEntry}(undef, n)
-    element_encodings = Vector{ElementEncoding}(undef, n)
+    element_types = Vector{Union{Nothing, String}}(undef, n)
     for (i, (e, fmeta)) in enumerate(zip(tss_entries, metas))
         owner = id_to_owner(Int(fmeta.owner_id), fmeta.owner_category)
-        element_encodings[i] = _element_encoding(fmeta.element_type)
+        element_types[i] = fmeta.element_type
         # `e.slot` is 0-based in the InfraStore store; carry it 1-based for Julia.
         entries[i] = ForecastReaderEntry(owner, _key_from_row(fmeta), e.slot + 1)
     end
     windows = Vector{Any}(nothing, InfraStore.forecast_num_slots(inner))
-    return ForecastReader{T}(inner, store, entries, element_encodings, windows, false)
+    return ForecastReader{T}(inner, store, entries, element_types, windows, false)
 end
 
 """
@@ -1594,7 +1359,7 @@ function get_forecast_window(reader::ForecastReader{T}, entry_index::Integer) wh
     isnothing(cached) || return cached
     raw = InfraStore.forecast_values(reader.inner, entry_index)
     window =
-        _decode_forecast_reader_window(T, raw, reader.element_encodings[entry_index])
+        _decode_forecast_reader_window(T, raw, reader.element_types[entry_index])
     reader.windows[entry.slot] = window
     return window
 end
@@ -1635,7 +1400,7 @@ mutable struct StaticTimeSeriesReader
     Resolved from the stored `element_type` once at build, so a per-timestamp
     read dispatches instead of re-interpreting the tag string.
     """
-    element_encodings::Vector{ElementEncoding}
+    element_types::Vector{Union{Nothing, String}}
     "Per-group materialized values cache; reset on each read."
     values::Vector{Any}
     has_read::Bool
@@ -1654,7 +1419,7 @@ function infrastore_build_static_time_series_reader(
     inner = InfraStore.build_static_reader(store.inner;
         resolution = resolution, name = name, features = features)
     entries = StaticTimeSeriesReaderEntry[]
-    element_encodings = ElementEncoding[]
+    element_types = Union{Nothing, String}[]
     groups = InfraStore.static_groups(inner)
     metas = _infrastore_reader_metadata(
         store,
@@ -1670,12 +1435,12 @@ function infrastore_build_static_time_series_reader(
                 entries,
                 StaticTimeSeriesReaderEntry(owner, _key_from_row(smeta), gi, col),
             )
-            push!(element_encodings, _element_encoding(smeta.element_type))
+            push!(element_types, smeta.element_type)
         end
     end
     values = Vector{Any}(nothing, length(groups))
     return StaticTimeSeriesReader(
-        inner, store, entries, element_encodings, values, false,
+        inner, store, entries, element_types, values, false,
     )
 end
 
@@ -1742,7 +1507,7 @@ function get_static_time_series_value(
         reader.values[entry.group] = vals
     end
     return _static_group_element(
-        vals, entry.column, reader.element_encodings[entry_index],
+        vals, entry.column, reader.element_types[entry_index],
     )
 end
 
@@ -1750,20 +1515,18 @@ end
 # scalar data (one value per column); a higher-rank group carries one element row
 # per column, decoded through the entry's encoding (same scheme as
 # `_decode_static_values`, at `len == 1`).
-_static_group_element(vals::AbstractVector, column::Integer, ::ElementEncoding) =
+_static_group_element(vals::AbstractVector, column::Integer, _element_type) =
     vals[column]
 
-function _static_group_element(
-    vals::AbstractArray, column::Integer, encoding::ElementEncoding,
-)
+function _static_group_element(vals::AbstractArray, column::Integer, element_type)
     colons = ntuple(_ -> Colon(), ndims(vals) - 1)
-    return _decode_element(vals[column, colons...], encoding)
+    row = reshape(vals[column, colons...], 1, :)
+    return only(
+        InfraStore.decode_element_values(
+            row, something(element_type, "f64"); types = _IS_ELEMENT_TYPES,
+        ),
+    )
 end
-
-_decode_element(element, ::ScalarEncoding) = element
-
-_decode_element(element, encoding::RowEncoding) =
-    _decode_static_values(reshape(element, 1, :), encoding, 1)[1]
 
 """Route a narrowed `has_time_series` query to the InfraStore store — the general
 catalog filter, serving every query the owner-scoped probe in `infrastore_has_any`
@@ -1957,12 +1720,20 @@ _infrastore_is_type(s::Symbol) =
 # for deserializing a key that travels as (id, type).
 _time_series_type_from_name(name::AbstractString) = _infrastore_is_type(Symbol(name))
 
-# The dtype a row's values are physically stored in, for the tags this binding
-# does not map to a domain type.
-function _row_value_dtype(row)
-    et = row.element_type
-    isnothing(et) && return Float64
-    dtype = InfraStore._physical_dtype_of(et)
+# The IS value element type a row's `element_type` decodes to — the `T` of a
+# `TimeSeriesData{T}`, and so of the `TimeSeriesKey{<:TimeSeriesData{T}}` naming
+# the series. A composite tag names one of IS's `FunctionData`; anything else
+# decodes to raw numbers, whose element type is the dtype the store holds them in.
+function _element_value_type(element_type)
+    isnothing(element_type) && return Float64
+    kind = InfraStore._element_kind(element_type)
+    if kind === :tuple
+        m = match(InfraStore._TUPLE_TAG, element_type)
+        m === nothing || return NTuple{parse(Int, m.captures[1]), Float64}
+    elseif kind !== nothing && haskey(_IS_ELEMENT_TYPES, kind)
+        return _IS_ELEMENT_TYPES[kind]
+    end
+    dtype = InfraStore._physical_dtype_of(element_type)
     return isnothing(dtype) ? Float64 : dtype
 end
 
@@ -1977,8 +1748,7 @@ end
 # free — it is a property of the stored array, not of the reference.
 function _key_from_row(row)
     kind = _infrastore_is_type(row.time_series_type)
-    value_type =
-        _element_value_type(_element_encoding(row.element_type), _row_value_dtype(row))
+    value_type = _element_value_type(row.element_type)
     return TimeSeriesKey{kind{value_type}}(row.id)
 end
 

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -2059,6 +2059,18 @@ function infrastore_get_time_series_key(
     return get_time_series_key(items[1])
 end
 
+# The catalog row `key` resolves to under `owner`, translated into IS's
+# `TimeSeriesMetadata`. One primary-key fetch: the row that answers the call is
+# the same row the owner is checked against, so there is no second lookup for the
+# two to disagree about.
+function infrastore_get_time_series_metadata(
+    owner::TimeSeriesOwners,
+    key::TimeSeriesKey,
+)
+    _, row = _store_and_association(owner, key)
+    return _metadata_from_row(row)
+end
+
 # Content hash (64-char lowercase hex, the documented public form of the
 # wrapper's 32-byte hash) of the array `key` resolves to under `owner`. The
 # catalog row the `association_id` names carries the hash, so this is one

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -562,13 +562,17 @@ function get_non_sequential(
     nts = InfraStore.get_time_series(InfraStore.NonSequentialTimeSeries, store.inner,
         owner_id,
         owner_category, name; features = features, time_range = time_range)
-    values = _decode_stored_values(nts.data, _element_encoding(nts.element_type))
-    return NonSequentialTimeSeries(
-        String(name), nts.timestamps, values; units = nts.units,
-        quantity_kind = nts.quantity_kind,
-        unit_system = _from_store_unit_system(nts.unit_system),
-    )
+    return _non_sequential_from_store(nts, name)
 end
+
+# Rebuild the IS `NonSequentialTimeSeries` from whatever the store handed back,
+# however the read was addressed.
+_non_sequential_from_store(nts, name::AbstractString) = NonSequentialTimeSeries(
+    String(name), nts.timestamps,
+    _decode_stored_values(nts.data, _element_encoding(nts.element_type));
+    units = nts.units, quantity_kind = nts.quantity_kind,
+    unit_system = _from_store_unit_system(nts.unit_system),
+)
 
 function get_num_time_series(store::Store)
     c = InfraStore.get_counts(store.inner)
@@ -632,52 +636,43 @@ much smaller the file got. An in-memory store has no file to rewrite.
 compact_time_series!(store::Store) = InfraStore.compact!(store.inner)
 
 """
-Remove exactly the association that a fully-resolved `TimeSeriesKey` names.
+Remove exactly the association that a `TimeSeriesKey` names, and nothing else.
 
-The key carries the complete stored identity — type, name, resolution, interval,
-and the *whole* feature set — so this routes to the store's exact-key removal
-(the core matches the features by set hash) instead of the subset feature filter
-that the by-name removals use. A sibling series whose feature set is a strict
-superset of the key's therefore survives, which the subset filter would have
-deleted along with the keyed series.
+The key's `association_id` names one catalog row, so this is the store's
+`remove_by_ids!` — a single id-addressed call that deletes that row and no
+other. The attribute-addressed removal it replaces was blunter than the
+docstring implied: an identity with no interval matches *any* interval, so a
+keyed removal could sweep a whole forecast family, and a `nothing` resolution
+likewise. Neither is reachable through an id.
 """
 function infrastore_remove_time_series!(
     store::Store,
     owner::TimeSeriesOwners,
     key::TimeSeriesKey,
 )
-    owner_id = get_owner_id(key)
-    category = get_owner_category(key)
-    name = get_name(key)
+    # `owner` is an argument in its own right, so it is confirmed against the key
+    # before anything is deleted; the id itself is taken as valid.
+    _check_association_owner(owner, key)
     try
-        InfraStore.remove_time_series!(
-            _infrastore_type(get_time_series_type(key)),
-            store.inner,
-            owner_id,
-            category,
-            name;
-            resolution = get_resolution(key),
-            interval = get_interval(key),
-            features = get_features(key),
-        )
+        InfraStore.remove_by_ids!(store.inner, [Int64(get_association_id(key))])
     catch e
         # `catch`-block exception inspection: the core reports both conditions
         # through its own error types, which IS maps to the errors callers
-        # dispatch on. The DST-orphan guard can only fire for a SingleTimeSeries
-        # key; an InvalidParameterError for any other key type is something else
-        # and propagates as itself.
-        if e isa InfraStore.InvalidParameterError &&
-           get_time_series_type(key) <: SingleTimeSeries
+        # dispatch on. `InvalidParameterError` out of a removal is the core's
+        # orphaned-DST guard, which fires only for a SingleTimeSeries backing one.
+        if e isa InfraStore.InvalidParameterError
             throw(
                 ArgumentError(
-                    "Cannot remove SingleTimeSeries '$name' because it is attached to a " *
-                    "DeterministicSingleTimeSeries."),
+                    "Cannot remove SingleTimeSeries '$(get_name(key))' because it is " *
+                    "attached to a DeterministicSingleTimeSeries."),
             )
         elseif e isa InfraStore.NotFoundError
             throw(
                 ArgumentError(
-                    "No time series matches the key $(summary(key)) with name='$name' " *
-                    "on $(summary(owner)); it may already have been removed."),
+                    "TimeSeriesKey names association_id=$(get_association_id(key)), which " *
+                    "is no longer in this store: $(summary(key)) with " *
+                    "name='$(get_name(key))' on $(summary(owner)) may already have been " *
+                    "removed."),
             )
         end
         rethrow()
@@ -875,68 +870,129 @@ function _validate_window(index::Integer, len, total::Integer)
     return n
 end
 
-# Key-addressed SingleTimeSeries read: the key carries the exact stored attributes
-# plus the `(initial_timestamp, resolution, length)` needed to validate the
-# requested window, so no catalog query is issued. The store slices the half-open
-# `[start, start + n·resolution)` window server-side; only the requested steps are
-# read and decoded.
+# ---- Key addressing --------------------------------------------------------
+# `association_id` is the identity of a stored association: the store mints it,
+# never reissues it, and every other field a `TimeSeriesKey` carries is a
+# snapshot of the catalog row it names. So a key is addressed by its id alone —
+# its `name`, `resolution`, `interval` and `features` are display state, never
+# lookup arguments. A key handed to an accessor is otherwise taken as valid:
+# nothing probes it for staleness first, and a dangling id surfaces as an error
+# from the call that was already committed to acting on it.
+#
+# The exception is the owner. `owner` is an argument in its own right, not
+# something the id can confirm, so every accessor checks that the association is
+# actually attached to the owner it was handed. Without it,
+# `remove_time_series!(sys, wrong_component, key)` would quietly delete a series
+# off some other component.
+#
+# How far that reaches is bounded by the core's id-addressed surface:
+# `read_by_ids` (whole series, no slicing), `remove_by_ids!`, and
+# `get_metadata_by_id`. A whole-series read and a removal are therefore each one
+# id-addressed call. A *sliced* read has no id-addressed entry point — the store
+# needs a time range, and `read_by_ids` takes none — so there the id resolves the
+# row and the row's own attributes drive the read. The id stays the only thing
+# the caller supplies, but it costs a second round trip until `read_by_ids`
+# grows a time range.
 
-# A key is a snapshot of one stored association, and every key carries the id the store
-# minted for it. Ids are never reissued, so "does this id still resolve?" is the exact
-# staleness test: if the series was removed (and possibly re-added under the same name and
-# features), the id is gone. This is a primary-key probe that fetches no row. Checking it
-# up front means every later mismatch is the caller's — an out-of-range `start_time`,
-# `len`, or `count` — and is reported as such rather than blamed on a stale key.
-function _throw_if_key_stale(store::Store, key::TimeSeriesKey)
+# The catalog row `id` names. `nothing` from the core means the row is gone, which
+# is an error here: the caller is already committed to acting on it.
+function _resolve_association(store::Store, key::TimeSeriesKey)
     id = get_association_id(key)
-    InfraStore.association_exists(store.inner, id) && return
+    row = InfraStore.get_metadata_by_id(store.inner, Int64(id))
+    isnothing(row) && throw(
+        ArgumentError(
+            "TimeSeriesKey names association_id=$id, which is no longer in this " *
+            "store: '$(get_name(key))' was removed after the key was obtained.",
+        ),
+    )
+    return row
+end
+
+# Confirm the association `key` names is attached to `owner`. Checked against the
+# catalog row wherever one is resolved anyway (removal, sliced reads); against the
+# key's own owner fields on the paths that address the store by id alone and never
+# fetch a row, where it is still the check that catches the mistake this guards
+# against — the caller naming the wrong component.
+_check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey) =
+    _check_association_owner(owner, key, get_owner_id(key), get_owner_category(key))
+
+_check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey, row) =
+    _check_association_owner(owner, key, row.owner_id, row.owner_category)
+
+function _check_association_owner(
+    owner::TimeSeriesOwners,
+    key::TimeSeriesKey,
+    association_owner_id,
+    association_category,
+)
+    owner_id, category = _infrastore_owner_id_category(owner)
+    (association_owner_id == owner_id && association_category == category) && return
     throw(
         ArgumentError(
-            "TimeSeriesKey is stale: the $(nameof(get_time_series_type(key))) " *
-            "'$(get_name(key))' it names (association_id=$id) is no longer in the " *
-            "store; it was removed after the key was obtained. Re-fetch the key with " *
+            "TimeSeriesKey '$(get_name(key))' (association_id=$(get_association_id(key))) " *
+            "is attached to owner id=$association_owner_id, not to $(summary(owner)); " *
+            "pass the owner it belongs to, or look up a key on this one with " *
             "get_time_series_key.",
         ),
     )
 end
 
+# The store an owner's manager holds, and the row `key`'s id resolves to in it,
+# confirmed to be attached to `owner`.
+function _store_and_association(owner::TimeSeriesOwners, key::TimeSeriesKey)
+    store = _get_time_series_manager_or_throw(owner).data_store
+    row = _resolve_association(store, key)
+    _check_association_owner(owner, key, row)
+    return (store, row)
+end
+
+# The one association `id` names, read whole in a single id-addressed call — no
+# catalog round trip, and no attribute off the key. `read_by_ids` takes no time
+# range, so this is the unsliced path only; it throws the core's `NotFoundError`
+# when the id dangles, which the public accessors map to an `ArgumentError`.
+_read_association_by_id(store::Store, key::TimeSeriesKey) =
+    only(InfraStore.read_by_ids(store.inner, [Int64(get_association_id(key))]))
+
+# Rebuild the IS `SingleTimeSeries` from whatever the store handed back, however
+# the read was addressed.
+_single_from_store(sts, name::AbstractString) = SingleTimeSeries(
+    String(name), sts.initial_timestamp, sts.resolution,
+    _decode_stored_values(sts.data, _element_encoding(sts.element_type));
+    units = sts.units, quantity_kind = sts.quantity_kind,
+    unit_system = _from_store_unit_system(sts.unit_system),
+)
+
+# Key-addressed SingleTimeSeries read. Unsliced, the id is the whole request. A
+# window needs the `(initial_timestamp, resolution, length)` grid to validate
+# against and a time range to push down, neither of which `read_by_ids` takes,
+# so it resolves the row and reads the half-open
+# `[start, start + n·resolution)` window server-side — only the requested steps
+# are read and decoded.
 function _infrastore_read_single(
     owner::TimeSeriesOwners,
     key::StaticTimeSeriesKey;
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
-    mgr = _get_time_series_manager_or_throw(owner)
-    store = mgr.data_store
-    _throw_if_key_stale(store, key)
-    owner_id, _, category = _infrastore_owner_args(owner)
-    name = get_name(key)
-    initial_timestamp = get_initial_timestamp(key)
-    resolution = get_resolution(key)
-    total = get_length(key)
-    feats = get_features(key)
-
-    start = if isnothing(start_time)
-        initial_timestamp
-    else
-        start_time
+    store = _get_time_series_manager_or_throw(owner).data_store
+    if isnothing(start_time) && isnothing(len)
+        _check_association_owner(owner, key)
+        sts = _read_association_by_id(store, key)::InfraStore.SingleTimeSeries
+        return _single_from_store(sts, sts.name)
     end
+    row = _resolve_association(store, key)
+    _check_association_owner(owner, key, row)
+    initial_timestamp = row.initial_timestamp
+    resolution = row.resolution
+    start = isnothing(start_time) ? initial_timestamp : start_time
     index = compute_time_array_index(initial_timestamp, start, resolution)
-    n = _validate_window(index, len, total)
-    time_range = if (isnothing(start_time) && isnothing(len))
-        nothing
-    else
-        (start, start + resolution * n)
-    end
-    sts = InfraStore.get_time_series(InfraStore.SingleTimeSeries, store.inner, owner_id,
-        category, name;
-        resolution = resolution, features = feats, time_range = time_range)
-    values = _decode_stored_values(sts.data, _element_encoding(sts.element_type))
-    return SingleTimeSeries(
-        String(name), sts.initial_timestamp, sts.resolution, values; units = sts.units,
-        quantity_kind = sts.quantity_kind,
-        unit_system = _from_store_unit_system(sts.unit_system),
-    )
+    n = _validate_window(index, len, row.length)
+    sts =
+        InfraStore.get_time_series(InfraStore.SingleTimeSeries, store.inner, row.owner_id,
+            row.owner_category, row.name;
+            resolution = resolution, features = _row_features(row),
+            time_range = (start, start + resolution * n))
+    return _single_from_store(sts, row.name)
 end
 
 """
@@ -962,11 +1018,11 @@ function infrastore_get_time_series(
     return _infrastore_read_non_sequential(owner, key; start_time = start_time, len = len)
 end
 
-# Key-addressed NonSequentialTimeSeries read (no catalog re-resolution). Only `start_time`
-# pushes down: `len` is a POINT COUNT, and turning it into an end timestamp needs to know
-# which irregular timestamps exist — which is what the read is for. The store has no
-# sentinel for "no upper bound" (`typemax(DateTime)` overflows the FFI's millisecond range
-# check), so the suffix read stands one in and `len` slices the result client-side.
+# Key-addressed NonSequentialTimeSeries read. Only `start_time` pushes down: `len` is a
+# POINT COUNT, and turning it into an end timestamp needs to know which irregular
+# timestamps exist — which is what the read is for. The store has no sentinel for "no upper
+# bound" (`typemax(DateTime)` overflows the FFI's millisecond range check), so the suffix
+# read stands one in and `len` slices the result client-side.
 const _FAR_FUTURE_DATETIME = Dates.DateTime(9999, 12, 31, 23, 59, 59)
 function _infrastore_read_non_sequential(
     owner::TimeSeriesOwners,
@@ -974,21 +1030,24 @@ function _infrastore_read_non_sequential(
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
-    mgr = _get_time_series_manager_or_throw(owner)
-    store = mgr.data_store
-    _throw_if_key_stale(store, key)
-    owner_id, _, category = _infrastore_owner_args(owner)
-    feats = get_features(key)
+    store = _get_time_series_manager_or_throw(owner).data_store
+    if isnothing(start_time) && isnothing(len)
+        _check_association_owner(owner, key)
+        raw = _read_association_by_id(store, key)::InfraStore.NonSequentialTimeSeries
+        return _non_sequential_from_store(raw, raw.name)
+    end
+    row = _resolve_association(store, key)
+    _check_association_owner(owner, key, row)
+    name = row.name
     time_range = if isnothing(start_time)
         nothing
     else
         (start_time, _FAR_FUTURE_DATETIME)
     end
     nts = get_non_sequential(
-        store, owner_id, category, get_name(key);
-        features = feats, time_range = time_range,
+        store, row.owner_id, row.owner_category, name;
+        features = _row_features(row), time_range = time_range,
     )
-    (isnothing(start_time) && isnothing(len)) && return nts
 
     # Slice the values directly (not via a TimeArray) so FunctionData / N-D series slice
     # too. With `start_time` given, `nts` is already the store-side suffix, so this narrows
@@ -1010,7 +1069,7 @@ function _infrastore_read_non_sequential(
     vals = full[index:(index + n - 1), colons...]
     # A slice is the same values over a shorter window, so it keeps the label.
     return NonSequentialTimeSeries(
-        String(get_name(key)), timestamps[index:(index + n - 1)], vals;
+        String(name), timestamps[index:(index + n - 1)], vals;
         units = get_units(nts), quantity_kind = get_quantity_kind(nts),
         unit_system = get_unit_system(nts))
 end
@@ -1359,8 +1418,10 @@ function _assemble_forecast_windows(initial_timestamp, interval, count, window)
 end
 
 """Reconstruct a forecast from the InfraStore store (matches the STORED type),
-honoring `start_time` / `count` slicing on the window axis. Pass `key` (a
-previously resolved `ForecastKey`) to skip the catalog resolution query."""
+honoring `start_time` / `count` slicing on the window axis. Pass `key` to address
+the forecast by its `association_id` instead of resolving one by name; the `name`
+argument is then only a label for error messages, and every lookup attribute
+comes off the row the id resolves to."""
 function _infrastore_get_forecast(
     owner, name;
     time_series_type::Type{<:Forecast} = Forecast,
@@ -1372,25 +1433,32 @@ function _infrastore_get_forecast(
     key::Union{Nothing, ForecastKey} = nothing,
     features::Union{Nothing, Dict} = nothing,
 )
-    mgr = _get_time_series_manager_or_throw(owner)
-    store = mgr.data_store
-    owner_id, _, category = _infrastore_owner_args(owner)
     # Resolve the unique forecast of the requested type matching a possibly-partial
     # (subset) feature / resolution / interval query, then read it by its exact stored
     # attributes. `interval` matters when one series name carries several forecasts
     # that differ only by interval (`transform_single_time_series!` with
     # `delete_existing = false`); without it the lookup is ambiguous. The type is part
     # of the lookup too: one name can carry a Deterministic and a Probabilistic.
-    matched = if isnothing(key)
-        infrastore_get_time_series_key(
-            owner, time_series_type, name;
-            resolution = resolution, interval = interval, features = features,
+    #
+    # A caller-supplied key skips that query: its `association_id` names the row
+    # directly, and the key rebuilt from that row — not the caller's snapshot of it —
+    # is what every lookup below is driven from.
+    store, matched = if isnothing(key)
+        mgr = _get_time_series_manager_or_throw(owner)
+        (
+            mgr.data_store,
+            infrastore_get_time_series_key(
+                owner, time_series_type, name;
+                resolution = resolution, interval = interval, features = features,
+            ),
         )
     else
-        # A caller-supplied key may predate a removal; a freshly resolved one cannot.
-        _throw_if_key_stale(store, key)
-        key
+        s, row = _store_and_association(owner, key)
+        (s, _key_from_row(row))
     end
+    owner_id = get_owner_id(matched)
+    category = get_owner_category(matched)
+    name = get_name(matched)
     feats = get_features(matched)
     resolution = get_resolution(matched)
     # `len` truncates each window to its first `len` steps; validate it against the
@@ -2264,34 +2332,13 @@ function infrastore_get_time_series_key(
 end
 
 # Content hash (64-char lowercase hex, the documented public form of the
-# wrapper's 32-byte hash) of the array `key` resolves to under `owner`. Pushes
-# the key's type/name/resolution/interval into one catalog query (a `nothing`
-# resolution or interval — a key type that has none — constrains nothing), so
-# the store applies its canonical comparisons; only the type residual and the
-# whole-feature-set match stay in-memory.
+# wrapper's 32-byte hash) of the array `key` resolves to under `owner`. The
+# catalog row the `association_id` names carries the hash, so this is one
+# primary-key fetch — no filtered listing, and no in-memory type residual or
+# whole-feature-set match to sift its results with.
 function infrastore_get_time_series_hash(owner::TimeSeriesOwners, key::TimeSeriesKey)
-    mgr = _get_time_series_manager_or_throw(owner)
-    store = mgr.data_store
-    owner_id, _, category = _infrastore_owner_args(owner)
-    T = get_time_series_type(key)
-    rows = InfraStore.list_array_groups(store.inner; owner_id = owner_id,
-        owner_category = category,
-        time_series_type = _infrastore_pushable_type(T), name = get_name(key),
-        resolution = get_resolution(key), interval = get_interval(key))
-    target_feats = get_features(key)
-    for row in rows
-        _infrastore_type_matches(_infrastore_is_type(row.time_series_type), T) || continue
-        row.features == target_feats || continue
-        return bytes2hex(row.data_hash)
-    end
-    throw(
-        ArgumentError(
-            "No time series matched the key for $(summary(owner)): " *
-            "type=$T name=$(get_name(key)) resolution=$(get_resolution(key)) " *
-            "interval=$(get_interval(key)) features=$(target_feats). The series may " *
-            "have been removed; re-fetch the key with get_time_series_key.",
-        ),
-    )
+    _, row = _store_and_association(owner, key)
+    return bytes2hex(row.data_hash)
 end
 
 # Content hashes for a homogeneous collection of owners, resolved by ONE catalog

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -753,6 +753,18 @@ function _store_and_association(owner::TimeSeriesOwners, key::TimeSeriesKey)
     return (store, _check_association_owner(owner, key, _resolve_association(store, key)))
 end
 
+# `len` and `count` are step and window COUNTS, and the store takes them as
+# `UInt64`: a negative one fails in the ccall marshalling with an `InexactError`
+# that names neither the argument nor the accessor, so the sign is checked here.
+# Only the sign — whether a window of a legal size fits the row is the core's
+# answer, and it gives the specific one.
+_check_window_count(::Symbol, ::Nothing) = nothing
+
+function _check_window_count(name::Symbol, n::Integer)
+    n < 1 && throw(ArgumentError("`$name` must be >= 1; got $n"))
+    return
+end
+
 # The association `key` names, or the window of it the accessor's arguments name,
 # in ONE id-addressed call: no catalog round trip, and no attribute off the key.
 # The core resolves the window against the row its primary-key lookup returned
@@ -796,6 +808,8 @@ function _read_association_by_id(
     len = nothing,
     count = nothing,
 )
+    _check_window_count(:len, len)
+    _check_window_count(:count, count)
     try
         return InfraStore.read_by_id(
             store.inner, Int64(get_association_id(key));
@@ -811,7 +825,11 @@ function _read_association_by_id(
         # carried through; only the type is remapped, to keep the accessors'
         # public `ArgumentError` contract.
         e isa InfraStore.InvalidParameterError && throw(ArgumentError(e.msg))
-        e isa InfraStore.OwnerMismatchError &&
+        # Only reachable on the owner-addressed path: a `nothing` owner sends no
+        # owner into the read, so the core has nothing to mismatch it against.
+        # Guarded anyway, so that if it ever does arrive here the handler reports
+        # the store's error rather than raising a `MethodError` over it.
+        e isa InfraStore.OwnerMismatchError && !isnothing(owner) &&
             throw(_not_this_owners_key(owner, key, e.msg))
         rethrow()
     end
@@ -1150,6 +1168,9 @@ function _infrastore_read_forecast(
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,
 )
+    # `count` is checked by the read below; `len` never reaches the store on this
+    # path — it truncates the windows here — so it is checked here.
+    _check_window_count(:len, len)
     raw = _read_association_by_id(
         target, key; start_time = start_time, count = count,
     )
@@ -1930,6 +1951,9 @@ function _metadata_from_row(row)
         row.quantity_kind,
         _from_store_unit_system(row.unit_system),
         row.component_field,
+        Dims(row.element_shape),
+        row.time_reference,
+        row.application_data,
     )
 end
 
@@ -2264,36 +2288,21 @@ function infrastore_list_owner_ids(
     resolution::Union{Nothing, Dates.Period} = nothing,
 )
     category = get_owner_category(owner_type)
-    # Without a resolution filter, enumerate owner ids in the core (optionally
-    # per concrete subtype). With one, the resolution is pushed into the core
-    # key listing and the strict subtype match applied on the rows.
-    if isnothing(resolution)
-        isnothing(time_series_type) &&
-            return InfraStore.list_owner_ids(store.inner, category)
-        ids = Set{Int}()
-        for t in _infrastore_subtype_types(time_series_type)
-            union!(
-                ids,
-                InfraStore.list_owner_ids(store.inner, category; time_series_type = t),
-            )
-        end
-        return collect(ids)
-    end
-    # Same `Deterministic`-family semantics as the branch above (the core widens a
-    # pushed `Deterministic` filter to DST rows), so the answer does not change with
-    # the presence of a `resolution` filter.
+    # Answered in the core, which takes both filters: one DISTINCT query, or one
+    # per concrete subtype when the strict `<:` match spans several. Listing the
+    # matching rows to collect their owner ids would decode a full catalog row —
+    # feature dict, hash bytes, every period column — per association, to read one
+    # integer off each.
+    isnothing(time_series_type) &&
+        return InfraStore.list_owner_ids(store.inner, category; resolution = resolution)
     ids = Set{Int}()
-    for row in
-        InfraStore.list_metadata(store.inner; owner_category = category,
-        time_series_type = _infrastore_pushable_type(time_series_type),
-        resolution = resolution)
-        if !isnothing(time_series_type)
-            _infrastore_type_matches(
-                _infrastore_is_type(row.time_series_type),
-                time_series_type,
-            ) || continue
-        end
-        push!(ids, Int(row.owner_id))
+    for t in _infrastore_subtype_types(time_series_type)
+        union!(
+            ids,
+            InfraStore.list_owner_ids(
+                store.inner, category; time_series_type = t, resolution = resolution,
+            ),
+        )
     end
     return collect(ids)
 end

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -1551,6 +1551,14 @@ mutable struct StaticTimeSeriesReader
     rather than once per value.
     """
     group_element_types::Vector{Union{Nothing, String}}
+    """
+    The stretch of `entries` belonging to each group. Entries are built
+    group-major and in column order, so a group's entries are contiguous and
+    `entries[group_ranges[g]][c]` is column `c` of group `g` — which is what lets
+    [`get_static_time_series_group_entries`](@ref) hand back a view that lines up
+    positionally with the group's values.
+    """
+    group_ranges::Vector{UnitRange{Int}}
     "Per-group values cache, decoded where `group_element_types` says so; reset on each read."
     values::Vector{Any}
     has_read::Bool
@@ -1572,6 +1580,7 @@ function infrastore_build_static_time_series_reader(
     element_types = Union{Nothing, String}[]
     groups = InfraStore.static_groups(inner)
     group_element_types = Vector{Union{Nothing, String}}(undef, length(groups))
+    group_ranges = Vector{UnitRange{Int}}(undef, length(groups))
     metas = _infrastore_reader_metadata(
         store,
         Int64[id for group in groups for id in group.ids],
@@ -1580,6 +1589,7 @@ function infrastore_build_static_time_series_reader(
     for (gi, group) in enumerate(groups)
         shared = nothing
         uniform = true
+        first_entry = i + 1
         for col in eachindex(group.ids)
             i += 1
             smeta = metas[i]
@@ -1596,10 +1606,12 @@ function infrastore_build_static_time_series_reader(
             end
         end
         group_element_types[gi] = _shared_group_element_type(group, shared, uniform)
+        group_ranges[gi] = first_entry:i
     end
     values = Vector{Any}(nothing, length(groups))
     return StaticTimeSeriesReader(
-        inner, store, entries, element_types, group_element_types, values, false,
+        inner, store, entries, element_types, group_element_types, group_ranges,
+        values, false,
     )
 end
 
@@ -1679,19 +1691,73 @@ function get_static_time_series_value(
     reader::StaticTimeSeriesReader,
     entry_index::Integer,
 )
+    entry = reader.entries[entry_index]
+    return _static_group_element(
+        get_static_time_series_group_values(reader, entry.group),
+        entry.column,
+        reader.element_types[entry_index],
+    )
+end
+
+"""
+$(TYPEDSIGNATURES)
+Columnar group `group_index`'s values from the most recent
+[`read_static_time_series_values!`](@ref): one value per column, lining up
+positionally with [`get_static_time_series_group_entries`](@ref). The exception
+is a multidimensional scalar series, which keeps the stored
+`(num_columns, element_shape...)` shape, where column `c`'s value is the slice
+`vals[c, ..]`.
+
+This is the allocation-free way to sweep.
+[`get_static_time_series_value`](@ref) hands back one entry at a time out of a
+cache the reader cannot give a concrete type, so every pull costs a dynamic
+dispatch and boxes its result — at 100k entries ~0.09 µs and 32 bytes per value,
+and it worsens as the reader grows, because the box traffic outgrows the cache.
+A group is one concrete array, so a loop that takes it through a function
+barrier pays neither, and stays flat with size:
+
+```julia
+for g in 1:get_num_static_time_series_groups(reader)
+    consume!(out, get_static_time_series_group_values(reader, g),
+        get_static_time_series_group_entries(reader, g))
+end
+```
+
+The barrier is the whole point: `consume!(out, vals::Vector{Float64}, entries)`
+specializes on the group's element type, so `vals[i]` is a plain load. Written
+inline against the `Any` this returns, the loop would be no faster than the
+per-value accessor.
+
+Materializes (and decodes) the group on first touch after a read, into the same
+cache [`get_static_time_series_value`](@ref) uses, so the two may be mixed and
+the group is still built at most once per read.
+"""
+function get_static_time_series_group_values(
+    reader::StaticTimeSeriesReader,
+    group_index::Integer,
+)
     reader.has_read || throw(
         ArgumentError(
             "call read_static_time_series_values! before reading values"))
-    entry = reader.entries[entry_index]
-    vals = reader.values[entry.group]
+    vals = reader.values[group_index]
     if isnothing(vals)
-        vals = _materialize_static_group(reader, entry.group)
-        reader.values[entry.group] = vals
+        vals = _materialize_static_group(reader, group_index)
+        reader.values[group_index] = vals
     end
-    return _static_group_element(
-        vals, entry.column, reader.element_types[entry_index],
-    )
+    return vals
 end
+
+"""
+$(TYPEDSIGNATURES)
+The entries of columnar group `group_index` (1-based), as a view in column
+order — so entry `i` of this view owns value `i` of
+[`get_static_time_series_group_values`](@ref). Needs no read; the grouping is
+fixed when the reader is built.
+"""
+get_static_time_series_group_entries(
+    reader::StaticTimeSeriesReader,
+    group_index::Integer,
+) = view(reader.entries, reader.group_ranges[group_index])
 
 # One group's values for the current timestamp, decoded to one value per column
 # when every column shares a composite element type.

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -1527,8 +1527,10 @@ end
 """
 A timestamp-oriented reader over every `SingleTimeSeries` matching a build
 filter. Drive it with [`read_static_time_series_values!`](@ref), then pull each
-entry's value with [`get_static_time_series_value`](@ref). Build one with
-`build_static_time_series_reader(data; ...)`.
+entry's value with [`get_static_time_series_value`](@ref) — or, to sweep every
+entry, take whole groups with [`get_static_time_series_group_values`](@ref) and
+[`get_static_time_series_group_entries`](@ref), which is markedly cheaper at
+scale. Build one with `build_static_time_series_reader(data; ...)`.
 
 The matched series are packed into columnar groups; one physical `.h5` read per
 group serves every entry in it at a timestamp — see
@@ -1668,8 +1670,9 @@ Base.length(reader::StaticTimeSeriesReader) = length(reader.entries)
 """
 $(TYPEDSIGNATURES)
 Read the value of every entry at `timestamp`, performing one `.h5` read per
-columnar group. Follow with [`get_static_time_series_value`](@ref). Throws if
-`timestamp` is off the reader's grid.
+columnar group. Follow with [`get_static_time_series_value`](@ref) per entry, or
+[`get_static_time_series_group_values`](@ref) per group to sweep them all.
+Throws if `timestamp` is off the reader's grid.
 """
 function read_static_time_series_values!(
     reader::StaticTimeSeriesReader,
@@ -1686,6 +1689,12 @@ $(TYPEDSIGNATURES)
 The decoded value for entry `entry_index` (1-based) from the most recent
 [`read_static_time_series_values!`](@ref): a scalar for scalar series, or the
 reconstructed element (e.g. a `FunctionData`) for structured series.
+
+This is the one-entry accessor. Reading *every* entry through it costs a dynamic
+dispatch and a boxed value per call — a cost that also grows with the entry
+count — so a sweep should go through
+[`get_static_time_series_group_values`](@ref) instead, which serves the same
+values from one concrete array per group.
 """
 function get_static_time_series_value(
     reader::StaticTimeSeriesReader,

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -682,7 +682,7 @@ end
 # Every keyed accessor is therefore back to **one** store call, and the race is
 # closed rather than narrowed.
 #
-# The by-name reads resolve their key out of a `list_metadata` scoped to one
+# The by-name reads resolve their key out of a `list_time_series_metadata` scoped to one
 # owner, which is where ownership is established; they take the `Store`-addressed
 # read below, which sets no guard. Re-guarding would only re-confirm what the
 # listing already said.
@@ -720,7 +720,7 @@ end
 _not_this_owners_key(owner::TimeSeriesOwners, key::TimeSeriesKey, detail) = ArgumentError(
     "TimeSeriesKey (association_id=$(get_association_id(key))) does not name a " *
     "time series of $(summary(owner)): $(detail). Pass the owner it belongs to, " *
-    "or look one up on this owner with list_metadata.",
+    "or look one up on this owner with list_time_series_metadata.",
 )
 
 # Confirm the association `key` names is attached to `owner`, against a catalog
@@ -1954,8 +1954,8 @@ _infrastore_query_types(::Nothing) = AllStoredTypes()
     return :($collapsed)
 end
 
-# The single InfraStore type to push into the core `list_metadata` filter for a query
-# type — a stored type, where `InfraStore.Deterministic` covers a
+# The single InfraStore type to push into the core `list_time_series_metadata`
+# filter for a query type — a stored type, where `InfraStore.Deterministic` covers a
 # `Deterministic`-family query because the core matches both storage forms under
 # it. `nothing` when the type spans more than that (a broader abstract family
 # like `Forecast`); the caller then applies the residual
@@ -2046,7 +2046,7 @@ _element_value_type(::Type{<:InfraStore.Probabilistic{T}}) where {T} =
 _element_value_type(::Type{<:InfraStore.Scenarios{T}}) where {T} = _is_element_type(T)
 _element_value_type(::Type) = Float64
 
-# Build the matching IS `TimeSeriesKey` from a catalog row — a `list_metadata`
+# Build the matching IS `TimeSeriesKey` from a catalog row — a `list_time_series_metadata`
 # row, which is the store's one listing shape and carries the `id` a key is
 # addressed by. A key is the id plus the stored type; every other column of the
 # row stays on the row, where a caller reads it without risk of the two drifting.
@@ -2116,7 +2116,7 @@ function get_time_series_key(store::Store, association_id::Integer)
 end
 
 # Every matching catalog row, as IS `TimeSeriesMetadata`. The core
-# `list_metadata` query filters owner / name / resolution / interval / features
+# `list_time_series_metadata` query filters owner / name / resolution / interval / features
 # (periods are canonicalized to ISO-8601 on both write and query, so a regular
 # `Hour(1)` matches a stored `Minute(60)`); an abstract `time_series_type` (or
 # `Deterministic`, which also matches a DST) is not a catalog filter column, so
@@ -2153,7 +2153,7 @@ function _infrastore_list_metadata(
     return out
 end
 
-# Owner-level `list_metadata` entry point.
+# Owner-level `list_time_series_metadata` entry point.
 function infrastore_owner_list_metadata(
     owner::TimeSeriesOwners;
     time_series_type = nothing,
@@ -2221,7 +2221,7 @@ function infrastore_get_time_series_hash(owner::TimeSeriesOwners, key::TimeSerie
 end
 
 # Content hashes for a homogeneous collection of owners, resolved by ONE catalog
-# query (`list_metadata` filtered on category/type/name/resolution/interval,
+# query (`list_time_series_metadata` filtered on category/type/name/resolution/interval,
 # whose every row carries the array's `data_hash`) instead of one per owner.
 # Returns `get_id(owner) => 64-char hex hash` for every owner in `owners` with a
 # stored series matching the filters; owners with no
@@ -2299,7 +2299,7 @@ function infrastore_group_by_hash(
 )
     # Keyed by the 64-char hex form of the content hash (the public contract).
     groups = Dict{String, Vector{Tuple{TimeSeriesOwners, TimeSeriesKey}}}()
-    for md in list_metadata(store)
+    for md in list_time_series_metadata(store)
         get_time_series_type(md) <: DeterministicSingleTimeSeries && continue
         owner = id_to_owner(get_owner_id(md), get_owner_category(md))
         pairs = get!(

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -879,11 +879,12 @@ end
 # nothing probes it for staleness first, and a dangling id surfaces as an error
 # from the call that was already committed to acting on it.
 #
-# The exception is the owner. `owner` is an argument in its own right, not
-# something the id can confirm, so every accessor checks that the association is
-# actually attached to the owner it was handed. Without it,
+# The exception is the owner. `owner` is an argument in its own right, so every
+# accessor confirms the key belongs to it before doing anything — without that,
 # `remove_time_series!(sys, wrong_component, key)` would quietly delete a series
-# off some other component.
+# off some other component. The key carries `owner_id` and `owner_category`, so
+# this is a comparison against the key, ahead of any store access: no probe, no
+# round trip, and the same check on every path.
 #
 # How far that reaches is bounded by the core's id-addressed surface:
 # `read_by_ids` (whole series, no slicing), `remove_by_ids!`, and
@@ -908,29 +909,16 @@ function _resolve_association(store::Store, key::TimeSeriesKey)
     return row
 end
 
-# Confirm the association `key` names is attached to `owner`. Checked against the
-# catalog row wherever one is resolved anyway (removal, sliced reads); against the
-# key's own owner fields on the paths that address the store by id alone and never
-# fetch a row, where it is still the check that catches the mistake this guards
-# against — the caller naming the wrong component.
-_check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey) =
-    _check_association_owner(owner, key, get_owner_id(key), get_owner_category(key))
-
-_check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey, row) =
-    _check_association_owner(owner, key, row.owner_id, row.owner_category)
-
-function _check_association_owner(
-    owner::TimeSeriesOwners,
-    key::TimeSeriesKey,
-    association_owner_id,
-    association_category,
-)
+# Confirm the association `key` names is attached to `owner`. The key carries the
+# owner it was minted for, so this is two field comparisons — the category matters
+# too, since a component and a supplemental attribute can share an integer id.
+function _check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey)
     owner_id, category = _infrastore_owner_id_category(owner)
-    (association_owner_id == owner_id && association_category == category) && return
+    (get_owner_id(key) == owner_id && get_owner_category(key) == category) && return
     throw(
         ArgumentError(
             "TimeSeriesKey '$(get_name(key))' (association_id=$(get_association_id(key))) " *
-            "is attached to owner id=$association_owner_id, not to $(summary(owner)); " *
+            "belongs to owner id=$(get_owner_id(key)), not to $(summary(owner)); " *
             "pass the owner it belongs to, or look up a key on this one with " *
             "get_time_series_key.",
         ),
@@ -938,12 +926,12 @@ function _check_association_owner(
 end
 
 # The store an owner's manager holds, and the row `key`'s id resolves to in it,
-# confirmed to be attached to `owner`.
+# for the paths the core cannot serve by id alone. The owner is confirmed first,
+# so a mismatched call costs no store access.
 function _store_and_association(owner::TimeSeriesOwners, key::TimeSeriesKey)
     store = _get_time_series_manager_or_throw(owner).data_store
-    row = _resolve_association(store, key)
-    _check_association_owner(owner, key, row)
-    return (store, row)
+    _check_association_owner(owner, key)
+    return (store, _resolve_association(store, key))
 end
 
 # The one association `id` names, read whole in a single id-addressed call — no
@@ -975,13 +963,12 @@ function _infrastore_read_single(
     len::Union{Nothing, Int} = nothing,
 )
     store = _get_time_series_manager_or_throw(owner).data_store
+    _check_association_owner(owner, key)
     if isnothing(start_time) && isnothing(len)
-        _check_association_owner(owner, key)
         sts = _read_association_by_id(store, key)::InfraStore.SingleTimeSeries
         return _single_from_store(sts, sts.name)
     end
     row = _resolve_association(store, key)
-    _check_association_owner(owner, key, row)
     initial_timestamp = row.initial_timestamp
     resolution = row.resolution
     start = isnothing(start_time) ? initial_timestamp : start_time
@@ -1031,13 +1018,12 @@ function _infrastore_read_non_sequential(
     len::Union{Nothing, Int} = nothing,
 )
     store = _get_time_series_manager_or_throw(owner).data_store
+    _check_association_owner(owner, key)
     if isnothing(start_time) && isnothing(len)
-        _check_association_owner(owner, key)
         raw = _read_association_by_id(store, key)::InfraStore.NonSequentialTimeSeries
         return _non_sequential_from_store(raw, raw.name)
     end
     row = _resolve_association(store, key)
-    _check_association_owner(owner, key, row)
     name = row.name
     time_range = if isnothing(start_time)
         nothing

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -1539,12 +1539,19 @@ mutable struct StaticTimeSeriesReader
     store::Store
     entries::Vector{StaticTimeSeriesReaderEntry}
     """
-    Decode plan for each entry (parallel to `entries`); drives the row decode.
-    Resolved from the stored `element_type` once at build, so a per-timestamp
-    read dispatches instead of re-interpreting the tag string.
+    Each entry's stored `element_type` (parallel to `entries`). Decodes that one
+    column, and is reached only for a group whose columns disagree — see
+    `group_element_types`.
     """
     element_types::Vector{Union{Nothing, String}}
-    "Per-group materialized values cache; reset on each read."
+    """
+    Per-group decode plan: the composite `element_type` that every column of the
+    group shares, or `nothing` when the group holds scalars or its columns
+    disagree. Resolved once at build, so a read interprets a tag once per group
+    rather than once per value.
+    """
+    group_element_types::Vector{Union{Nothing, String}}
+    "Per-group values cache, decoded where `group_element_types` says so; reset on each read."
     values::Vector{Any}
     has_read::Bool
 end
@@ -1564,12 +1571,15 @@ function infrastore_build_static_time_series_reader(
     entries = StaticTimeSeriesReaderEntry[]
     element_types = Union{Nothing, String}[]
     groups = InfraStore.static_groups(inner)
+    group_element_types = Vector{Union{Nothing, String}}(undef, length(groups))
     metas = _infrastore_reader_metadata(
         store,
         Int64[id for group in groups for id in group.ids],
     )
     i = 0
     for (gi, group) in enumerate(groups)
+        shared = nothing
+        uniform = true
         for col in eachindex(group.ids)
             i += 1
             smeta = metas[i]
@@ -1579,13 +1589,42 @@ function infrastore_build_static_time_series_reader(
                 StaticTimeSeriesReaderEntry(owner, _key_from_row(smeta), gi, col),
             )
             push!(element_types, smeta.element_type)
+            if col == 1
+                shared = smeta.element_type
+            elseif smeta.element_type != shared
+                uniform = false
+            end
         end
+        group_element_types[gi] = _shared_group_element_type(group, shared, uniform)
     end
     values = Vector{Any}(nothing, length(groups))
     return StaticTimeSeriesReader(
-        inner, store, entries, element_types, values, false,
+        inner, store, entries, element_types, group_element_types, values, false,
     )
 end
+
+# The tag a whole group can be decoded by, or `nothing` to leave it raw and
+# decode per entry.
+#
+# The core groups columns by `(element_type, element_shape)`, so a group is
+# uniform in its element type by construction — but `InfraStore.StaticGroup`
+# surfaces only the derived `dtype`, so IS cannot read that guarantee off the
+# group and establishes it from the columns instead. Decoding a whole group under
+# one column's tag while another column disagreed would hand back wrong values
+# silently, which is why the disagreement is checked rather than assumed; the
+# per-entry path it falls back to is correct, only slower.
+#
+# The empty-shape guard keeps a scalar group out: a composite always occupies one
+# trailing axis, so a group with no element axis has nothing to decode.
+_shared_group_element_type(group, shared, uniform) =
+    if (
+        uniform && !isempty(group.element_shape) &&
+        InfraStore.is_composite_element_type(shared)
+    )
+        shared
+    else
+        nothing
+    end
 
 """
 $(TYPEDSIGNATURES)
@@ -1646,7 +1685,7 @@ function get_static_time_series_value(
     entry = reader.entries[entry_index]
     vals = reader.values[entry.group]
     if isnothing(vals)
-        vals = InfraStore.static_values(reader.inner, entry.group)
+        vals = _materialize_static_group(reader, entry.group)
         reader.values[entry.group] = vals
     end
     return _static_group_element(
@@ -1654,11 +1693,36 @@ function get_static_time_series_value(
     )
 end
 
-# One entry's value out of its group's materialized array. A vector group is
-# scalar data (one value per column); a higher-rank group is one of two things,
-# told apart by the tag rather than by the rank:
-#   - a composite element type — one element row per column, decoded through the
-#     entry's encoding (same scheme as `_decode_static_values`, at `len == 1`);
+# One group's values for the current timestamp, decoded to one value per column
+# when every column shares a composite element type.
+#
+# The decode is whole-group because the read is: the reader performs one `.h5`
+# read per group per timestamp, and this makes it one decode per group per
+# timestamp to match. Decoding per entry instead re-derived the same answer from
+# the same tag string once per (entry, timestamp) — a fresh `String`, a regex
+# probe for the tuple spelling, and a one-row array to unwrap, once per component
+# per timestep in a sweep. All of it is amortized over the group here, and a
+# decoded group needs no decode branch on the per-value path at all.
+#
+# The whole-group decode is paid on the group's first touch after a read, so a
+# caller pulling one entry decodes columns it will not look at. That is the same
+# bargain the values cache already makes — the `.h5` read above it is whole-group
+# too — and it is the access pattern the reader exists for.
+function _materialize_static_group(reader::StaticTimeSeriesReader, group::Integer)
+    vals = InfraStore.static_values(reader.inner, group)
+    tag = reader.group_element_types[group]
+    isnothing(tag) && return vals
+    return InfraStore.decode_element_values(vals, tag; types = _IS_ELEMENT_TYPES)
+end
+
+# One entry's value out of its group's materialized values. A vector group is one
+# value per column — scalar data, or a group already decoded by
+# `_materialize_static_group`; a higher-rank group is one of two things, told
+# apart by the tag rather than by the rank:
+#   - a composite element type this column carries alone, because the group's
+#     columns disagree — decoded one row at a time. See
+#     `_shared_group_element_type` for why that case is guarded against rather
+#     than assumed away;
 #   - a multidimensional scalar series — a `SingleTimeSeries{Float64, N}` holds an
 #     `N-1`-dimensional slice per step, and there is nothing to decode, so the
 #     slice *is* the value. Decoding one would hand back the slice unchanged and

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -300,6 +300,18 @@ const _ELEMENT_ENCODINGS = Dict{String, ElementEncoding}(
 
 const _TUPLE_ELEMENT_TYPE = r"^tuple\((\d+),f64\)$"
 
+# The IS value element type an `element_type` tag decodes to — the `T` of a
+# `TimeSeriesData{T}`, and so of the `TimeSeriesKey{<:TimeSeriesData{T}}` that
+# names the series. A tag this binding does not map decodes to raw numbers, whose
+# element type is the array's own dtype; `Float64` is the only dtype the store
+# ever pairs with a mapped tag, and the fallback covers the rest.
+_element_value_type(::ScalarEncoding, dtype::Type) = dtype
+_element_value_type(::LinearFunctionEncoding, ::Type) = LinearFunctionData
+_element_value_type(::QuadraticFunctionEncoding, ::Type) = QuadraticFunctionData
+_element_value_type(::PiecewiseLinearEncoding, ::Type) = PiecewiseLinearData
+_element_value_type(::PiecewiseStepEncoding, ::Type) = PiecewiseStepData
+_element_value_type(::TupleEncoding{N}, ::Type) where {N} = NTuple{N, Float64}
+
 # The string -> type barrier. Deliberately the only type-unstable step: every
 # decode reached from here is dispatched and inferrable.
 _element_encoding(::Nothing) = ScalarEncoding()
@@ -627,9 +639,9 @@ function infrastore_remove_time_series!(
     owner::TimeSeriesOwners,
     key::TimeSeriesKey,
 )
-    # `owner` is an argument in its own right, so it is confirmed against the key
-    # before anything is deleted; the id itself is taken as valid.
-    _check_association_owner(owner, key)
+    # `owner` is an argument in its own right, so it is confirmed against the
+    # catalog row before anything is deleted.
+    _check_association_owner(owner, store, key)
     try
         InfraStore.remove_by_ids!(store.inner, [Int64(get_association_id(key))])
     catch e
@@ -640,16 +652,16 @@ function infrastore_remove_time_series!(
         if e isa InfraStore.InvalidParameterError
             throw(
                 ArgumentError(
-                    "Cannot remove SingleTimeSeries '$(get_name(key))' because it is " *
+                    "Cannot remove the SingleTimeSeries named by " *
+                    "association_id=$(get_association_id(key)) because it is " *
                     "attached to a DeterministicSingleTimeSeries."),
             )
         elseif e isa InfraStore.NotFoundError
             throw(
                 ArgumentError(
                     "TimeSeriesKey names association_id=$(get_association_id(key)), which " *
-                    "is no longer in this store: $(summary(key)) with " *
-                    "name='$(get_name(key))' on $(summary(owner)) may already have been " *
-                    "removed."),
+                    "is no longer in this store: $(summary(key)) on " *
+                    "$(summary(owner)) may already have been removed."),
             )
         end
         rethrow()
@@ -704,7 +716,7 @@ function infrastore_add_time_series!(
     end
     # The row is written by the time we get here, so the key is built around the id
     # the catalog actually filed it under.
-    return build_key(staged, only(added).id)
+    return build_key(staged, only(added))
 end
 
 # The store's duplicate-association rejection, which the add paths rely on
@@ -872,35 +884,40 @@ function _resolve_association(store::Store, key::TimeSeriesKey)
     isnothing(row) && throw(
         ArgumentError(
             "TimeSeriesKey names association_id=$id, which is no longer in this " *
-            "store: '$(get_name(key))' was removed after the key was obtained.",
+            "store: it was removed after the key was obtained.",
         ),
     )
     return row
 end
 
-# Confirm the association `key` names is attached to `owner`. The key carries the
-# owner it was minted for, so this is two field comparisons — the category matters
-# too, since a component and a supplemental attribute can share an integer id.
-function _check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey)
+# Confirm the association `key` names is attached to `owner`, against the catalog
+# row rather than a copy on the key. The category matters as well as the id, since
+# a component and a supplemental attribute can share an integer id.
+#
+# The row is the authority: an owner cached on the key would be one more field to
+# go stale when a series is reassigned, which is the whole reason a key carries
+# only its id.
+_check_association_owner(owner::TimeSeriesOwners, store::Store, key::TimeSeriesKey) =
+    _check_association_owner(owner, key, _resolve_association(store, key))
+
+function _check_association_owner(owner::TimeSeriesOwners, key::TimeSeriesKey, row)
     owner_id, category = _infrastore_owner_id_category(owner)
-    (get_owner_id(key) == owner_id && get_owner_category(key) == category) && return
+    (row.owner_id == owner_id && row.owner_category == category) && return row
     throw(
         ArgumentError(
-            "TimeSeriesKey '$(get_name(key))' (association_id=$(get_association_id(key))) " *
-            "belongs to owner id=$(get_owner_id(key)), not to $(summary(owner)); " *
-            "pass the owner it belongs to, or look up a key on this one with " *
-            "get_time_series_key.",
+            "TimeSeriesKey (association_id=$(get_association_id(key))) names " *
+            "'$(row.name)', which belongs to owner id=$(row.owner_id), not to " *
+            "$(summary(owner)); pass the owner it belongs to, or look one up on this " *
+            "owner with list_metadata.",
         ),
     )
 end
 
 # The store an owner's manager holds, and the row `key`'s id resolves to in it —
 # for the catalog-row accessors, which want the row itself rather than the data.
-# The owner is confirmed first, so a mismatched call costs no store access.
 function _store_and_association(owner::TimeSeriesOwners, key::TimeSeriesKey)
     store = _get_time_series_manager_or_throw(owner).data_store
-    _check_association_owner(owner, key)
-    return (store, _resolve_association(store, key))
+    return (store, _check_association_owner(owner, key, _resolve_association(store, key)))
 end
 
 # The association `key` names, or the window of it the accessor's arguments name,
@@ -915,8 +932,8 @@ function _read_association_by_id(
     len = nothing,
     count = nothing,
 )
-    _check_association_owner(owner, key)
     store = _get_time_series_manager_or_throw(owner).data_store
+    _check_association_owner(owner, store, key)
     try
         return InfraStore.read_by_id(
             store.inner, Int64(get_association_id(key));
@@ -950,7 +967,7 @@ _single_from_store(sts, name::AbstractString) = SingleTimeSeries(
 # decoded.
 function _infrastore_read_single(
     owner::TimeSeriesOwners,
-    key::StaticTimeSeriesKey;
+    key::TimeSeriesKey{<:SingleTimeSeries};
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
@@ -991,7 +1008,7 @@ end
 # only the requested points cross.
 function _infrastore_read_non_sequential(
     owner::TimeSeriesOwners,
-    key::NonSequentialTimeSeriesKey;
+    key::TimeSeriesKey{<:NonSequentialTimeSeries};
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
 )
@@ -1008,16 +1025,16 @@ end
 
 """
 Commit a staged `AddBatch` to the store as one all-or-nothing bulk add, returning
-the store's `InfraStore.AddedTimeSeries` per request, in the order they were staged.
+the catalog `id` the store filed each request under, in the order they were staged.
 
 The backend packs the arrays into batch-sized datasets written whole-chunk, so
 this is materially cheaper than the same adds issued one at a time — which is why
 the client-side buffer exists even though the store now has transactions.
 
-Each returned entry carries the `association_id` the catalog minted for that row.
-That id is the reason the write, not the staging, is where a `TimeSeriesKey` can
-first be built: the store owns the id stream, so nothing before this call knows
-what a staged association will be filed under.
+Each returned id is the `association_id` the catalog minted for that row. That id
+is the reason the write, not the staging, is where a `TimeSeriesKey` can first be
+built: the store owns the id stream, so nothing before this call knows what a
+staged association will be filed under.
 """
 function _infrastore_commit_batch!(mgr::AbstractTimeSeriesManager, batch)
     added = try
@@ -1061,6 +1078,13 @@ function _infrastore_stage!(
     )
 end
 
+# The type parameter a key gets for `ts`: its kind carrying the value element
+# type, rank left free — the rank belongs to the stored array, not to a reference
+# to it. This is what `_key_from_row` derives from a catalog row too, so a key
+# handed back by a write and a key listed from the catalog for the same series are
+# the same type as well as equal.
+_key_type(ts::TimeSeriesData) = Base.typename(typeof(ts)).wrapper{eltype(ts)}
+
 function _infrastore_stage_data!(
     batch::InfraStore.AddBatch,
     mgr::TimeSeriesManager,
@@ -1074,16 +1098,7 @@ function _infrastore_stage_data!(
     feats = _infrastore_features(features)
     nbytes = serialize_single!(batch, owner_id, owner_type, category, name,
         time_series; features = feats)
-    staged = StagedKey{StaticTimeSeriesKey}((
-        owner_id = owner_id,
-        owner_category = category,
-        time_series_type = SingleTimeSeries,
-        name = name,
-        initial_timestamp = get_initial_timestamp(time_series),
-        resolution = get_resolution(time_series),
-        length = length(time_series),
-        features = _key_features(feats),
-    ))
+    staged = StagedKey{_key_type(time_series)}()
     return staged, nbytes
 end
 
@@ -1100,14 +1115,7 @@ function _infrastore_stage_data!(
     feats = _infrastore_features(features)
     nbytes = serialize_non_sequential!(batch, owner_id, owner_type, category, name,
         time_series; features = feats)
-    staged = StagedKey{NonSequentialTimeSeriesKey}((
-        owner_id = owner_id,
-        owner_category = category,
-        time_series_type = NonSequentialTimeSeries,
-        name = name,
-        length = length(time_series),
-        features = _key_features(feats),
-    ))
+    staged = StagedKey{_key_type(time_series)}()
     return staged, nbytes
 end
 
@@ -1136,7 +1144,7 @@ end
 
 # The three dense-forecast stagers differ only in how they build the InfraStore
 # forecast object; the validation, owner marshalling, add, and returned
-# `(ForecastKey, staged_nbytes)` pair around it are shared. `build(initial,
+# `(StagedKey, staged_nbytes)` pair around it are shared. `build(initial,
 # resolution, horizon, interval, name)` returns that object together
 # with its window count, which is the one field the callers disagree on.
 function _infrastore_stage_forecast!(
@@ -1159,15 +1167,7 @@ function _infrastore_stage_forecast!(
     obj, count = build(initial, resolution, horizon, interval, name)
     InfraStore.add_time_series!(batch, owner_id, owner_type, category, obj;
         features = feats)
-    # The key names the stored type as its UnionAll (`Probabilistic`, not
-    # `Probabilistic{Float64, 2}`), exactly as a key listed back from the catalog does,
-    # so the two compare and query alike.
-    staged = StagedKey{ForecastKey}((
-        owner_id = owner_id, owner_category = category,
-        time_series_type = _unparameterized_type(typeof(ts)), name = name,
-        initial_timestamp = initial, resolution = resolution,
-        horizon = horizon, interval = interval, count = count,
-        features = _key_features(feats)))
+    staged = StagedKey{_key_type(ts)}()
     # `obj.data` is the encoded dense array the batch buffers; its byte size drives
     # auto-flush.
     return staged, sizeof(obj.data)
@@ -1279,14 +1279,14 @@ returned, so nothing here computes a time range or fetches a grid to compute one
 from, and the `name` argument goes unused. Without a key the forecast is resolved
 by name first, and that resolution is the extra call."""
 function _infrastore_get_forecast(
-    owner, name;
+    owner, name = nothing;
     time_series_type::Type{<:Forecast} = Forecast,
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     len::Union{Nothing, Int} = nothing,
     count::Union{Nothing, Int} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
-    key::Union{Nothing, ForecastKey} = nothing,
+    key::Union{Nothing, TimeSeriesKey{<:Forecast}} = nothing,
     features::Union{Nothing, Dict} = nothing,
 )
     if !isnothing(key)
@@ -1478,7 +1478,7 @@ forecast array (and read plan) report the same `slot`.
 """
 struct ForecastReaderEntry
     owner::TimeSeriesOwners
-    key::ForecastKey
+    key::TimeSeriesKey{<:Forecast}
     slot::Int
 end
 
@@ -1506,43 +1506,13 @@ mutable struct ForecastReader{T <: Forecast}
     has_read::Bool
 end
 
-# The association identity a reader entry / metadata row is matched on:
-# everything a build filter cannot disambiguate further (`key_info` carries no
-# interval, but two same-identity forecasts differing only by interval cannot
-# share one reader timeline, so the reader build has already rejected that
-# case). Both arguments come off the same core catalog, so the periods and
-# feature values compare exactly.
-_infrastore_row_match_identity(x) = (
-    Int(x.owner_id),
-    x.owner_category,
-    x.time_series_type,
-    String(x.name),
-    x.resolution,
-    Tuple(sort!([string(k) => v for (k, v) in x.features])),
-)
-
-# Metadata rows for every association matching a reader build filter, indexed
-# by association identity — ONE core catalog query for the whole reader,
-# instead of a `get_metadata` round-trip per entry.
-function _infrastore_metadata_by_identity(store::Store, resolution, name, features)
-    metas = Dict{Any, InfraStore.TimeSeriesMetadata}()
-    for m in InfraStore.list_time_series(store.inner;
-        resolution = resolution, name = name, features = _infrastore_features(features))
-        # Identities are unique per (resolution, interval, features); rows that
-        # collide here differ only by interval and are unreachable behind a
-        # reader build (they cannot share a window timeline).
-        metas[_infrastore_row_match_identity(m)] = m
-    end
-    return metas
-end
-
-# The metadata row backing one reader entry (`info = key_info(entry.key)`).
-function _infrastore_entry_metadata(metas::AbstractDict, info)
-    meta = get(metas, _infrastore_row_match_identity(info), nothing)
-    isnothing(meta) &&
-        error("unreachable: reader entry $(info.name) has no matching metadata row")
-    return meta
-end
+# The metadata row behind each of a reader's entries, in entry order — ONE core
+# catalog query for the whole reader, addressed by the association ids its
+# entries carry. `list_metadata_by_ids` answers one row per id asked for, in the
+# order asked, and throws if any id has gone stale (none can here: the reader
+# holds the store's own rows).
+_infrastore_reader_metadata(store::Store, ids::Vector{Int64}) =
+    InfraStore.list_metadata_by_ids(store.inner, ids)
 
 # Build a reader from the store. `id_to_owner(owner_id::Int, category::String)`
 # resolves each entry's owner object (the system holds the owner maps). Per-entry
@@ -1558,14 +1528,12 @@ function infrastore_build_forecast_reader(
     inner = InfraStore.build_forecast_reader(store.inner, _tss_forecast_type(T);
         resolution = resolution, name = name, features = features)
     tss_entries = InfraStore.forecast_entries(inner)
-    metas = _infrastore_metadata_by_identity(store, resolution, name, features)
+    metas = _infrastore_reader_metadata(store, Int64[e.id for e in tss_entries])
     n = length(tss_entries)
     entries = Vector{ForecastReaderEntry}(undef, n)
     element_encodings = Vector{ElementEncoding}(undef, n)
-    for (i, e) in enumerate(tss_entries)
-        info = InfraStore.key_info(e.key)
-        owner = id_to_owner(Int(info.owner_id), info.owner_category)
-        fmeta = _infrastore_entry_metadata(metas, info)
+    for (i, (e, fmeta)) in enumerate(zip(tss_entries, metas))
+        owner = id_to_owner(Int(fmeta.owner_id), fmeta.owner_category)
         element_encodings[i] = _element_encoding(fmeta.element_type)
         # `e.slot` is 0-based in the InfraStore store; carry it 1-based for Julia.
         entries[i] = ForecastReaderEntry(owner, _key_from_row(fmeta), e.slot + 1)
@@ -1643,7 +1611,7 @@ One series in a [`StaticTimeSeriesReader`], bound to its owner. `group` and
 """
 struct StaticTimeSeriesReaderEntry
     owner::TimeSeriesOwners
-    key::StaticTimeSeriesKey
+    key::TimeSeriesKey{<:SingleTimeSeries}
     group::Int
     column::Int
 end
@@ -1685,15 +1653,19 @@ function infrastore_build_static_time_series_reader(
 )
     inner = InfraStore.build_static_reader(store.inner;
         resolution = resolution, name = name, features = features)
-    metas = _infrastore_metadata_by_identity(store, resolution, name, features)
     entries = StaticTimeSeriesReaderEntry[]
     element_encodings = ElementEncoding[]
     groups = InfraStore.static_groups(inner)
+    metas = _infrastore_reader_metadata(
+        store,
+        Int64[id for group in groups for id in group.ids],
+    )
+    i = 0
     for (gi, group) in enumerate(groups)
-        for (col, k) in enumerate(group.keys)
-            info = InfraStore.key_info(k)
-            owner = id_to_owner(Int(info.owner_id), info.owner_category)
-            smeta = _infrastore_entry_metadata(metas, info)
+        for col in eachindex(group.ids)
+            i += 1
+            smeta = metas[i]
+            owner = id_to_owner(Int(smeta.owner_id), smeta.owner_category)
             push!(
                 entries,
                 StaticTimeSeriesReaderEntry(owner, _key_from_row(smeta), gi, col),
@@ -1931,7 +1903,7 @@ _infrastore_query_types(::Nothing) = AllStoredTypes()
     return :($collapsed)
 end
 
-# The single InfraStore type to push into the core `list_keys` filter for a query
+# The single InfraStore type to push into the core `list_metadata` filter for a query
 # type — a stored type, where `InfraStore.Deterministic` covers a
 # `Deterministic`-family query because the core matches both storage forms under
 # it. `nothing` when the type spans more than that (a broader abstract family
@@ -1981,54 +1953,58 @@ _infrastore_is_type(s::Symbol) =
         error("InfraStore backend does not support time series type $s")
     end
 
-# Build the matching IS `TimeSeriesKey` from a catalog row — a
-# `list_time_series` metadata row (the only row kind that carries the store's
-# `id`; a bare `list_keys`/`list_array_groups` row does not, so every caller
-# lists through `list_time_series` instead). The key is the single descriptor
-# for a stored association; forecast-only fields (percentiles, scenario_count)
-# are not carried — they come from the data on read.
-_key_from_row(row) = _key_from_row(_infrastore_is_type(row.time_series_type), row)
+# The IS time series type named by a catalog row's `time_series_type` string,
+# for deserializing a key that travels as (id, type).
+_time_series_type_from_name(name::AbstractString) = _infrastore_is_type(Symbol(name))
+
+# The dtype a row's values are physically stored in, for the tags this binding
+# does not map to a domain type.
+function _row_value_dtype(row)
+    et = row.element_type
+    isnothing(et) && return Float64
+    dtype = InfraStore._physical_dtype_of(et)
+    return isnothing(dtype) ? Float64 : dtype
+end
+
+# Build the matching IS `TimeSeriesKey` from a catalog row — a `list_metadata`
+# row, which is the store's one listing shape and carries the `id` a key is
+# addressed by. A key is the id plus the stored type; every other column of the
+# row stays on the row, where a caller reads it without risk of the two drifting.
+#
+# The type parameter carries the *value* element type as well as the kind, so a
+# key names what a read of it hands back: a `piecewise_linear` row becomes a
+# `TimeSeriesKey{SingleTimeSeries{PiecewiseLinearData}}`. The array rank is left
+# free — it is a property of the stored array, not of the reference.
+function _key_from_row(row)
+    kind = _infrastore_is_type(row.time_series_type)
+    value_type =
+        _element_value_type(_element_encoding(row.element_type), _row_value_dtype(row))
+    return TimeSeriesKey{kind{value_type}}(row.id)
+end
 
 _row_features(row) = Dict{String, Any}(string(k) => v for (k, v) in row.features)
 
-_key_from_row(::Type{T}, row) where {T <: NonSequentialTimeSeries} =
-    NonSequentialTimeSeriesKey(;
-        owner_id = row.owner_id,
-        owner_category = row.owner_category,
-        association_id = row.id,
-        time_series_type = T,
-        name = row.name,
-        length = row.length,
-        features = _row_features(row),
+# The IS `TimeSeriesMetadata` for a store catalog row: the key, plus the
+# descriptive columns translated into IS's vocabulary. The translation is the
+# point — a raw store row names *InfraStore's* `SingleTimeSeries`, and IS exports
+# its own, so handing one back unconverted would give callers a type that fails
+# every `<: SingleTimeSeries` test they write.
+function _metadata_from_row(row)
+    key = _key_from_row(row)
+    return TimeSeriesMetadata(
+        key,
+        Int(row.owner_id),
+        row.owner_category,
+        String(row.name),
+        row.initial_timestamp,
+        row.resolution,
+        row.horizon,
+        row.interval,
+        isnothing(row.count) ? nothing : Int(row.count),
+        isnothing(row.length) ? nothing : Int(row.length),
+        _row_features(row),
     )
-
-_key_from_row(::Type{T}, row) where {T <: StaticTimeSeries} =
-    StaticTimeSeriesKey(;
-        owner_id = row.owner_id,
-        owner_category = row.owner_category,
-        association_id = row.id,
-        time_series_type = T,
-        name = row.name,
-        initial_timestamp = row.initial_timestamp,
-        resolution = row.resolution,
-        length = row.length,
-        features = _row_features(row),
-    )
-
-_key_from_row(::Type{T}, row) where {T <: Forecast} =
-    ForecastKey(;
-        owner_id = row.owner_id,
-        owner_category = row.owner_category,
-        association_id = row.id,
-        time_series_type = T,
-        name = row.name,
-        initial_timestamp = row.initial_timestamp,
-        resolution = row.resolution,
-        horizon = row.horizon,
-        interval = row.interval,
-        count = row.count,
-        features = _row_features(row),
-    )
+end
 
 """
 Resolve a wire `association_id` to the full `TimeSeriesKey` it names, from the
@@ -2050,12 +2026,12 @@ function get_time_series_key(store::Store, association_id::Integer)
 end
 
 # All matching associations for one owner, as `TimeSeriesKey` objects. The core
-# `list_time_series` query filters owner / name / resolution / interval / features
+# `list_metadata` query filters owner / name / resolution / interval / features
 # (periods are canonicalized to ISO-8601 on both write and query, so a regular
 # `Hour(1)` matches a stored `Minute(60)`); an abstract `time_series_type` (or
 # `Deterministic`, which also matches a DST) is not a catalog filter column, so
 # it is applied as a residual on the already-narrowed rows.
-function _infrastore_list_keys(
+function _infrastore_list_metadata(
     store::Store,
     owner_id::Integer,
     owner_category::InfraStore.OwnerCategory;
@@ -2068,11 +2044,11 @@ function _infrastore_list_keys(
     type_filter = _infrastore_pushable_type(time_series_type)
     feats = _infrastore_features(features)
     rows =
-        InfraStore.list_time_series(store.inner; owner_id = owner_id,
+        InfraStore.list_metadata(store.inner; owner_id = owner_id,
             owner_category = owner_category, time_series_type = type_filter,
             name = name, resolution = resolution, interval = interval,
             features = feats)
-    out = ConcreteTimeSeriesKey[]
+    out = TimeSeriesMetadata[]
     for row in rows
         if !isnothing(time_series_type)
             _infrastore_type_matches(
@@ -2081,13 +2057,13 @@ function _infrastore_list_keys(
             ) ||
                 continue
         end
-        push!(out, _key_from_row(row))
+        push!(out, _metadata_from_row(row))
     end
     return out
 end
 
 # Owner-level `list_metadata` entry point.
-function infrastore_owner_list_keys(
+function infrastore_owner_list_metadata(
     owner::TimeSeriesOwners;
     time_series_type = nothing,
     name = nothing,
@@ -2100,7 +2076,7 @@ function infrastore_owner_list_keys(
     mgr = _get_time_series_manager_or_throw(owner)
     store = mgr.data_store
     owner_id, _, category = _infrastore_owner_args(owner)
-    return _infrastore_list_keys(store, owner_id, category;
+    return _infrastore_list_metadata(store, owner_id, category;
         time_series_type = time_series_type, name = name, resolution = resolution,
         interval = interval, features = _infrastore_features(features))
 end
@@ -2114,7 +2090,7 @@ function infrastore_get_time_series_key(
     interval = nothing,
     features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
-    items = infrastore_owner_list_keys(owner; time_series_type = T, name = name,
+    items = infrastore_owner_list_metadata(owner; time_series_type = T, name = name,
         resolution = resolution, interval = interval, features = features)
     if isempty(items)
         throw(ArgumentError("No matching metadata is stored."))
@@ -2127,7 +2103,7 @@ function infrastore_get_time_series_key(
             ),
         )
     end
-    return items[1]
+    return get_time_series_key(items[1])
 end
 
 # Content hash (64-char lowercase hex, the documented public form of the
@@ -2141,9 +2117,10 @@ function infrastore_get_time_series_hash(owner::TimeSeriesOwners, key::TimeSerie
 end
 
 # Content hashes for a homogeneous collection of owners, resolved by ONE catalog
-# query (`list_array_groups` filtered on category/type/name/resolution/interval)
-# instead of one per owner. Returns `get_id(owner) => 64-char hex hash` for every
-# owner in `owners` with a stored series matching the filters; owners with no
+# query (`list_metadata` filtered on category/type/name/resolution/interval,
+# whose every row carries the array's `data_hash`) instead of one per owner.
+# Returns `get_id(owner) => 64-char hex hash` for every owner in `owners` with a
+# stored series matching the filters; owners with no
 # match are simply absent. Two matches with the same hash are fine (they resolve
 # to the same array); two matches with different hashes mean the filters
 # underdetermine the series for that owner, so that is an error.
@@ -2176,7 +2153,7 @@ function infrastore_get_time_series_hashes(
         )
         push!(ids, get_id(o))
     end
-    rows = InfraStore.list_array_groups(store.inner;
+    rows = InfraStore.list_metadata(store.inner;
         owner_category = category,
         time_series_type = _infrastore_pushable_type(T),
         name = name,
@@ -2218,7 +2195,7 @@ function infrastore_group_by_hash(
 )
     # Keyed by the 64-char hex form of the content hash (the public contract).
     groups = Dict{String, Vector{Tuple{TimeSeriesOwners, TimeSeriesKey}}}()
-    for row in InfraStore.list_time_series(store.inner)
+    for row in InfraStore.list_metadata(store.inner)
         _infrastore_is_type(row.time_series_type) <: DeterministicSingleTimeSeries &&
             continue
         owner = id_to_owner(Int(row.owner_id), row.owner_category)
@@ -2240,24 +2217,27 @@ function infrastore_get_time_series_multiple(
     resolution = nothing,
     interval = nothing,
 )
-    metas = infrastore_owner_list_keys(owner; time_series_type = type, name = name,
+    metas = infrastore_owner_list_metadata(owner; time_series_type = type, name = name,
         resolution = resolution, interval = interval)
     Channel() do channel
         for m in metas
-            ts = _infrastore_read_key(owner, m)
+            ts = _infrastore_read_key(owner, get_time_series_key(m))
             (isnothing(filter_func) || filter_func(ts)) && put!(channel, ts)
         end
     end
 end
 
 # Read one series by its already-resolved key — no catalog re-resolution.
-_infrastore_read_key(owner::TimeSeriesOwners, key::ForecastKey) =
-    _infrastore_get_forecast(owner, get_name(key); key = key)
+_infrastore_read_key(owner::TimeSeriesOwners, key::TimeSeriesKey{<:Forecast}) =
+    _infrastore_get_forecast(owner; key = key)
 
-_infrastore_read_key(owner::TimeSeriesOwners, key::NonSequentialTimeSeriesKey) =
+_infrastore_read_key(
+    owner::TimeSeriesOwners,
+    key::TimeSeriesKey{<:NonSequentialTimeSeries},
+) =
     _infrastore_read_non_sequential(owner, key)
 
-_infrastore_read_key(owner::TimeSeriesOwners, key::StaticTimeSeriesKey) =
+_infrastore_read_key(owner::TimeSeriesOwners, key::TimeSeriesKey{<:SingleTimeSeries}) =
     _infrastore_read_single(owner, key)
 
 # ---- Store-wide aggregates -------------------------------------------------
@@ -2377,7 +2357,7 @@ function infrastore_list_owner_ids(
     # the presence of a `resolution` filter.
     ids = Set{Int}()
     for row in
-        InfraStore.list_keys(store.inner; owner_category = category,
+        InfraStore.list_metadata(store.inner; owner_category = category,
         time_series_type = _infrastore_pushable_type(time_series_type),
         resolution = resolution)
         if !isnothing(time_series_type)
@@ -2404,7 +2384,7 @@ function infrastore_list_keys_with_owner(
     resolution::Union{Nothing, Dates.Period} = nothing,
 )
     category = get_owner_category(owner_type)
-    rows = InfraStore.list_time_series(store.inner; owner_category = category,
+    rows = InfraStore.list_metadata(store.inner; owner_category = category,
         time_series_type = _infrastore_pushable_type(time_series_type),
         resolution = resolution)
     out = NamedTuple[]

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -238,6 +238,22 @@ serialized system) never touch the InfraStore module themselves.
 """
 make_add_batch() = InfraStore.AddBatch()
 
+# The bytes one staged array holds in the batch's buffer, which is what drives
+# auto-flush. `sizeof` is the answer only for a plain numeric array: a composite
+# element type is stored as one pointer per value but staged as a
+# `length x element_row_width` matrix of `Float64`, so `sizeof` under-counts it by
+# the row width — a factor that is unbounded for ragged piecewise data, and would
+# let a block hold gigabytes past the byte threshold before flushing.
+_staged_nbytes(values::AbstractArray) = sizeof(values)
+_staged_nbytes(values::AbstractArray{<:StaticFunctionData}) = _encoded_nbytes(values)
+_staged_nbytes(values::AbstractArray{<:Tuple{Vararg{Float64}}}) = _encoded_nbytes(values)
+
+# `element_row_width` is defined on the flat vector of values the store packs, so
+# a forecast's `(horizon, count)` matrix is measured through `vec` (a reshape, not
+# a copy).
+_encoded_nbytes(values::AbstractArray) =
+    length(values) * InfraStore.element_row_width(vec(values)) * sizeof(Float64)
+
 """
     commit_batch!(store::Store, batch)
 
@@ -287,10 +303,8 @@ function serialize_single!(
         owner_category, tss_ts; features = features, units = units,
         quantity_kind = quantity_kind,
         unit_system = _to_store_unit_system(unit_system))
-    # Drives auto-flush. A composite element type is packed wider than the values
-    # measure here, which under-counts the buffer — the threshold is a heuristic,
-    # and one that errs toward flushing late rather than toward a wrong answer.
-    return sizeof(values)
+    # Drives auto-flush; measured as the store packs it, not as Julia holds it.
+    return _staged_nbytes(values)
 end
 
 """
@@ -325,7 +339,7 @@ function serialize_non_sequential!(
         quantity_kind = quantity_kind,
         unit_system = _to_store_unit_system(unit_system))
     # The staged bytes are the encoded array plus the timestamps the association carries.
-    return sizeof(values) + sizeof(get_timestamps(nts))
+    return _staged_nbytes(values) + sizeof(get_timestamps(nts))
 end
 
 # Rebuild the IS `NonSequentialTimeSeries` from whatever the store handed back,
@@ -941,9 +955,9 @@ function _infrastore_stage_forecast!(
     InfraStore.add_time_series!(batch, owner_id, owner_type, category, obj;
         features = feats)
     staged = StagedKey{_key_type(ts)}()
-    # `obj.data` is the encoded dense array the batch buffers; its byte size drives
-    # auto-flush.
-    return staged, sizeof(obj.data)
+    # `obj.data` is the dense window array the batch buffers; its encoded byte size
+    # drives auto-flush.
+    return staged, _staged_nbytes(obj.data)
 end
 
 function _infrastore_stage_data!(
@@ -1512,18 +1526,24 @@ function get_static_time_series_value(
 end
 
 # One entry's value out of its group's materialized array. A vector group is
-# scalar data (one value per column); a higher-rank group carries one element row
-# per column, decoded through the entry's encoding (same scheme as
-# `_decode_static_values`, at `len == 1`).
+# scalar data (one value per column); a higher-rank group is one of two things,
+# told apart by the tag rather than by the rank:
+#   - a composite element type — one element row per column, decoded through the
+#     entry's encoding (same scheme as `_decode_static_values`, at `len == 1`);
+#   - a multidimensional scalar series — a `SingleTimeSeries{Float64, N}` holds an
+#     `N-1`-dimensional slice per step, and there is nothing to decode, so the
+#     slice *is* the value. Decoding one would hand back the slice unchanged and
+#     then `only` it, which throws for every width above 1.
 _static_group_element(vals::AbstractVector, column::Integer, _element_type) =
     vals[column]
 
 function _static_group_element(vals::AbstractArray, column::Integer, element_type)
     colons = ntuple(_ -> Colon(), ndims(vals) - 1)
-    row = reshape(vals[column, colons...], 1, :)
+    slice = vals[column, colons...]
+    InfraStore.is_composite_element_type(element_type) || return slice
     return only(
         InfraStore.decode_element_values(
-            row, something(element_type, "f64"); types = _IS_ELEMENT_TYPES,
+            reshape(slice, 1, :), element_type; types = _IS_ELEMENT_TYPES,
         ),
     )
 end

--- a/src/openapi_associations.jl
+++ b/src/openapi_associations.jl
@@ -5,19 +5,23 @@
 """
 $(TYPEDSIGNATURES)
 
-Metadata for every time series in a store matching the (all-optional, independent) filters —
-the same filter keywords as `InfraStore.list_time_series`/`InfraStore.list_keys` — in one
-catalog query.
+A [`TimeSeriesMetadata`](@ref) row for every time series in a store matching the
+(all-optional, independent) filters — the same filter keywords as
+`InfraStore.list_metadata` — in one catalog query.
 
 Takes the store directly as well as a `SystemData`, because a writer that stages series into
 a scratch store — a parser building a document, say — needs the same rows before any
 `SystemData` exists.
-"""
-list_time_series_metadata(store::Store; kwargs...) =
-    InfraStore.list_time_series(store.inner; kwargs...)
 
-list_time_series_metadata(data::SystemData; kwargs...) =
-    list_time_series_metadata(get_data_store(data); kwargs...)
+The rows are translated into IS's vocabulary on the way out: a raw store row names
+*InfraStore's* `SingleTimeSeries`, and IS exports its own, so an untranslated row would fail
+every `<: SingleTimeSeries` test a caller writes.
+"""
+list_metadata(store::Store; kwargs...) =
+    [_metadata_from_row(row) for row in InfraStore.list_metadata(store.inner; kwargs...)]
+
+list_metadata(data::SystemData; kwargs...) =
+    list_metadata(get_data_store(data); kwargs...)
 
 """
 $(TYPEDSIGNATURES)
@@ -25,7 +29,7 @@ $(TYPEDSIGNATURES)
 Every `(component_id, component_type, attribute_id, attribute_type)` association row in
 `data`, in one catalog query.
 
-The counterpart of [`list_time_series_metadata`](@ref) for the attachment table. Callers
+The counterpart of [`list_metadata`](@ref) for the attachment table. Callers
 building a document group these by `component_id` instead of asking the store once per
 component.
 """
@@ -46,7 +50,7 @@ $(TYPEDSIGNATURES)
 
 The raw, already schema-conformant JSON array InfraStore's `openapi` module produces for
 `time_series_associations` matching the filter (the same filter keywords as
-[`list_time_series_metadata`](@ref)), each row stamped with the store's own `uri` and
+[`list_metadata`](@ref)), each row stamped with the store's own `uri` and
 `data_hash`. For a caller that embeds the JSON verbatim (into a document, say) rather than
 round-tripping it through the generated model types; see
 [`openapi_time_series_association_rows`](@ref) for that.

--- a/src/openapi_associations.jl
+++ b/src/openapi_associations.jl
@@ -17,16 +17,18 @@ a scratch store — a parser building a document, say — needs the same rows be
 store's own `element_type` spelling included, so such a writer works from it alone.
 
 Both vocabularies are IS's on the way in as well as out. `time_series_type` is an **IS**
-type — the same spelling [`list_metadata`](@ref list_metadata(::TimeSeriesOwners)) on an
+type — the same spelling
+[`list_time_series_metadata`](@ref list_time_series_metadata(::TimeSeriesOwners)) on an
 owner takes, and abstract families (`Forecast`, `StaticTimeSeries`) resolve here exactly as
 they do there. And the rows come back translated: a raw store row names *InfraStore's*
 `SingleTimeSeries`, and IS exports its own, so an untranslated row would fail every
 `<: SingleTimeSeries` test a caller writes.
 """
-list_metadata(store::Store; kwargs...) = _infrastore_list_metadata(store; kwargs...)
+list_time_series_metadata(store::Store; kwargs...) =
+    _infrastore_list_metadata(store; kwargs...)
 
-list_metadata(data::SystemData; kwargs...) =
-    list_metadata(get_data_store(data); kwargs...)
+list_time_series_metadata(data::SystemData; kwargs...) =
+    list_time_series_metadata(get_data_store(data); kwargs...)
 
 """
 $(TYPEDSIGNATURES)
@@ -34,7 +36,7 @@ $(TYPEDSIGNATURES)
 Every `(component_id, component_type, attribute_id, attribute_type)` association row in
 `data`, in one catalog query.
 
-The counterpart of [`list_metadata`](@ref) for the attachment table. Callers
+The counterpart of [`list_time_series_metadata`](@ref) for the attachment table. Callers
 building a document group these by `component_id` instead of asking the store once per
 component.
 """
@@ -55,7 +57,7 @@ $(TYPEDSIGNATURES)
 
 The raw, already schema-conformant JSON array InfraStore's `openapi` module produces for
 `time_series_associations` matching the filter (the same filter keywords as
-[`list_metadata`](@ref)), each row stamped with the store's own `uri` and
+[`list_time_series_metadata`](@ref)), each row stamped with the store's own `uri` and
 `data_hash`. For a caller that embeds the JSON verbatim (into a document, say) rather than
 round-tripping it through the generated model types; see
 [`openapi_time_series_association_rows`](@ref) for that.

--- a/src/openapi_associations.jl
+++ b/src/openapi_associations.jl
@@ -7,18 +7,23 @@ $(TYPEDSIGNATURES)
 
 A [`TimeSeriesMetadata`](@ref) row for every time series in a store matching the
 (all-optional, independent) filters — the same filter keywords as
-`InfraStore.list_metadata` — in one catalog query.
+`InfraStore.list_metadata`: `owner_id`, `owner_category`, `time_series_type`, `name`,
+`name_glob`, `resolution`, `interval`, `features`, `component_field`, `zoneless` — in one
+catalog query.
 
 Takes the store directly as well as a `SystemData`, because a writer that stages series into
 a scratch store — a parser building a document, say — needs the same rows before any
-`SystemData` exists.
+`SystemData` exists. A row carries every column the catalog holds, `data_hash` and the
+store's own `element_type` spelling included, so such a writer works from it alone.
 
-The rows are translated into IS's vocabulary on the way out: a raw store row names
-*InfraStore's* `SingleTimeSeries`, and IS exports its own, so an untranslated row would fail
-every `<: SingleTimeSeries` test a caller writes.
+Both vocabularies are IS's on the way in as well as out. `time_series_type` is an **IS**
+type — the same spelling [`list_metadata`](@ref list_metadata(::TimeSeriesOwners)) on an
+owner takes, and abstract families (`Forecast`, `StaticTimeSeries`) resolve here exactly as
+they do there. And the rows come back translated: a raw store row names *InfraStore's*
+`SingleTimeSeries`, and IS exports its own, so an untranslated row would fail every
+`<: SingleTimeSeries` test a caller writes.
 """
-list_metadata(store::Store; kwargs...) =
-    [_metadata_from_row(row) for row in InfraStore.list_metadata(store.inner; kwargs...)]
+list_metadata(store::Store; kwargs...) = _infrastore_list_metadata(store; kwargs...)
 
 list_metadata(data::SystemData; kwargs...) =
     list_metadata(get_data_store(data); kwargs...)

--- a/src/production_variable_cost_curve.jl
+++ b/src/production_variable_cost_curve.jl
@@ -166,7 +166,7 @@ struct FuelCurve{T <: ValueCurve, U <: AbstractUnitSystem} <:
     "A fixed value for fuel cost; mutually exclusive with `fuel_cost_time_series`"
     fuel_cost::Union{Nothing, Float64}
     "The [`TimeSeriesKey`](@ref) to a fuel cost time series; mutually exclusive with `fuel_cost`"
-    fuel_cost_time_series::Union{Nothing, ConcreteTimeSeriesKey}
+    fuel_cost_time_series::Union{Nothing, TimeSeriesKey}
     "(default of 0) Fuel consumption at the unit startup proceedure. Additional cost to the startup costs and related only to the initial fuel required to start the unit.
     represented as a [`LinearCurve`](@ref)"
     startup_fuel_offtake::LinearCurve
@@ -177,7 +177,7 @@ struct FuelCurve{T <: ValueCurve, U <: AbstractUnitSystem} <:
     function FuelCurve{T, U}(
         value_curve::T,
         fuel_cost::Union{Nothing, Float64},
-        fuel_cost_time_series::Union{Nothing, ConcreteTimeSeriesKey},
+        fuel_cost_time_series::Union{Nothing, TimeSeriesKey},
         startup_fuel_offtake::LinearCurve,
         vom_cost::LinearCurve,
     ) where {T, U}
@@ -198,7 +198,7 @@ end
 FuelCurve{T, U}(;
     value_curve::T,
     fuel_cost::Union{Nothing, Float64} = nothing,
-    fuel_cost_time_series::Union{Nothing, ConcreteTimeSeriesKey} = nothing,
+    fuel_cost_time_series::Union{Nothing, TimeSeriesKey} = nothing,
     startup_fuel_offtake::LinearCurve = LinearCurve(0.0),
     vom_cost::LinearCurve = LinearCurve(0.0),
 ) where {T, U} =
@@ -355,14 +355,14 @@ _deserialize_fuel_cost(raw) =
     )
 
 _deserialize_fuel_cost_time_series(::Nothing) = nothing
-# A key is on the wire as its association id alone; the store bound for the
-# deserialization turns it back into a key.
-_deserialize_fuel_cost_time_series(association_id::Integer) =
-    deserialize(TimeSeriesKey, association_id)
+# A key is on the wire as its association id and its stored time series type, so
+# it rebuilds itself without the catalog that minted it.
+_deserialize_fuel_cost_time_series(raw::AbstractDict) = deserialize(TimeSeriesKey, raw)
 _deserialize_fuel_cost_time_series(raw) =
     throw(
         ArgumentError(
-            "FuelCurve fuel_cost_time_series must be a time series association id or nothing, got $(typeof(raw))",
+            "FuelCurve fuel_cost_time_series must be a serialized time series key or " *
+            "nothing, got $(typeof(raw))",
         ),
     )
 

--- a/src/production_variable_cost_curve.jl
+++ b/src/production_variable_cost_curve.jl
@@ -166,7 +166,7 @@ struct FuelCurve{T <: ValueCurve, U <: AbstractUnitSystem} <:
     "A fixed value for fuel cost; mutually exclusive with `fuel_cost_time_series`"
     fuel_cost::Union{Nothing, Float64}
     "The [`TimeSeriesKey`](@ref) to a fuel cost time series; mutually exclusive with `fuel_cost`"
-    fuel_cost_time_series::Union{Nothing, TimeSeriesKey}
+    fuel_cost_time_series::Union{Nothing, ScalarTimeSeriesKey}
     "(default of 0) Fuel consumption at the unit startup proceedure. Additional cost to the startup costs and related only to the initial fuel required to start the unit.
     represented as a [`LinearCurve`](@ref)"
     startup_fuel_offtake::LinearCurve

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -134,11 +134,15 @@ function add_serialization_metadata!(data::Dict, ::Type{T}) where {T}
     return
 end
 
-# TimeSeriesFunctionData{T} is parametric — ensure the type parameter is reconstructed
+# TimeSeriesFunctionData is parametric — ensure the type parameter is reconstructed
 # during deserialization by setting CONSTRUCT_WITH_PARAMETERS_KEY.
+#
+# Only `T` is written. `U` follows from the key the value carries, which
+# serializes with its own time series type, so recording it here as well would be
+# a second copy of one fact — and the outer constructor rebuilds it.
 function add_serialization_metadata!(
     data::Dict,
-    ::Type{TimeSeriesFunctionData{T}},
+    ::Type{<:TimeSeriesFunctionData{T}},
 ) where {T <: StaticFunctionData}
     data[METADATA_KEY] = Dict{String, Any}(
         TYPE_KEY => string(nameof(TimeSeriesFunctionData)),
@@ -257,18 +261,15 @@ function deserialize(T::Union, data::Dict)
     # better than the also undocumented T.a and T.b, see
     # https://github.com/JuliaLang/julia/issues/53193
     types_within = Base.uniontypes(T)
+    # A `TimeSeriesKey` serializes to a small dict, so an optional key field
+    # (`Union{Nothing, TimeSeriesKey}`) arrives as one. `Nothing` is not something
+    # the count below can rule out, and a key is unambiguous wherever it appears:
+    # nothing else in these unions deserializes from a dict.
+    any(x -> x <: TimeSeriesKey, types_within) &&
+        return deserialize(TimeSeriesKey, data)
     maybe_from_dict = filter(x -> !(x <: _NOT_FROM_DICT), types_within)
     (length(maybe_from_dict) == 1) && (return deserialize(first(maybe_from_dict), data))
     throw(ArgumentError("Cannot pick which of union type $T to deserialize to"))
-end
-
-# Mirror of the `Dict` and `AbstractString` union dispatchers above for an integer
-# payload: a `TimeSeriesKey` serializes to its bare `association_id`, so an optional
-# key field (`Union{Nothing, ConcreteTimeSeriesKey}`) arrives as an integer. A union
-# with no key in it keeps the generic scalar behavior.
-function deserialize(T::Union, data::Integer)
-    any(x -> x <: TimeSeriesKey, Base.uniontypes(T)) || return deepcopy(data)
-    return deserialize(TimeSeriesKey, data)
 end
 
 function deserialize(::Type{T}, data::Array) where {T <: Vector{<:Tuple}}

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -1424,6 +1424,13 @@ component's value": drive it with [`read_static_time_series_values!`](@ref) and
 read each entry with [`get_static_time_series_value`](@ref). Series with the
 same element type are packed into one columnar group and served by a single
 storage read per timestamp.
+
+To sweep every entry — which is what this reader is for — take the groups
+instead, with [`get_static_time_series_group_values`](@ref) and
+[`get_static_time_series_group_entries`](@ref). The per-entry accessor returns
+one value at a time out of a container the reader cannot type, so it dispatches
+dynamically and boxes each value; the group path costs neither and stays flat as
+the reader grows.
 """
 function build_static_time_series_reader(
     data::SystemData;

--- a/src/system_data.jl
+++ b/src/system_data.jl
@@ -260,6 +260,14 @@ function remove_time_series!(
     return remove_time_series!(data.time_series_manager, owner, ts_key)
 end
 
+# A metadata row carries the key that addresses its series; accept one here too,
+# so a listing can be acted on directly.
+remove_time_series!(
+    data::SystemData,
+    owner::TimeSeriesOwners,
+    md::TimeSeriesMetadata,
+) = remove_time_series!(data, owner, get_time_series_key(md))
+
 """
 Removes all time series of a particular type from a System.
 
@@ -909,20 +917,19 @@ function deserialize(
         )
     end
     next_id = Int(raw["next_id"])
-    # An attribute may carry a `TimeSeriesKey`, which arrives as a bare association id
-    # and is resolved against the store opened above.
+    # An attribute may carry a `TimeSeriesKey`. A key travels as its association id
+    # and its time series type — both facts the store never rewrites — so it
+    # rebuilds itself without the catalog that minted it.
     supplemental_attribute_manager =
-        with_deserialization_store(get_data_store(time_series_manager)) do
-            deserialize(
-                SupplementalAttributeManager,
-                get(
-                    raw,
-                    "supplemental_attribute_manager",
-                    Dict("attributes" => [], "associations" => []),
-                ),
-                time_series_manager,
-            )
-        end
+        deserialize(
+            SupplementalAttributeManager,
+            get(
+                raw,
+                "supplemental_attribute_manager",
+                Dict("attributes" => [], "associations" => []),
+            ),
+            time_series_manager,
+        )
     internal = deserialize(InfrastructureSystemsInternal, raw["internal"])
     validation_descriptors = if isnothing(validation_descriptor_file)
         []
@@ -962,9 +969,8 @@ function deserialize(
     end
 
     # Note: components need to be deserialized by the parent so that they can go through
-    # the proper checks. A component may carry a `TimeSeriesKey`, which is on the wire as
-    # a bare association id, so the parent must run that pass inside
-    # `with_deserialization_store(get_data_store(sys.time_series_manager))`.
+    # the proper checks. A component may carry a `TimeSeriesKey`; it rebuilds itself from
+    # the wire without the store, so the parent's pass needs no extra scoping.
     return sys
 end
 

--- a/src/time_series_cache.jl
+++ b/src/time_series_cache.jl
@@ -241,7 +241,7 @@ function ForecastCache(
     interval::Union{Nothing, Dates.Period} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
 ) where {T <: Forecast}
-    ts_metadata = get_time_series_key(
+    ts_metadata = get_time_series_metadata(
         T,
         component,
         name;
@@ -380,7 +380,7 @@ function StaticTimeSeriesCache(
     start_time::Union{Nothing, Dates.DateTime} = nothing,
     resolution::Union{Nothing, Dates.Period} = nothing,
 ) where {T <: SingleTimeSeries}
-    ts_metadata = get_time_series_key(T, component, name; resolution = resolution)
+    ts_metadata = get_time_series_metadata(T, component, name; resolution = resolution)
     initial_timestamp = get_initial_timestamp(ts_metadata)
     if start_time === nothing
         start_time = initial_timestamp

--- a/src/time_series_context.jl
+++ b/src/time_series_context.jl
@@ -53,7 +53,7 @@ mutable struct TimeSeriesContext{M <: AbstractTimeSeriesManager, V}
     the store minted for them. Only collected when `collect_keys` is set; a bulk
     ingest that never asks for its keys should not pay to retain one per series.
     """
-    added::Vector{ConcreteTimeSeriesKey}
+    added::Vector{TimeSeriesKey}
     "Whether to retain a key per written addition in `added`."
     collect_keys::Bool
     "Forecast window parameters per `(resolution, interval)` group."
@@ -96,7 +96,7 @@ function TimeSeriesContext(
         mgr,
         nothing,
         StagedKey[],
-        ConcreteTimeSeriesKey[],
+        TimeSeriesKey[],
         collect_keys,
         Dict{Tuple{Dates.Period, Dates.Period}, Union{Nothing, ForecastParameters}}(),
         false,
@@ -177,7 +177,7 @@ function flush!(context::TimeSeriesContext)
     added = _infrastore_commit_batch!(context.mgr, batch)
     context.collect_keys && append!(
         context.added,
-        (build_key(entry, item.id) for (entry, item) in zip(staged, added)),
+        (build_key(entry, id) for (entry, id) in zip(staged, added)),
     )
     return
 end

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -307,6 +307,32 @@ function get_time_series_metadata(
 end
 
 """
+$(TYPEDSIGNATURES)
+Return the [`TimeSeriesMetadata`](@ref) row that `key` names under `owner` — the
+series' name, resolution, `initial_timestamp`, features, and, for a forecast, its
+horizon, interval, and count.
+
+This is how a caller holding a key reads the attributes a key deliberately does
+not carry: a key is its `association_id` and the stored type, and everything else
+lives in the catalog. Take the row when you want those attributes; keep the key
+when you only need to address the series.
+
+Throws an `ArgumentError` if the id no longer resolves (the series was removed
+after the key was obtained) or if it names a series belonging to another owner.
+
+See also: [`get_time_series_metadata` by name](@ref get_time_series_metadata(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    resolution::Union{Nothing, Dates.Period} = nothing,
+    interval::Union{Nothing, Dates.Period} = nothing,
+    features::Union{Nothing, Dict} = nothing,
+) where {T <: TimeSeriesData}), [`list_metadata`](@ref).
+"""
+get_time_series_metadata(owner::TimeSeriesOwners, key::TimeSeriesKey) =
+    infrastore_get_time_series_metadata(owner, key)
+
+"""
 Return a `TimeSeries.TimeArray` from storage for the given time series parameters.
 
 This will load all forecast windows into memory by default. Be
@@ -1341,6 +1367,7 @@ for f in (
     :get_time_series_timestamps,
     :get_time_series_values,
     :get_time_series_hash,
+    :get_time_series_metadata,
 )
     @eval $f(owner::TimeSeriesOwners, md::TimeSeriesMetadata; kwargs...) =
         $f(owner, get_time_series_key(md); kwargs...)

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -15,7 +15,7 @@ Return the [`TimeSeriesManager`](@ref) backing `owner`, or throw if there is non
 An owner that was never added to a system — or one whose type does not support time
 series — has no manager. Reading time series from it is a caller mistake, so it gets an
 actionable `ArgumentError` rather than a `FieldError` on `nothing`. Callers that treat
-"detached" as an ordinary empty answer (`has_time_series`, `list_metadata`,
+"detached" as an ordinary empty answer (`has_time_series`, `list_time_series_metadata`,
 `get_time_series_multiple`, `copy_time_series!`) check for `nothing` themselves instead.
 """
 function _get_time_series_manager_or_throw(owner)
@@ -245,7 +245,7 @@ end
 Return the [`TimeSeriesKey`](@ref) identifying the single time series of type `T`
 attached to `owner` under `name` (and the given resolution/interval/features).
 
-Pairs with [`list_metadata`](@ref) (enumeration) and
+Pairs with [`list_time_series_metadata`](@ref) (enumeration) and
 [`get_time_series(::TimeSeriesOwners, ::TimeSeriesKey)`](@ref) (retrieval).
 """
 function get_time_series_key(
@@ -272,7 +272,7 @@ end
 Return the [`TimeSeriesMetadata`](@ref) row for the single time series of type `T`
 attached to `owner` under `name` (and the given resolution/interval/features).
 
-The one-row counterpart of [`list_metadata`](@ref), and what
+The one-row counterpart of [`list_time_series_metadata`](@ref), and what
 [`get_time_series_key`](@ref) resolves through — take the row when you want the
 series' attributes, the key when you only want to address it.
 """
@@ -284,7 +284,7 @@ function get_time_series_metadata(
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Union{Nothing, Dict} = nothing,
 ) where {T <: TimeSeriesData}
-    rows = list_metadata(
+    rows = list_time_series_metadata(
         owner;
         time_series_type = T,
         name = name,
@@ -327,7 +327,7 @@ See also: [`get_time_series_metadata` by name](@ref get_time_series_metadata(
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Union{Nothing, Dict} = nothing,
-) where {T <: TimeSeriesData}), [`list_metadata`](@ref).
+) where {T <: TimeSeriesData}), [`list_time_series_metadata`](@ref).
 """
 get_time_series_metadata(owner::TimeSeriesOwners, key::TimeSeriesKey) =
     infrastore_get_time_series_metadata(owner, key)
@@ -1191,7 +1191,7 @@ function _copy_time_series_same_kind!(
     # `dst` holding a subset of `src`'s series.
     src_label = _copy_source_label(src)
     time_series_transaction(mgr) do _
-        for md in list_metadata(src)
+        for md in list_time_series_metadata(src)
             name = get_name(md)
             new_name = name
             if !isnothing(name_mapping)
@@ -1217,7 +1217,7 @@ function _copy_time_series_same_kind!(
 end
 
 """
-    list_metadata(owner; time_series_type, name, resolution, interval, features)
+    list_time_series_metadata(owner; time_series_type, name, resolution, interval, features)
 
 Return a [`TimeSeriesMetadata`](@ref) row for each time series attached to
 `owner`, optionally filtered by type / name / resolution / interval / features.
@@ -1230,7 +1230,7 @@ the key it carries stays valid as the catalog changes around it.
 An owner with no time series manager — one not attached to a system — has no time
 series, so this is empty rather than an error.
 """
-function list_metadata(
+function list_time_series_metadata(
     owner::TimeSeriesOwners;
     time_series_type::Union{Type{<:TimeSeriesData}, Nothing} = nothing,
     name::Union{String, Nothing} = nothing,
@@ -1240,7 +1240,7 @@ function list_metadata(
 )
     mgr = get_time_series_manager(owner)
     isnothing(mgr) && return TimeSeriesMetadata[]
-    return list_metadata(
+    return list_time_series_metadata(
         mgr,
         owner;
         time_series_type = time_series_type,
@@ -1279,7 +1279,7 @@ when processing many owners (e.g. batching model parameters by shared array).
 
 All owners must be of one category (all components or all supplemental
 attributes). `resolution`, `interval`, and `features` narrow the match the same
-way they do in [`list_metadata`](@ref); if the filters leave more than
+way they do in [`list_time_series_metadata`](@ref); if the filters leave more than
 one matching series with distinct arrays for an owner, an error is thrown.
 """
 get_time_series_hashes(
@@ -1359,7 +1359,7 @@ end
 
 # A metadata row carries the key that addresses its series, so a row is accepted
 # anywhere a key is. A caller that has just listed rows should not have to unwrap
-# every one of them to act on it, and the row is the only thing `list_metadata`
+# every one of them to act on it, and the row is the only thing `list_time_series_metadata`
 # hands back.
 for f in (
     :get_time_series,

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -160,15 +160,19 @@ function get_time_series(
     end
 end
 
+# Dispatch to the reader for the key's stored kind. `target` is a
+# `KeyedReadTarget`: an owner, whose ownership of the key is checked against the
+# catalog first, or the store, for a key the caller resolved from that owner's own
+# listing and so does not have to confirm again.
 _get_time_series_by_key(
-    owner::TimeSeriesOwners,
+    target::KeyedReadTarget,
     key::TimeSeriesKey{<:Forecast};
     start_time,
     len,
     count,
-) = _infrastore_get_forecast(
-    owner;
-    key = key,
+) = _infrastore_read_forecast(
+    target,
+    key;
     start_time = start_time,
     len = len,
     count = count,
@@ -177,20 +181,20 @@ _get_time_series_by_key(
 # `count` does not apply to a static series; it is accepted for interface
 # uniformity and ignored.
 _get_time_series_by_key(
-    owner::TimeSeriesOwners,
+    target::KeyedReadTarget,
     key::TimeSeriesKey{<:NonSequentialTimeSeries};
     start_time,
     len,
     count,
-) = _infrastore_read_non_sequential(owner, key; start_time = start_time, len = len)
+) = _infrastore_read_non_sequential(target, key; start_time = start_time, len = len)
 
 _get_time_series_by_key(
-    owner::TimeSeriesOwners,
+    target::KeyedReadTarget,
     key::TimeSeriesKey{<:SingleTimeSeries};
     start_time,
     len,
     count,
-) = _infrastore_read_single(owner, key; start_time = start_time, len = len)
+) = _infrastore_read_single(target, key; start_time = start_time, len = len)
 
 """
 Returns an iterator of TimeSeriesData instances attached to the component or attribute.

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -15,7 +15,7 @@ Return the [`TimeSeriesManager`](@ref) backing `owner`, or throw if there is non
 An owner that was never added to a system — or one whose type does not support time
 series — has no manager. Reading time series from it is a caller mistake, so it gets an
 actionable `ArgumentError` rather than a `FieldError` on `nothing`. Callers that treat
-"detached" as an ordinary empty answer (`has_time_series`, `get_time_series_keys`,
+"detached" as an ordinary empty answer (`has_time_series`, `list_metadata`,
 `get_time_series_multiple`, `copy_time_series!`) check for `nothing` themselves instead.
 """
 function _get_time_series_manager_or_throw(owner)
@@ -151,8 +151,8 @@ function get_time_series(
             throw(
                 ArgumentError(
                     "TimeSeriesKey names association_id=$(get_association_id(key)), " *
-                    "which is no longer in this store: $(summary(key)) with " *
-                    "name='$(get_name(key))' on $(summary(owner)) may have been removed.",
+                    "which is no longer in this store: $(summary(key)) on " *
+                    "$(summary(owner)) may have been removed.",
                 ),
             )
         end
@@ -162,13 +162,12 @@ end
 
 _get_time_series_by_key(
     owner::TimeSeriesOwners,
-    key::ForecastKey;
+    key::TimeSeriesKey{<:Forecast};
     start_time,
     len,
     count,
 ) = _infrastore_get_forecast(
-    owner,
-    get_name(key);
+    owner;
     key = key,
     start_time = start_time,
     len = len,
@@ -179,7 +178,7 @@ _get_time_series_by_key(
 # uniformity and ignored.
 _get_time_series_by_key(
     owner::TimeSeriesOwners,
-    key::NonSequentialTimeSeriesKey;
+    key::TimeSeriesKey{<:NonSequentialTimeSeries};
     start_time,
     len,
     count,
@@ -187,7 +186,7 @@ _get_time_series_by_key(
 
 _get_time_series_by_key(
     owner::TimeSeriesOwners,
-    key::StaticTimeSeriesKey;
+    key::TimeSeriesKey{<:SingleTimeSeries};
     start_time,
     len,
     count,
@@ -242,7 +241,7 @@ end
 Return the [`TimeSeriesKey`](@ref) identifying the single time series of type `T`
 attached to `owner` under `name` (and the given resolution/interval/features).
 
-Pairs with [`get_time_series_keys`](@ref) (enumeration) and
+Pairs with [`list_metadata`](@ref) (enumeration) and
 [`get_time_series(::TimeSeriesOwners, ::TimeSeriesKey)`](@ref) (retrieval).
 """
 function get_time_series_key(
@@ -263,6 +262,44 @@ function get_time_series_key(
         interval = interval,
         features = features,
     )
+end
+
+"""
+Return the [`TimeSeriesMetadata`](@ref) row for the single time series of type `T`
+attached to `owner` under `name` (and the given resolution/interval/features).
+
+The one-row counterpart of [`list_metadata`](@ref), and what
+[`get_time_series_key`](@ref) resolves through — take the row when you want the
+series' attributes, the key when you only want to address it.
+"""
+function get_time_series_metadata(
+    ::Type{T},
+    owner::TimeSeriesOwners,
+    name::AbstractString;
+    resolution::Union{Nothing, Dates.Period} = nothing,
+    interval::Union{Nothing, Dates.Period} = nothing,
+    features::Union{Nothing, Dict} = nothing,
+) where {T <: TimeSeriesData}
+    rows = list_metadata(
+        owner;
+        time_series_type = T,
+        name = name,
+        resolution = resolution,
+        interval = interval,
+        features = features,
+    )
+    if isempty(rows)
+        throw(ArgumentError("No matching metadata is stored."))
+    elseif length(rows) > 1
+        throw(
+            ArgumentError(
+                "Found more than one matching metadata: $(length(rows)). Specify " *
+                "additional keyword arguments (resolution, interval, or features) to " *
+                "disambiguate.",
+            ),
+        )
+    end
+    return only(rows)
 end
 
 """
@@ -1124,8 +1161,8 @@ function _copy_time_series_same_kind!(
     # `dst` holding a subset of `src`'s series.
     src_label = _copy_source_label(src)
     time_series_transaction(mgr) do _
-        for ts_key in get_time_series_keys(src)
-            name = get_name(ts_key)
+        for md in list_metadata(src)
+            name = get_name(md)
             new_name = name
             if !isnothing(name_mapping)
                 new_name = get(name_mapping, (src_label, name), nothing)
@@ -1135,18 +1172,14 @@ function _copy_time_series_same_kind!(
                 end
                 @debug "Copy ts_key with" _group = LOG_GROUP_TIME_SERIES new_name
             end
+            # The key already carries the association id, so the copy is addressed
+            # by it: no attribute re-resolution in the store to find the source row.
             InfraStore.copy_time_series!(
-                _infrastore_type(get_time_series_type(ts_key)),
                 store.inner,
-                get_owner_id(ts_key),
-                get_owner_category(ts_key),
-                name,
+                get_association_id(md),
                 dst_id,
                 dst_type;
                 new_name = new_name,
-                resolution = get_resolution(ts_key),
-                interval = get_interval(ts_key),
-                features = Dict{String, Any}(get_features(ts_key)),
             )
         end
     end
@@ -1154,11 +1187,20 @@ function _copy_time_series_same_kind!(
 end
 
 """
-Return the [`TimeSeriesKey`](@ref) for each time series attached to `owner`,
-optionally filtered by type/name/resolution/interval/features. Each key can be
-passed to [`get_time_series(::TimeSeriesOwners, ::TimeSeriesKey)`](@ref).
+    list_metadata(owner; time_series_type, name, resolution, interval, features)
+
+Return a [`TimeSeriesMetadata`](@ref) row for each time series attached to
+`owner`, optionally filtered by type / name / resolution / interval / features.
+
+This is the identify half of the surface: it answers *which* series exist and
+what they look like. Take [`get_time_series_key`](@ref) of a row to act on one —
+read it, remove it, or store the reference in a component. A row is a snapshot;
+the key it carries stays valid as the catalog changes around it.
+
+An owner with no time series manager — one not attached to a system — has no time
+series, so this is empty rather than an error.
 """
-function get_time_series_keys(
+function list_metadata(
     owner::TimeSeriesOwners;
     time_series_type::Union{Type{<:TimeSeriesData}, Nothing} = nothing,
     name::Union{String, Nothing} = nothing,
@@ -1167,8 +1209,8 @@ function get_time_series_keys(
     features::Union{Nothing, Dict} = nothing,
 )
     mgr = get_time_series_manager(owner)
-    isnothing(mgr) && return TimeSeriesKey[]
-    return list_time_series_keys(
+    isnothing(mgr) && return TimeSeriesMetadata[]
+    return list_metadata(
         mgr,
         owner;
         time_series_type = time_series_type,
@@ -1207,7 +1249,7 @@ when processing many owners (e.g. batching model parameters by shared array).
 
 All owners must be of one category (all components or all supplemental
 attributes). `resolution`, `interval`, and `features` narrow the match the same
-way they do in [`get_time_series_keys`](@ref); if the filters leave more than
+way they do in [`list_metadata`](@ref); if the filters leave more than
 one matching series with distinct arrays for an owner, an error is thrown.
 """
 get_time_series_hashes(
@@ -1283,4 +1325,19 @@ function get_forecast_window_count(
     end
 
     return count
+end
+
+# A metadata row carries the key that addresses its series, so a row is accepted
+# anywhere a key is. A caller that has just listed rows should not have to unwrap
+# every one of them to act on it, and the row is the only thing `list_metadata`
+# hands back.
+for f in (
+    :get_time_series,
+    :get_time_series_array,
+    :get_time_series_timestamps,
+    :get_time_series_values,
+    :get_time_series_hash,
+)
+    @eval $f(owner::TimeSeriesOwners, md::TimeSeriesMetadata; kwargs...) =
+        $f(owner, get_time_series_key(md); kwargs...)
 end

--- a/src/time_series_interface.jl
+++ b/src/time_series_interface.jl
@@ -143,15 +143,16 @@ function get_time_series(
             count = count,
         )
     catch e
-        # `catch`-block exception inspection: a stale key — the series was
-        # removed after the key was obtained — surfaces as the store's
-        # NotFoundError; keep the accessors' public ArgumentError contract.
+        # `catch`-block exception inspection: an id that no longer resolves — the
+        # series was removed after the key was obtained — surfaces as the store's
+        # NotFoundError; keep the accessors' public ArgumentError contract, and
+        # name the id, which is what the read was addressed by.
         if e isa InfraStore.NotFoundError
             throw(
                 ArgumentError(
-                    "No time series matches the key $(summary(key)) with " *
-                    "name='$(get_name(key))' on $(summary(owner)); " *
-                    "it may have been removed.",
+                    "TimeSeriesKey names association_id=$(get_association_id(key)), " *
+                    "which is no longer in this store: $(summary(key)) with " *
+                    "name='$(get_name(key))' on $(summary(owner)) may have been removed.",
                 ),
             )
         end

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -332,7 +332,7 @@ get_time_series_key(
     features = features,
 )
 
-list_metadata(
+list_time_series_metadata(
     mgr::TimeSeriesManager,
     component::TimeSeriesOwners;
     time_series_type::Union{Type{<:TimeSeriesData}, Nothing} = nothing,

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -92,9 +92,6 @@ function _infrastore_features(features::Dict)
     return out
 end
 
-_key_features(::Nothing) = Dict{String, Any}()
-_key_features(features::Dict) = Dict{String, Any}(features)
-
 function _check_interval_supported(::Type{T}, interval) where {T <: TimeSeriesData}
     if T <: StaticTimeSeries && !isnothing(interval)
         throw(

--- a/src/time_series_manager.jl
+++ b/src/time_series_manager.jl
@@ -335,7 +335,7 @@ get_time_series_key(
     features = features,
 )
 
-list_time_series_keys(
+list_metadata(
     mgr::TimeSeriesManager,
     component::TimeSeriesOwners;
     time_series_type::Union{Type{<:TimeSeriesData}, Nothing} = nothing,
@@ -343,7 +343,7 @@ list_time_series_keys(
     resolution::Union{Nothing, Dates.Period} = nothing,
     interval::Union{Nothing, Dates.Period} = nothing,
     features::Union{Nothing, Dict} = nothing,
-) = infrastore_owner_list_keys(
+) = infrastore_owner_list_metadata(
     component;
     time_series_type = time_series_type,
     name = name,

--- a/src/time_series_structs.jl
+++ b/src/time_series_structs.jl
@@ -287,6 +287,10 @@ get_initial_timestamp(md::TimeSeriesMetadata) = md.initial_timestamp
 get_resolution(md::TimeSeriesMetadata) = md.resolution
 get_horizon(md::TimeSeriesMetadata) = md.horizon
 get_interval(md::TimeSeriesMetadata) = md.interval
+"""
+The number of windows a forecast row holds. `nothing` on a static series row,
+which has no windows — its per-series length is [`get_length`](@ref).
+"""
 get_count(md::TimeSeriesMetadata) = md.count
 get_features(md::TimeSeriesMetadata) = md.features
 get_percentiles(md::TimeSeriesMetadata) = md.percentiles

--- a/src/time_series_structs.jl
+++ b/src/time_series_structs.jl
@@ -100,15 +100,35 @@ _key_element_name(T::Type{<:Tuple}) = "NTuple{$(length(T.parameters)),Float64}"
 """
 Rebuild a key from what it serialized to.
 
-An `element_type` this version does not know leaves the kind unparameterized
-rather than guessing: a key whose element type cannot be named still addresses
-its series, and a read resolves the values from the catalog either way.
+An `element_type` this version cannot name — one off a payload written by a newer
+version, or a payload carrying none at all — is an error here rather than a key
+left unparameterized. Every field a key is ever stored in is bound by its element
+type (a [`ScalarTimeSeriesKey`](@ref) field, a `TimeSeriesFunctionData`), so an
+unparameterized key would survive only as far as the field it is assigned to and
+then fail there, with a message about the key's shape instead of about the
+element type nothing here could name.
 """
 function deserialize(::Type{<:TimeSeriesKey}, data::AbstractDict)
     kind = _time_series_type_from_name(data["time_series_type"])
-    element = _key_element_type_from_name(get(data, "element_type", nothing))
-    T = isnothing(element) ? kind : kind{element}
-    return TimeSeriesKey{T}(data["association_id"])
+    name = get(data, "element_type", nothing)
+    element = _key_element_type_from_name(name)
+    if isnothing(element)
+        why = if isnothing(name)
+            "carries no element_type"
+        else
+            "names element_type '$name', which this version of " *
+            "InfrastructureSystems cannot resolve"
+        end
+        throw(
+            ArgumentError(
+                "serialized TimeSeriesKey (association_id=$(data["association_id"]), " *
+                "time_series_type=$(data["time_series_type"])) $why; a key cannot be " *
+                "rebuilt without its element type. The document was most likely " *
+                "written by a newer version.",
+            ),
+        )
+    end
+    return TimeSeriesKey{kind{element}}(data["association_id"])
 end
 
 # The value element types a key's parameter can name: the physical dtypes the
@@ -194,10 +214,13 @@ and stored with the data), `horizon` / `interval` / `count` on a static series,
 A row carries **every** column the catalog records bar the values themselves —
 the descriptive labels (`units`, `quantity_kind`, `unit_system`,
 `component_field`) as well as the identity ones, the store's own `element_type`
-spelling, and the array's content hash. That completeness is the contract: a
-writer restaging these series into another store, or emitting them into a
-document, works from this row alone and never has to drop to the store's own
-listing for a column IS declined to carry.
+and `element_shape`, the array's content hash, the row's `time_reference`, and
+the opaque `application_data` another client may have attached. That completeness
+is the contract: a writer restaging these series into another store, or emitting
+them into a document, works from this row alone and never has to drop to the
+store's own listing for a column IS declined to carry. The last three are columns
+IS itself neither writes nor interprets; they are carried so that restaging a row
+written by another client does not silently drop them.
 """
 struct TimeSeriesMetadata{T <: TimeSeriesData}
     key::TimeSeriesKey{T}
@@ -231,6 +254,25 @@ struct TimeSeriesMetadata{T <: TimeSeriesData}
     quantity_kind::Union{Nothing, String}
     unit_system::Union{Nothing, AbstractUnitSystem}
     component_field::Union{Nothing, String}
+    """
+    The stored array's shape after its leading axis, as the store records it —
+    `()` for one number per timestep, `(3,)` for a three-wide row. A restaging
+    writer hands it back verbatim; the IS value type the row decodes to is
+    `eltype(md)`.
+    """
+    element_shape::Dims
+    """
+    The time reference the row's timestamps are stated against — a zone, a fixed
+    offset, UTC, or none. IS reads and writes wall-clock `DateTime`s, so its own
+    rows are `ZonelessReference`; it does not interpret the column, and carries it
+    so that a zoned row written by another client does not re-land as a wall clock.
+    """
+    time_reference::Union{Nothing, InfraStore.TimeReference}
+    """
+    The opaque per-association blob a client may attach to a row. IS attaches
+    none and never looks inside one.
+    """
+    application_data::Union{Nothing, String}
 end
 
 "The [`TimeSeriesKey`](@ref) that addresses the association this row describes."
@@ -253,6 +295,9 @@ get_quantity_kind(md::TimeSeriesMetadata) = md.quantity_kind
 get_unit_system(md::TimeSeriesMetadata) = md.unit_system
 get_component_field(md::TimeSeriesMetadata) = md.component_field
 get_element_type(md::TimeSeriesMetadata) = md.element_type
+get_element_shape(md::TimeSeriesMetadata) = md.element_shape
+get_time_reference(md::TimeSeriesMetadata) = md.time_reference
+get_application_data(md::TimeSeriesMetadata) = md.application_data
 
 """
 The 64-char lowercase hex content hash of the stored array this row's series

--- a/src/time_series_structs.jl
+++ b/src/time_series_structs.jl
@@ -1,6 +1,17 @@
 const TimeSeriesOwners = Union{InfrastructureSystemsComponent, SupplementalAttribute}
 
 """
+What a keyed read is addressed against: a `TimeSeriesOwners`, whose ownership of
+the key is confirmed against the catalog first, or the [`Store`](@ref) itself,
+for a key already known to belong to the owner the caller resolved it from.
+
+The two differ by one store call — the ownership lookup — and by nothing else, so
+the by-name accessors, which resolve their key out of one owner's own listing,
+read through the store rather than paying to confirm what the listing said.
+"""
+const KeyedReadTarget = Union{Store, TimeSeriesOwners}
+
+"""
     TimeSeriesKey{T <: TimeSeriesData}
 
 A reference to one stored time series association: its store-minted
@@ -127,6 +138,43 @@ function _key_element_type_from_name(name)
 end
 
 """
+The keys a *scalar-valued* time series field may hold — a time-series-backed
+curve's `initial_input` and `input_at_zero`, a `FuelCurve`'s
+`fuel_cost_time_series`.
+
+A closed union of concrete key types rather than the abstract
+[`TimeSeriesKey`](@ref), for the same reason the fields it types are read in
+per-window loops: a union of concrete `isbits` types is stored inline and
+union-splits, where the abstract spelling boxes every key it holds and makes each
+read of the field a dynamic dispatch.
+
+Closed at `Float64`, and at the kinds whose values resolve to one number per
+timestep, because that is what these fields mean — `build_static_curves` reads
+them as an `AbstractVector{Float64}`, so a key naming anything else could only
+fail there. Declaring it here moves that failure to where the field is set.
+"""
+const ScalarTimeSeriesKey = Union{
+    TimeSeriesKey{SingleTimeSeries{Float64}},
+    TimeSeriesKey{NonSequentialTimeSeries{Float64}},
+    TimeSeriesKey{Deterministic{Float64}},
+    TimeSeriesKey{DeterministicSingleTimeSeries{Float64}},
+}
+
+# Setting one of these fields is where a key of the wrong shape is caught, and
+# `new` gets there through `convert`. Left to Base that is a bare "Cannot
+# `convert`" naming the union and nothing else; this says which key it got and
+# what the field is for. Only reached for a key OUTSIDE the union — one already
+# inside it is not converted at all.
+Base.convert(::Type{Union{Nothing, ScalarTimeSeriesKey}}, key::TimeSeriesKey) = throw(
+    ArgumentError(
+        "$key cannot be stored in a scalar time series field: such a field is " *
+        "read one Float64 per timestep, so it takes a key naming a Float64 " *
+        "SingleTimeSeries, NonSequentialTimeSeries, Deterministic, or " *
+        "DeterministicSingleTimeSeries.",
+    ),
+)
+
+"""
     TimeSeriesMetadata{T <: TimeSeriesData}
 
 One catalog row: everything the store records about a time series association
@@ -140,11 +188,21 @@ that cached them could hand back a name the catalog had since changed.
 Fields a row's type does not use are `nothing`: `resolution` and
 `initial_timestamp` on a `NonSequentialTimeSeries` (its timestamps are irregular
 and stored with the data), `horizon` / `interval` / `count` on a static series,
-`length` on a forecast, whose per-window length is its horizon count.
+`length` on a forecast, whose per-window length is its horizon count, and
+`percentiles` on anything but a `Probabilistic`.
+
+A row carries **every** column the catalog records bar the values themselves —
+the descriptive labels (`units`, `quantity_kind`, `unit_system`,
+`component_field`) as well as the identity ones, the store's own `element_type`
+spelling, and the array's content hash. That completeness is the contract: a
+writer restaging these series into another store, or emitting them into a
+document, works from this row alone and never has to drop to the store's own
+listing for a column IS declined to carry.
 """
 struct TimeSeriesMetadata{T <: TimeSeriesData}
     key::TimeSeriesKey{T}
     owner_id::Int
+    owner_type::String
     owner_category::InfraStore.OwnerCategory
     name::String
     initial_timestamp::Union{Nothing, Dates.DateTime}
@@ -153,7 +211,26 @@ struct TimeSeriesMetadata{T <: TimeSeriesData}
     interval::Union{Nothing, Dates.Period}
     count::Union{Nothing, Int}
     length::Union{Nothing, Int}
+    percentiles::Union{Nothing, Vector{Float64}}
     features::Dict{String, Any}
+    """
+    The store's own `element_type` spelling, kept raw: a writer restaging this row
+    into another store hands it back verbatim. The IS value type it decodes to is
+    `eltype(md)`.
+    """
+    element_type::String
+    """
+    The 32-byte content hash of the array the series resolves to, as the store
+    records it. Read it with [`get_data_hash`](@ref), which renders the hex form
+    IS's public API is spelled in; the bytes are kept because a listing of a large
+    catalog would otherwise pay a string per row for a column most callers of it
+    never look at.
+    """
+    data_hash::Vector{UInt8}
+    units::Union{Nothing, String}
+    quantity_kind::Union{Nothing, String}
+    unit_system::Union{Nothing, AbstractUnitSystem}
+    component_field::Union{Nothing, String}
 end
 
 "The [`TimeSeriesKey`](@ref) that addresses the association this row describes."
@@ -161,6 +238,7 @@ get_time_series_key(md::TimeSeriesMetadata) = md.key
 get_association_id(md::TimeSeriesMetadata) = get_association_id(md.key)
 get_time_series_type(::TimeSeriesMetadata{T}) where {T} = T
 get_owner_id(md::TimeSeriesMetadata) = md.owner_id
+get_owner_type(md::TimeSeriesMetadata) = md.owner_type
 get_owner_category(md::TimeSeriesMetadata) = md.owner_category
 get_name(md::TimeSeriesMetadata) = md.name
 get_initial_timestamp(md::TimeSeriesMetadata) = md.initial_timestamp
@@ -169,6 +247,33 @@ get_horizon(md::TimeSeriesMetadata) = md.horizon
 get_interval(md::TimeSeriesMetadata) = md.interval
 get_count(md::TimeSeriesMetadata) = md.count
 get_features(md::TimeSeriesMetadata) = md.features
+get_percentiles(md::TimeSeriesMetadata) = md.percentiles
+get_units(md::TimeSeriesMetadata) = md.units
+get_quantity_kind(md::TimeSeriesMetadata) = md.quantity_kind
+get_unit_system(md::TimeSeriesMetadata) = md.unit_system
+get_component_field(md::TimeSeriesMetadata) = md.component_field
+get_element_type(md::TimeSeriesMetadata) = md.element_type
+
+"""
+The 64-char lowercase hex content hash of the stored array this row's series
+resolves to — the spelling every IS hash accessor uses. Two rows sharing it name
+the same array.
+"""
+get_data_hash(md::TimeSeriesMetadata) = bytes2hex(md.data_hash)
+
+"""
+The unparameterized time series kind of a row — `SingleTimeSeries` for a
+`SingleTimeSeries{Float64}`.
+
+[`get_time_series_type`](@ref) carries the value element type as well, which is
+what a caller dispatches on; this is what a caller *groups* or *labels* by, where
+one owner's `SingleTimeSeries{Float64}` and `SingleTimeSeries{PiecewiseStepData}`
+rows belong under one heading and the element type is a column of its own.
+"""
+get_time_series_kind(::TimeSeriesMetadata{T}) where {T} = Base.typename(T).wrapper
+
+"The IS value element type of the series this row describes."
+Base.eltype(::TimeSeriesMetadata{T}) where {T} = eltype(T)
 
 """
 The number of values one window of the series holds. A forecast row has no

--- a/src/time_series_structs.jl
+++ b/src/time_series_structs.jl
@@ -22,7 +22,7 @@ resolution, initial timestamp, horizon, interval, count, owner, features — liv
 in the catalog, and a key that also carried a copy could only disagree with it.
 `rename_time_series!` and a reassignment both change catalog columns while
 preserving the id, so a cached copy goes stale where the id cannot. Ask the store
-when you need those: [`list_metadata`](@ref) for a set of rows, or
+when you need those: [`list_time_series_metadata`](@ref) for a set of rows, or
 [`get_time_series_metadata`](@ref) for one.
 
 `T` is the exception, because it is the one fact that *cannot* drift: a stored
@@ -31,7 +31,7 @@ rewritten. Carrying it as a type parameter costs nothing at runtime (a key is an
 8-byte `isbits` value) and lets callers dispatch on it —
 `f(key::TimeSeriesKey{<:Forecast})`.
 
-Keys are produced by IS (`add_time_series!`, `list_metadata`), never constructed
+Keys are produced by IS (`add_time_series!`, `list_time_series_metadata`), never constructed
 by users. Two keys are equal exactly when they name the same association.
 """
 struct TimeSeriesKey{T <: TimeSeriesData}
@@ -198,7 +198,7 @@ Base.convert(::Type{Union{Nothing, ScalarTimeSeriesKey}}, key::TimeSeriesKey) = 
     TimeSeriesMetadata{T <: TimeSeriesData}
 
 One catalog row: everything the store records about a time series association
-except its values. Returned by [`list_metadata`](@ref).
+except its values. Returned by [`list_time_series_metadata`](@ref).
 
 This is where the descriptive attributes live now that a [`TimeSeriesKey`](@ref)
 carries only its id. Reading them from a row rather than a key is the whole point

--- a/src/time_series_structs.jl
+++ b/src/time_series_structs.jl
@@ -1,224 +1,212 @@
 const TimeSeriesOwners = Union{InfrastructureSystemsComponent, SupplementalAttribute}
 
 """
-Supertype for keys that can be used to access a desired time series dataset
+    TimeSeriesKey{T <: TimeSeriesData}
 
-The concrete subtypes are a closed set — [`StaticTimeSeriesKey`](@ref),
-[`NonSequentialTimeSeriesKey`](@ref), and [`ForecastKey`](@ref), collected in
-`ConcreteTimeSeriesKey`. Keys are produced by IS (e.g. `add_time_series!`,
-`get_time_series_keys`), never constructed by users, and key-carrying structs
-store the `ConcreteTimeSeriesKey` union, so a foreign subtype cannot flow
-through the key-addressed paths (reads, removal, copy, hashing).
+A reference to one stored time series association: its store-minted
+`association_id`, with the stored time series type as the type parameter.
 
-Every concrete key implements the interface below, which generic key-consuming
-code may call on any key:
-- `get_owner_id`
-- `get_owner_category`
-- `get_association_id` — the store-minted surrogate id of the stored association
-- `get_name`
-- `get_resolution` — `nothing` for a key with no regular resolution
-- `get_time_series_type`
-- `get_interval` — `nothing` for a key that is not a forecast
-- `get_features`
-- `get_initial_timestamp` — `nothing` for a key with no regular initial timestamp
-- `get_count`, `Base.length`
+The id is the whole content. Everything else a caller might want — name,
+resolution, initial timestamp, horizon, interval, count, owner, features — lives
+in the catalog, and a key that also carried a copy could only disagree with it.
+`rename_time_series!` and a reassignment both change catalog columns while
+preserving the id, so a cached copy goes stale where the id cannot. Ask the store
+when you need those: [`list_metadata`](@ref) for a set of rows, or
+[`get_time_series_metadata`](@ref) for one.
 
-The default methods rely on the field names `owner_id`, `owner_category`,
-`association_id`, `name`, `time_series_type`, `resolution`,
-`initial_timestamp`, `features`, and `length`, and default to a single window
-with no interval; each concrete key defines the methods its fields don't cover
-(as [`NonSequentialTimeSeriesKey`](@ref) does).
+`T` is the exception, because it is the one fact that *cannot* drift: a stored
+association's time series type is part of its identity in the store and is never
+rewritten. Carrying it as a type parameter costs nothing at runtime (a key is an
+8-byte `isbits` value) and lets callers dispatch on it —
+`f(key::TimeSeriesKey{<:Forecast})`.
+
+Keys are produced by IS (`add_time_series!`, `list_metadata`), never constructed
+by users. Two keys are equal exactly when they name the same association.
 """
-abstract type TimeSeriesKey <: InfrastructureSystemsType end
+struct TimeSeriesKey{T <: TimeSeriesData}
+    association_id::Int64
 
-get_owner_id(key::TimeSeriesKey) = key.owner_id
-get_owner_category(key::TimeSeriesKey) = key.owner_category
+    # Inner, so the widening happens in one place and `new` cannot recurse into
+    # it: an outer method taking `Integer` would call itself for an `Int64`.
+    TimeSeriesKey{T}(association_id::Integer) where {T <: TimeSeriesData} =
+        new{T}(Int64(association_id))
+end
+
+"The store-minted surrogate id of the association this key names."
 get_association_id(key::TimeSeriesKey) = key.association_id
-get_name(key::TimeSeriesKey) = key.name
-get_resolution(key::TimeSeriesKey) = key.resolution
-get_time_series_type(key::TimeSeriesKey) = key.time_series_type
-get_initial_timestamp(key::TimeSeriesKey) = key.initial_timestamp
-get_features(key::TimeSeriesKey) = key.features
 
-"""
-Return the number of values one window of the series holds, so `get_length` and
-`Base.length` agree for every key type. A [`ForecastKey`](@ref) has no `length` field: for
-it this is the horizon count (the per-window length), **not** the number of windows — use
-[`get_count`](@ref) for that.
-"""
-get_length(key::TimeSeriesKey) = key.length
+"The stored time series type this key names."
+get_time_series_type(::TimeSeriesKey{T}) where {T} = T
+get_time_series_type(::Type{TimeSeriesKey{T}}) where {T} = T
 
-# A key represents a single window unless it is a forecast.
-get_interval(::TimeSeriesKey) = nothing
-get_count(::TimeSeriesKey) = 1
-Base.length(key::TimeSeriesKey) = get_length(key)
+# Two keys naming the same association are the same key, and hash alike. `T` is a
+# function of the id — the store decides what an id names — so letting it into
+# either would reintroduce exactly the failure the old all-fields comparison had:
+# two spellings of one series that compare unequal and miss each other in a Dict.
+Base.:(==)(a::TimeSeriesKey, b::TimeSeriesKey) =
+    get_association_id(a) == get_association_id(b)
+Base.hash(key::TimeSeriesKey, h::UInt) =
+    hash(get_association_id(key), hash(TimeSeriesKey, h))
 
-# The store a deserialization resolves association ids against. A key travels as its
-# association id alone, so rebuilding one needs the catalog that minted it; the
-# `deserialize` signatures are fixed by callers outside IS, so the store arrives out of
-# band rather than as an argument.
-const DESERIALIZATION_STORE = Base.ScopedValues.ScopedValue{Store}()
-
-"Whether a store is bound for the current deserialization scope."
-has_deserialization_store() =
-    !isnothing(Base.ScopedValues.get(DESERIALIZATION_STORE))
-
-"The store bound by the innermost enclosing [`with_deserialization_store`](@ref)."
-get_deserialization_store() = DESERIALIZATION_STORE[]
-
-"""
-    with_deserialization_store(f, store::Store)
-
-Run `f()` with `store` bound as the catalog that [`TimeSeriesKey`](@ref)
-deserialization resolves association ids against, and return its result.
-
-A serialized key is nothing but its `association_id`, so anything that
-deserializes a key-carrying struct — a component with a time-series-backed cost
-curve, a supplemental attribute — has to run inside this block. `deserialize` of a
-[`SystemData`](@ref) binds the store it just opened around its own work; a parent
-package that deserializes components itself must wrap that pass in this function.
-"""
-function with_deserialization_store(f, store::Store)
-    return Base.ScopedValues.with(f, DESERIALIZATION_STORE => store)
+# Module-qualified names would triple the width of every key in a table, and the
+# element type is worth the two extra words now that it is what a
+# `TimeSeriesFunctionData` is bound by.
+function Base.show(io::IO, key::TimeSeriesKey{T}) where {T}
+    print(io, "TimeSeriesKey{", nameof(T))
+    element = eltype(T)
+    element === Any || print(io, "{", nameof(element), "}")
+    print(io, "}(", get_association_id(key), ")")
+    return
 end
 
 """
-A key serializes to its `association_id` alone. The id is the store-minted surrogate
-for the whole association, so every other field of the key is a copy of something the
-catalog already holds; writing them out invites the two to disagree.
-"""
-serialize(key::TimeSeriesKey) = get_association_id(key)
+A key serializes to its `association_id`, its time series kind, and the value
+element type — `{"association_id": 7, "time_series_type": "SingleTimeSeries",
+"element_type": "Float64"}`.
 
+All three are immutable facts about the association: the store never rewrites
+any of them, so none can fall out of step with the catalog the way a cached
+`name` or `resolution` would. Carrying them is what lets a key deserialize
+*without a store* — the id alone would leave the type parameter unrecoverable for
+a field declared as the abstract `TimeSeriesKey`, and the kind alone would lose
+the element type a `TimeSeriesFunctionData` is bound by.
 """
-Rebuild a key from the association id it serialized to, against the store bound by
-[`with_deserialization_store`](@ref).
-"""
-function deserialize(::Type{<:TimeSeriesKey}, association_id::Integer)
-    has_deserialization_store() || throw(
-        ArgumentError(
-            "Deserializing a TimeSeriesKey needs the store that minted " *
-            "association_id=$association_id; run the deserialization inside " *
-            "`with_deserialization_store`.",
-        ),
+function serialize(key::TimeSeriesKey{T}) where {T}
+    return Dict{String, Any}(
+        "association_id" => get_association_id(key),
+        "time_series_type" => string(nameof(T)),
+        "element_type" => _key_element_name(eltype(T)),
     )
-    return get_time_series_key(get_deserialization_store(), association_id)
+end
+
+# The wire name of a key's value element type: the bare type name, so the
+# spelling does not carry a module prefix that a rename would invalidate. A tuple
+# element type has no useful `nameof` (every arity is `Tuple`), so it is spelled
+# out with its arity.
+_key_element_name(T::Type) = string(nameof(T))
+_key_element_name(T::Type{<:Tuple}) = "NTuple{$(length(T.parameters)),Float64}"
+
+"""
+Rebuild a key from what it serialized to.
+
+An `element_type` this version does not know leaves the kind unparameterized
+rather than guessing: a key whose element type cannot be named still addresses
+its series, and a read resolves the values from the catalog either way.
+"""
+function deserialize(::Type{<:TimeSeriesKey}, data::AbstractDict)
+    kind = _time_series_type_from_name(data["time_series_type"])
+    element = _key_element_type_from_name(get(data, "element_type", nothing))
+    T = isnothing(element) ? kind : kind{element}
+    return TimeSeriesKey{T}(data["association_id"])
+end
+
+# The value element types a key's parameter can name: the physical dtypes the
+# store holds, plus the function-data types IS decodes them into. Names, not
+# types, because the function-data types are defined after this file is included;
+# resolving by name at call time keeps this table free of include ordering.
+#
+# An allowlist rather than a bare `getfield`: a name off the wire must not be able
+# to reach for an arbitrary binding in this module.
+const _KEY_ELEMENT_TYPE_NAMES = Set{String}([
+    "Float64", "Float32", "Int64", "Int32", "Int16", "Int8",
+    "UInt64", "UInt32", "UInt16", "UInt8", "Bool",
+    "LinearFunctionData", "QuadraticFunctionData",
+    "PiecewiseLinearData", "PiecewiseStepData",
+])
+
+const _NTUPLE_ELEMENT = r"^(?:NTuple\{(\d+), *Float64\}|Tuple\{(?:Float64(?:, *)?)+\})$"
+
+function _key_element_type_from_name(name)
+    isnothing(name) && return nothing
+    s = String(name)
+    s in _KEY_ELEMENT_TYPE_NAMES && return getfield(@__MODULE__, Symbol(s))
+    m = match(_NTUPLE_ELEMENT, s)
+    isnothing(m) && return nothing
+    isnothing(m.captures[1]) && return NTuple{count(==(','), s) + 1, Float64}
+    return NTuple{parse(Int, m.captures[1]), Float64}
 end
 
 """
-A unique key to identify and retrieve a [`StaticTimeSeries`](@ref)
+    TimeSeriesMetadata{T <: TimeSeriesData}
 
-See: [`get_time_series_keys`](@ref) and [`get_time_series(::TimeSeriesOwners, ::TimeSeriesKey)`](@ref).
+One catalog row: everything the store records about a time series association
+except its values. Returned by [`list_metadata`](@ref).
+
+This is where the descriptive attributes live now that a [`TimeSeriesKey`](@ref)
+carries only its id. Reading them from a row rather than a key is the whole point
+— the row is a snapshot the caller asked for and knows the age of, where a key
+that cached them could hand back a name the catalog had since changed.
+
+Fields a row's type does not use are `nothing`: `resolution` and
+`initial_timestamp` on a `NonSequentialTimeSeries` (its timestamps are irregular
+and stored with the data), `horizon` / `interval` / `count` on a static series,
+`length` on a forecast, whose per-window length is its horizon count.
 """
-@kwdef struct StaticTimeSeriesKey <: TimeSeriesKey
+struct TimeSeriesMetadata{T <: TimeSeriesData}
+    key::TimeSeriesKey{T}
     owner_id::Int
     owner_category::InfraStore.OwnerCategory
-    association_id::Int
-    time_series_type::Type{<:StaticTimeSeries}
     name::String
-    initial_timestamp::Dates.DateTime
-    resolution::Dates.Period
-    length::Int
+    initial_timestamp::Union{Nothing, Dates.DateTime}
+    resolution::Union{Nothing, Dates.Period}
+    horizon::Union{Nothing, Dates.Period}
+    interval::Union{Nothing, Dates.Period}
+    count::Union{Nothing, Int}
+    length::Union{Nothing, Int}
     features::Dict{String, Any}
 end
 
-"""
-A unique key to identify and retrieve a [`NonSequentialTimeSeries`](@ref)
+"The [`TimeSeriesKey`](@ref) that addresses the association this row describes."
+get_time_series_key(md::TimeSeriesMetadata) = md.key
+get_association_id(md::TimeSeriesMetadata) = get_association_id(md.key)
+get_time_series_type(::TimeSeriesMetadata{T}) where {T} = T
+get_owner_id(md::TimeSeriesMetadata) = md.owner_id
+get_owner_category(md::TimeSeriesMetadata) = md.owner_category
+get_name(md::TimeSeriesMetadata) = md.name
+get_initial_timestamp(md::TimeSeriesMetadata) = md.initial_timestamp
+get_resolution(md::TimeSeriesMetadata) = md.resolution
+get_horizon(md::TimeSeriesMetadata) = md.horizon
+get_interval(md::TimeSeriesMetadata) = md.interval
+get_count(md::TimeSeriesMetadata) = md.count
+get_features(md::TimeSeriesMetadata) = md.features
 
-Unlike [`StaticTimeSeriesKey`](@ref), a non-sequential series is irregular: it has
-no `resolution` and no regular `initial_timestamp` (its timestamps are stored with
-the data), so the key carries only its `length`. This mirrors the dedicated
-non-sequential key in the InfraStore backend.
-
-See: [`get_time_series_keys`](@ref) and [`get_time_series(::TimeSeriesOwners, ::TimeSeriesKey)`](@ref).
 """
-@kwdef struct NonSequentialTimeSeriesKey <: TimeSeriesKey
-    owner_id::Int
-    owner_category::InfraStore.OwnerCategory
-    association_id::Int
-    time_series_type::Type{<:NonSequentialTimeSeries}
-    name::String
-    length::Int
-    features::Dict{String, Any}
+The number of values one window of the series holds. A forecast row has no
+`length` of its own: for it this is the horizon count (the per-window length),
+**not** the number of windows — use [`get_count`](@ref) for that.
+"""
+get_length(md::TimeSeriesMetadata) = md.length
+get_length(md::TimeSeriesMetadata{<:Forecast}) = get_horizon_count(md)
+Base.length(md::TimeSeriesMetadata) = get_length(md)
+
+"The number of time steps in one window of a forecast row."
+get_horizon_count(md::TimeSeriesMetadata{<:Forecast}) =
+    get_horizon_count(get_horizon(md), get_resolution(md))
+
+function Base.show(io::IO, md::TimeSeriesMetadata{T}) where {T}
+    print(io, "TimeSeriesMetadata{", nameof(T), "}(", repr(md.name),
+        ", association_id=", get_association_id(md), ", owner_id=", md.owner_id, ")")
 end
 
-# A non-sequential key is irregular: it has neither field.
-get_resolution(::NonSequentialTimeSeriesKey) = nothing
-get_initial_timestamp(::NonSequentialTimeSeriesKey) = nothing
+"""
+The time series type of an addition staged onto a batch, held for the span between
+staging and the store writing it.
+
+The catalog mints the id on insert, so a staged addition does not have one yet, and a
+key is immutable. Staging therefore produces this — the one thing a key needs besides
+the id — and [`build_key`](@ref) turns it into the real key once the write hands back
+the id it was filed under.
+"""
+struct StagedKey{T <: TimeSeriesData} end
 
 """
-A unique key to identify and retrieve a [`Forecast`](@ref)
-
-See: [`get_time_series_keys`](@ref) and [`get_time_series(::TimeSeriesOwners, ::TimeSeriesKey)`](@ref).
-"""
-@kwdef struct ForecastKey <: TimeSeriesKey
-    owner_id::Int
-    owner_category::InfraStore.OwnerCategory
-    association_id::Int
-    time_series_type::Type{<:Forecast}
-    name::String
-    initial_timestamp::Dates.DateTime
-    resolution::Dates.Period
-    horizon::Dates.Period
-    interval::Dates.Period
-    count::Int
-    features::Dict{String, Any}
-end
-
-get_horizon(key::ForecastKey) = key.horizon
-get_interval(key::ForecastKey) = key.interval
-get_count(key::ForecastKey) = key.count
-get_horizon_count(key::ForecastKey) =
-    get_horizon_count(get_horizon(key), get_resolution(key))
-# A ForecastKey has no `length` field; its per-window length is the horizon count.
-get_length(key::ForecastKey) = get_horizon_count(key)
-Base.length(key::ForecastKey) = get_horizon_count(key)
-
-# Keys are values: two keys naming the same stored association are equal, whatever
-# spelling their periods arrived in (`Hour(1)` from a constructor, `Millisecond(3600000)`
-# back from the catalog — `==` and `hash` on `Period` already agree across those).
-function Base.:(==)(a::T, b::T) where {T <: TimeSeriesKey}
-    return all(getfield(a, f) == getfield(b, f) for f in fieldnames(T))
-end
-
-function Base.hash(key::T, h::UInt) where {T <: TimeSeriesKey}
-    h = hash(T, h)
-    for f in fieldnames(T)
-        h = hash(getfield(key, f), h)
-    end
-    return h
-end
-
-# All concrete key types, for use in struct fields: a `Union` of concrete types
-# union-splits (no boxing / dynamic dispatch in per-timestep paths), unlike the
-# abstract `TimeSeriesKey`.
-const ConcreteTimeSeriesKey =
-    Union{StaticTimeSeriesKey, NonSequentialTimeSeriesKey, ForecastKey}
-
-"""
-Everything a [`TimeSeriesKey`](@ref) needs except its `association_id`, held for the
-span between staging an addition onto a batch and the store writing it.
-
-The catalog mints the id on insert, so a staged addition does not have one yet — and
-a key is a value, immutable, never patched after the fact. Staging therefore produces
-this instead, and [`build_key`](@ref) turns it into the real key once the write hands
-back the id it was filed under. `K` is the concrete key type the fields belong to, so
-the built key's type is known from the staged one alone.
-"""
-struct StagedKey{K <: TimeSeriesKey, NT <: NamedTuple}
-    fields::NT
-end
-
-StagedKey{K}(fields::NT) where {K <: TimeSeriesKey, NT <: NamedTuple} =
-    StagedKey{K, NT}(fields)
-
-"""
-    build_key(staged::StagedKey, association_id) -> ConcreteTimeSeriesKey
+    build_key(staged::StagedKey, association_id) -> TimeSeriesKey
 
 The key `staged` describes, filed under `association_id` — the id the store minted for
 its row.
 """
-build_key(staged::StagedKey{K}, association_id::Integer) where {K} =
-    K(; staged.fields..., association_id = Int(association_id))
+build_key(::StagedKey{T}, association_id::Integer) where {T} =
+    TimeSeriesKey{T}(association_id)
 
 """
 Provides counts of time series including attachments to components and supplemental

--- a/src/time_series_value_curve.jl
+++ b/src/time_series_value_curve.jl
@@ -50,9 +50,9 @@ retrieved time series data.
     "The underlying `TimeSeriesFunctionData` representation of this `ValueCurve`"
     function_data::T
     "The initial input value, either a TimeSeriesKey or nothing"
-    initial_input::Union{Nothing, TimeSeriesKey}
+    initial_input::Union{Nothing, ScalarTimeSeriesKey}
     "Optional, an explicit representation of the input value at zero output."
-    input_at_zero::Union{Nothing, TimeSeriesKey} = nothing
+    input_at_zero::Union{Nothing, ScalarTimeSeriesKey} = nothing
 end
 
 TimeSeriesIncrementalCurve(function_data, initial_input) =
@@ -87,9 +87,9 @@ retrieved time series data.
     "The underlying `TimeSeriesFunctionData` representation of this `ValueCurve`"
     function_data::T
     "The initial input value, either a TimeSeriesKey or nothing"
-    initial_input::Union{Nothing, TimeSeriesKey}
+    initial_input::Union{Nothing, ScalarTimeSeriesKey}
     "Optional, an explicit representation of the input value at zero output."
-    input_at_zero::Union{Nothing, TimeSeriesKey} = nothing
+    input_at_zero::Union{Nothing, ScalarTimeSeriesKey} = nothing
 end
 
 TimeSeriesAverageRateCurve(function_data, initial_input) =

--- a/src/time_series_value_curve.jl
+++ b/src/time_series_value_curve.jl
@@ -50,9 +50,9 @@ retrieved time series data.
     "The underlying `TimeSeriesFunctionData` representation of this `ValueCurve`"
     function_data::T
     "The initial input value, either a TimeSeriesKey or nothing"
-    initial_input::Union{Nothing, ConcreteTimeSeriesKey}
+    initial_input::Union{Nothing, TimeSeriesKey}
     "Optional, an explicit representation of the input value at zero output."
-    input_at_zero::Union{Nothing, ConcreteTimeSeriesKey} = nothing
+    input_at_zero::Union{Nothing, TimeSeriesKey} = nothing
 end
 
 TimeSeriesIncrementalCurve(function_data, initial_input) =
@@ -87,9 +87,9 @@ retrieved time series data.
     "The underlying `TimeSeriesFunctionData` representation of this `ValueCurve`"
     function_data::T
     "The initial input value, either a TimeSeriesKey or nothing"
-    initial_input::Union{Nothing, ConcreteTimeSeriesKey}
+    initial_input::Union{Nothing, TimeSeriesKey}
     "Optional, an explicit representation of the input value at zero output."
-    input_at_zero::Union{Nothing, ConcreteTimeSeriesKey} = nothing
+    input_at_zero::Union{Nothing, TimeSeriesKey} = nothing
 end
 
 TimeSeriesAverageRateCurve(function_data, initial_input) =
@@ -181,8 +181,11 @@ static_curve_type(::Type{<:TimeSeriesInputOutputCurve}) = InputOutputCurve
 static_curve_type(::Type{<:TimeSeriesIncrementalCurve}) = IncrementalCurve
 static_curve_type(::Type{<:TimeSeriesAverageRateCurve}) = AverageRateCurve
 
+# `<:` on the inner parameter: `TimeSeriesFunctionData{T}` is a `UnionAll` over
+# the time series type, so a constructed curve's parameter is the concrete
+# two-parameter form and would not match the partial spelling.
 _static_function_data_type(
-    ::ValueCurve{TimeSeriesFunctionData{T}},
+    ::ValueCurve{<:TimeSeriesFunctionData{T}},
 ) where {T <: StaticFunctionData} = T
 
 """

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -59,7 +59,7 @@ function Base.summary(x::Forecast)
     return "$(label) resolution=$(resolution) interval=$(interval)"
 end
 
-function Base.summary(x::ForecastKey)
+function Base.summary(x::TimeSeriesKey{<:Forecast})
     label = make_label(typeof(x), get_name(x))
     resolution = Dates.canonicalize(get_resolution(x))
     interval = Dates.canonicalize(get_interval(x))

--- a/src/utils/print.jl
+++ b/src/utils/print.jl
@@ -50,16 +50,11 @@ make_label(type::Type{<:InfrastructureSystemsType}, name) = "$(nameof(type)): $n
 Base.summary(x::InfrastructureSystemsComponent) = make_label(typeof(x), get_name(x))
 Base.summary(x::SupplementalAttribute) = make_label(typeof(x), get_id(x))
 Base.summary(x::TimeSeriesData) = make_label(typeof(x), get_name(x))
-Base.summary(x::TimeSeriesKey) = make_label(typeof(x), get_name(x))
+# A key is its id and its type — the name and resolution the old descriptive key
+# printed live in the catalog now, so the summary is the `show` form.
+Base.summary(x::TimeSeriesKey) = sprint(show, x)
 
 function Base.summary(x::Forecast)
-    label = make_label(typeof(x), get_name(x))
-    resolution = Dates.canonicalize(get_resolution(x))
-    interval = Dates.canonicalize(get_interval(x))
-    return "$(label) resolution=$(resolution) interval=$(interval)"
-end
-
-function Base.summary(x::TimeSeriesKey{<:Forecast})
     label = make_label(typeof(x), get_name(x))
     resolution = Dates.canonicalize(get_resolution(x))
     interval = Dates.canonicalize(get_interval(x))

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -229,7 +229,8 @@ end
 # series is read for. A catalog row carries more — the owner columns (constant
 # across this table, since it IS one owner's), the content hash (32 raw bytes),
 # the remaining descriptive labels — and a table wide enough to hold all of it
-# truncates away the columns above. Reach for `list_metadata` when you want them.
+# truncates away the columns above. Reach for `list_time_series_metadata` when you
+# want them.
 const _TIME_SERIES_DISPLAY_COLUMNS = (
     :name, :element_type, :initial_timestamp, :resolution, :horizon, :interval,
     :count, :length, :units, :features,
@@ -237,7 +238,7 @@ const _TIME_SERIES_DISPLAY_COLUMNS = (
 
 function show_time_series(io::IO, owner::TimeSeriesOwners)
     data_by_type = Dict{Any, Vector{OrderedDict{String, Any}}}()
-    for md in list_metadata(owner)
+    for md in list_time_series_metadata(owner)
         # Grouped by KIND, not by the row's full type: the type parameter carries
         # the value element type too, so grouping on it would split one owner's
         # `SingleTimeSeries{Float64}` and `SingleTimeSeries{PiecewiseStepData}`

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -227,23 +227,31 @@ end
 
 function show_time_series(io::IO, owner::TimeSeriesOwners)
     data_by_type = Dict{Any, Vector{OrderedDict{String, Any}}}()
-    for key in get_time_series_keys(owner)
-        ts_type = get_time_series_type(key)
+    for md in list_metadata(owner)
+        ts_type = get_time_series_type(md)
         if !haskey(data_by_type, ts_type)
             data_by_type[ts_type] = Vector{OrderedDict{String, Any}}()
         end
         data = OrderedDict{String, Any}()
-        for (fname, ftype) in zip(fieldnames(typeof(key)), fieldtypes(typeof(key)))
-            if ftype <: Type{<:TimeSeriesData}
-                data[string(fname)] = string(nameof(Base.getproperty(key, fname)))
+        # The row's own columns, minus the key: the id is shown separately, and a
+        # key renders as a type plus that id, which reads as noise in a table.
+        for fname in fieldnames(typeof(md))
+            fname === :key && continue
+            value = Base.getproperty(md, fname)
+            if value isa Type
+                data[string(fname)] = string(nameof(value))
             else
-                data[string(fname)] = Base.getproperty(key, fname)
+                data[string(fname)] = value
             end
         end
         push!(data_by_type[ts_type], data)
     end
-    for rows in values(data_by_type)
-        PrettyTables.pretty_table(io, DataFrame(rows))
+    # The type titles each table: it is the row's type parameter now, not a
+    # column, so without this it would not appear in the output at all.
+    for (ts_type, rows) in data_by_type
+        PrettyTables.pretty_table(
+            io, DataFrame(rows); title = string(nameof(ts_type)),
+        )
     end
 end
 

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -225,18 +225,30 @@ function show_supplemental_attributes(io::IO, component::InfrastructureSystemsCo
     end
 end
 
+# What identifies and shapes a series, which is what a listing of one owner's
+# series is read for. A catalog row carries more — the owner columns (constant
+# across this table, since it IS one owner's), the content hash (32 raw bytes),
+# the remaining descriptive labels — and a table wide enough to hold all of it
+# truncates away the columns above. Reach for `list_metadata` when you want them.
+const _TIME_SERIES_DISPLAY_COLUMNS = (
+    :name, :element_type, :initial_timestamp, :resolution, :horizon, :interval,
+    :count, :length, :units, :features,
+)
+
 function show_time_series(io::IO, owner::TimeSeriesOwners)
     data_by_type = Dict{Any, Vector{OrderedDict{String, Any}}}()
     for md in list_metadata(owner)
-        ts_type = get_time_series_type(md)
+        # Grouped by KIND, not by the row's full type: the type parameter carries
+        # the value element type too, so grouping on it would split one owner's
+        # `SingleTimeSeries{Float64}` and `SingleTimeSeries{PiecewiseStepData}`
+        # rows into separate tables under the same heading. The element type is a
+        # column of its own instead.
+        ts_type = get_time_series_kind(md)
         if !haskey(data_by_type, ts_type)
             data_by_type[ts_type] = Vector{OrderedDict{String, Any}}()
         end
         data = OrderedDict{String, Any}()
-        # The row's own columns, minus the key: the id is shown separately, and a
-        # key renders as a type plus that id, which reads as noise in a table.
-        for fname in fieldnames(typeof(md))
-            fname === :key && continue
+        for fname in _TIME_SERIES_DISPLAY_COLUMNS
             value = Base.getproperty(md, fname)
             if value isa Type
                 data[string(fname)] = string(nameof(value))
@@ -246,8 +258,8 @@ function show_time_series(io::IO, owner::TimeSeriesOwners)
         end
         push!(data_by_type[ts_type], data)
     end
-    # The type titles each table: it is the row's type parameter now, not a
-    # column, so without this it would not appear in the output at all.
+    # The kind titles each table: it is part of the row's type parameter now, not
+    # a column, so without this it would not appear in the output at all.
     for (ts_type, rows) in data_by_type
         PrettyTables.pretty_table(
             io, DataFrame(rows); title = string(nameof(ts_type)),

--- a/src/utils/test.jl
+++ b/src/utils/test.jl
@@ -50,7 +50,7 @@ only the store that minted it can resolve back into a key.
 """
 mutable struct TimeSeriesKeyTestComponent <: InfrastructureSystemsComponent
     name::String
-    time_series_key::ConcreteTimeSeriesKey
+    time_series_key::TimeSeriesKey
     internal::InfrastructureSystemsInternal
 end
 

--- a/src/utils/utils.jl
+++ b/src/utils/utils.jl
@@ -255,8 +255,8 @@ compare_values(x, y; kwargs...) = compare_values(nothing, x, y; kwargs...)
 _fetch_match_fn(match_fn::Function) = match_fn
 _fetch_match_fn(::Nothing) = isequivalent
 
-# Whether to stop recursing and apply the match_fn. Type-valued fields (e.g.
-# `ForecastKey.time_series_type`) are leaves: compare them directly rather than
+# Whether to stop recursing and apply the match_fn. Type-valued fields are
+# leaves: compare them directly rather than
 # recursing into type internals. A concrete type is a `DataType`; an
 # unparametrized parametric type (e.g. `Deterministic`) is a `UnionAll` whose
 # `fieldnames` (`:var`, `:body`) would otherwise drive a recursion that crashes.

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,7 +26,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
-InfraStore = "0.10"
+InfraStore = "0.11"
 
 # `[sources]` applies ONLY to the top-level project, so the package's own entries are NOT
 # inherited by this environment. PowerCoreOpenAPIModels and PowerTimeSeriesOpenAPIModels are

--- a/test/common.jl
+++ b/test/common.jl
@@ -122,13 +122,6 @@ end
 
 sort_name!(x) = sort!(collect(x); by = IS.get_name)
 
-"""
-A system holding one `Deterministic` per name in `names`, returned with the real
-`TimeSeriesKey` for each, in order.
-
-A key serializes to its association id alone, so a serialization round trip needs keys the
-system's store can resolve; a fabricated key no longer survives one.
-"""
 # One forecast window of `n` values of the given element type. A key names one
 # stored series, so a `TimeSeriesFunctionData{T}` can only wrap a key of `T`
 # values — a fixture that always stored `Float64` could only build combinations
@@ -143,6 +136,14 @@ _fixture_window(::Type{IS.PiecewiseLinearData}, n) =
 _fixture_window(::Type{IS.PiecewiseStepData}, n) =
     [IS.PiecewiseStepData([1.0, 2.0, 3.0], [i, 2i]) for i in 1.0:n]
 
+"""
+A system holding one `Deterministic` per name in `names`, returned with the real
+`TimeSeriesKey` for each, in order.
+
+A key names a store-minted association id, so tests that exercise real keys need
+ones a system actually minted; a fabricated id names nothing the store can read
+back.
+"""
 function create_forecast_key_fixture(
     names...;
     horizon_count = 24,
@@ -165,6 +166,3 @@ function create_forecast_key_fixture(
     end
     return sys, keys
 end
-
-"The store a system's keys resolve against during deserialization."
-key_store(sys::IS.SystemData) = IS.get_data_store(sys.time_series_manager)

--- a/test/common.jl
+++ b/test/common.jl
@@ -129,7 +129,25 @@ A system holding one `Deterministic` per name in `names`, returned with the real
 A key serializes to its association id alone, so a serialization round trip needs keys the
 system's store can resolve; a fabricated key no longer survives one.
 """
-function create_forecast_key_fixture(names...; horizon_count = 24)
+# One forecast window of `n` values of the given element type. A key names one
+# stored series, so a `TimeSeriesFunctionData{T}` can only wrap a key of `T`
+# values — a fixture that always stored `Float64` could only build combinations
+# the type system now rejects.
+_fixture_window(::Type{Float64}, n) = rand(n)
+_fixture_window(::Type{IS.LinearFunctionData}, n) =
+    [IS.LinearFunctionData(i, 2i) for i in 1.0:n]
+_fixture_window(::Type{IS.QuadraticFunctionData}, n) =
+    [IS.QuadraticFunctionData(i, 2i, 3i) for i in 1.0:n]
+_fixture_window(::Type{IS.PiecewiseLinearData}, n) =
+    [IS.PiecewiseLinearData([(x = 1.0, y = i), (x = 2.0, y = 2i)]) for i in 1.0:n]
+_fixture_window(::Type{IS.PiecewiseStepData}, n) =
+    [IS.PiecewiseStepData([1.0, 2.0, 3.0], [i, 2i]) for i in 1.0:n]
+
+function create_forecast_key_fixture(
+    names...;
+    horizon_count = 24,
+    element_type::Type = Float64,
+)
     sys = IS.SystemData(; time_series_in_memory = true)
     component = IS.TestComponent("Component1", 5)
     IS.add_component!(sys, component)
@@ -137,7 +155,9 @@ function create_forecast_key_fixture(names...; horizon_count = 24)
     resolution = Dates.Hour(1)
     keys = map(names) do name
         forecast = IS.Deterministic(;
-            data = SortedDict(initial_time => rand(horizon_count)),
+            data = SortedDict(
+                initial_time => _fixture_window(element_type, horizon_count),
+            ),
             name = name,
             resolution = resolution,
         )

--- a/test/test_convexity_checks.jl
+++ b/test/test_convexity_checks.jl
@@ -259,42 +259,33 @@ end
 end
 
 @testset "is_valid_data rejects time-series-backed data" begin
-    forecast_key = IS.ForecastKey(;
-        owner_id = 1,
-        owner_category = IS.InfraStore.Component,
-        association_id = 1,
-        time_series_type = IS.Deterministic,
-        name = "test_forecast",
-        initial_timestamp = Dates.DateTime("2020-01-01"),
-        resolution = Dates.Hour(1),
-        horizon = Dates.Hour(24),
-        interval = Dates.Hour(24),
-        count = 1,
-        features = Dict{String, Any}(),
-    )
+    # A key names one stored series, so its element type is fixed: a
+    # `TimeSeriesFunctionData{T}` can only wrap a key of `T` values.
+    lin_key = IS.TimeSeriesKey{IS.Deterministic{IS.LinearFunctionData}}(1)
+    step_key = IS.TimeSeriesKey{IS.Deterministic{IS.PiecewiseStepData}}(1)
 
     # Raw TimeSeriesFunctionData — no inline data to validate
-    ts_lin_fd = IS.TimeSeriesLinearFunctionData(forecast_key)
+    ts_lin_fd = IS.TimeSeriesLinearFunctionData(lin_key)
     @test_throws ArgumentError IS.is_valid_data(ts_lin_fd)
 
-    ts_psd_fd = IS.TimeSeriesPiecewiseStepData(forecast_key)
+    ts_psd_fd = IS.TimeSeriesPiecewiseStepData(step_key)
     @test_throws ArgumentError IS.is_valid_data(ts_psd_fd)
 
     # TimeSeriesInputOutputCurve — wraps TimeSeriesFunctionData
     ts_io_curve =
-        IS.TimeSeriesInputOutputCurve(IS.TimeSeriesLinearFunctionData(forecast_key))
+        IS.TimeSeriesInputOutputCurve(IS.TimeSeriesLinearFunctionData(lin_key))
     @test_throws ArgumentError IS.is_valid_data(ts_io_curve)
 
     # TimeSeriesIncrementalCurve — wraps TimeSeriesFunctionData
     ts_inc_curve = IS.TimeSeriesIncrementalCurve(
-        IS.TimeSeriesPiecewiseStepData(forecast_key),
+        IS.TimeSeriesPiecewiseStepData(step_key),
         nothing,
     )
     @test_throws ArgumentError IS.is_valid_data(ts_inc_curve)
 
     # TimeSeriesAverageRateCurve — wraps TimeSeriesFunctionData
     ts_arc_curve = IS.TimeSeriesAverageRateCurve(
-        IS.TimeSeriesPiecewiseStepData(forecast_key),
+        IS.TimeSeriesPiecewiseStepData(step_key),
         nothing,
     )
     @test_throws ArgumentError IS.is_valid_data(ts_arc_curve)

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -286,11 +286,8 @@ end
         IS.InputOutputCurve(IS.QuadraticFunctionData(1, 2, 3)),
         fuel_key,
     )
-    @test IS.serialize(fc_ts)["fuel_cost_time_series"] ==
-          IS.get_association_id(fuel_key)
-    fc_ts_rt = IS.with_deserialization_store(key_store(sys)) do
-        IS.deserialize(IS.FuelCurve, IS.serialize(fc_ts))
-    end
+    @test IS.serialize(fc_ts)["fuel_cost_time_series"] == IS.serialize(fuel_key)
+    fc_ts_rt = IS.deserialize(IS.FuelCurve, IS.serialize(fc_ts))
     @test IS.compare_values(fc_ts_rt, fc_ts)
 
     @test zero(cc) == IS.CostCurve(IS.InputOutputCurve(IS.LinearFunctionData(0.0, 0.0)))
@@ -358,26 +355,18 @@ end
 end
 
 @testset "is_time_series_backed for CostCurve and FuelCurve" begin
-    forecast_key = IS.ForecastKey(;
-        owner_id = 1,
-        owner_category = IS.InfraStore.Component,
-        association_id = 1,
-        time_series_type = IS.Deterministic,
-        name = "fuel_price",
-        initial_timestamp = Dates.DateTime("2020-01-01"),
-        resolution = Dates.Hour(1),
-        horizon = Dates.Hour(24),
-        interval = Dates.Hour(24),
-        count = 1,
-        features = Dict{String, Any}(),
-    )
+    # A key names one stored series, so its element type is fixed: a
+    # `TimeSeriesFunctionData{T}` can only wrap a key of `T` values.
+    quad_key = IS.TimeSeriesKey{IS.Deterministic{IS.QuadraticFunctionData}}(1)
+    # A fuel cost varies as a plain scalar over time, not as function data.
+    forecast_key = IS.TimeSeriesKey{IS.Deterministic{Float64}}(1)
 
     # Scalar dispatches
     @test IS.is_time_series_backed(forecast_key) == true
     @test IS.is_time_series_backed(nothing) == false
 
     static_vc = IS.InputOutputCurve(IS.QuadraticFunctionData(1, 2, 3))
-    ts_vc = IS.TimeSeriesInputOutputCurve(IS.TimeSeriesQuadraticFunctionData(forecast_key))
+    ts_vc = IS.TimeSeriesInputOutputCurve(IS.TimeSeriesQuadraticFunctionData(quad_key))
 
     # CostCurve: only time-series-backed when its value curve is
     @test IS.is_time_series_backed(IS.CostCurve(static_vc)) == false
@@ -444,9 +433,7 @@ end
 
     # The key-form round trip resolves the serialized association id against the store
     # that minted it.
-    fc_ts_rt = IS.with_deserialization_store(key_store(sys)) do
-        IS.deserialize(IS.FuelCurve, IS.serialize(fc_ts))
-    end
+    fc_ts_rt = IS.deserialize(IS.FuelCurve, IS.serialize(fc_ts))
     @test IS.compare_values(fc_ts_rt, fc_ts)
 end
 

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -425,6 +425,26 @@ end
         fuel_cost_time_series = key,
     )
 
+    # A scalar field takes a closed union of concrete key types, so it is stored
+    # inline rather than boxed. A key naming anything the field cannot resolve to
+    # one Float64 per timestep is refused where it is set, with a message that
+    # says what the field is for — not where it would be read.
+    for wrong in (
+        IS.TimeSeriesKey{IS.Probabilistic{Float64}}(1),
+        IS.TimeSeriesKey{IS.SingleTimeSeries{Float32}}(1),
+        IS.TimeSeriesKey{IS.SingleTimeSeries{IS.PiecewiseStepData}}(1),
+    )
+        err = try
+            IS.FuelCurve(vc, wrong)
+            nothing
+        catch e
+            e
+        end
+        @test err isa ArgumentError
+        @test occursin("scalar time series field", sprint(showerror, err))
+    end
+    @test isconcretetype(typeof(IS.get_fuel_cost_time_series(fc_ts)))
+
     # Neither set: rejected by the inner constructor
     @test_throws ArgumentError IS.FuelCurve(; value_curve = vc)
 

--- a/test/test_element_type_conformance.jl
+++ b/test/test_element_type_conformance.jl
@@ -141,3 +141,54 @@ end
     end
     @test checked >= 5
 end
+
+@testset "element_type names are the store's neutral vocabulary" begin
+    # A regression guard on the names themselves: they are a storage contract
+    # shared with every other binding, not Julia type names. The composite tags
+    # are the ones IS's own values carry, so they are asserted off the encoder.
+    encode(values) = IS.InfraStore.encode_element_values(values)[2]
+    @test encode([IS.LinearFunctionData(1.0, 2.0)]) == "linear_function"
+    @test encode([IS.QuadraticFunctionData(1.0, 2.0, 3.0)]) == "quadratic_function"
+    @test encode([IS.PiecewiseLinearData([(0.0, 1.0), (1.0, 3.0)])]) == "piecewise_linear"
+    @test encode([IS.PiecewiseStepData([0.0, 1.0], [2.0])]) == "piecewise_step"
+    @test encode([(1.0, 2.0, 3.0)]) == "tuple(3,f64)"
+
+    # A value type nothing encodes is a loud error, not a silent scalar.
+    @test_throws IS.InfraStore.InvalidParameterError encode([1.0 + 2.0im])
+
+    # A scalar dtype is named by the store on the way in — IS never tags one — so
+    # those spellings are pinned off the catalog rows of a round trip instead.
+    sys = IS.SystemData()
+    component = IS.TestComponent("conformance", 1)
+    IS.add_component!(sys, component)
+    initial_time = Dates.DateTime("2020-01-01")
+    resolution = Dates.Hour(1)
+    for (name, values, tag) in (
+        ("floats", [1.0, 2.0, 3.0], "f64"),
+        ("ints", Int64[1, 2, 3], "i64"),
+        ("bools", Bool[true, false, true], "bool"),
+    )
+        IS.add_time_series!(
+            sys,
+            component,
+            IS.SingleTimeSeries(name, initial_time, resolution, values),
+        )
+        @test IS.get_element_type(only(IS.list_metadata(sys; name = name))) == tag
+    end
+end
+
+@testset "the vendored corpus matches the live one when both are present" begin
+    live = _live_element_type_vectors_path()
+    if isempty(live) || live == VENDORED_ELEMENT_TYPE_VECTORS
+        @test isfile(VENDORED_ELEMENT_TYPE_VECTORS)
+    elseif read(live) != read(VENDORED_ELEMENT_TYPE_VECTORS)
+        # Not a failure: the live checkout may be mid-edit. The testsets above ran
+        # against `live`, so the contract is still asserted — only the pinned copy
+        # is stale, and refreshing it is a deliberate step (see the README).
+        @warn "Vendored conformance corpus differs from the live one; refresh it" live vendored =
+            VENDORED_ELEMENT_TYPE_VECTORS
+        @test_skip false
+    else
+        @test true
+    end
+end

--- a/test/test_element_type_conformance.jl
+++ b/test/test_element_type_conformance.jl
@@ -1,5 +1,12 @@
-# Asserts IS's `_storage_array` / `_decode_static_values` against the shared
-# `element_type_vectors.json` conformance corpus.
+# Asserts IS's `FunctionData` against the shared `element_type_vectors.json`
+# conformance corpus.
+#
+# The encodings themselves live in InfraStore.jl now, with their own conformance
+# test covering every vector in both directions. What IS still owns is the two
+# ends: the `element_type_tag` / `element_row_width` / `write_element_row!`
+# methods that pack one of *its* values, and the `_IS_ELEMENT_TYPES` table that
+# names which of its types a tag decodes to. This checks that pair against the
+# corpus, so a drift in either shows up here rather than in a store round trip.
 
 # The corpus is vendored at `test/conformance/element_type_vectors.json` (see the README
 # there) so the parity check always runs. A live copy — from `INFRASTORE_CONFORMANCE_DIR`
@@ -93,15 +100,20 @@ end
         _is_representable(vector) || continue
         expected = _vector_expected_values(vector)
         isnothing(expected) && continue
-        # Only the static layouts decode through `_decode_static_values`;
-        # forecast layouts go through `_decode_forecast_window`, which slices
-        # a window out first and is covered separately.
-        vector["leading_dims"] == 1 || continue
 
         arr = _vector_storage_array(vector)
-        encoding = IS._element_encoding(vector["element_type"])
-        got = IS._decode_static_values(arr, encoding, size(arr, 1))
-        @test got == expected
+        got = IS.InfraStore.decode_element_values(
+            arr, vector["element_type"], vector["leading_dims"];
+            types = IS._IS_ELEMENT_TYPES,
+        )
+        # Forecast layouts come back windowed, so flatten to the corpus'
+        # row-major timestep order before comparing.
+        flat = if got isa AbstractVector
+            got
+        else
+            vec(permutedims(got, reverse(ntuple(identity, ndims(got)))))
+        end
+        @test flat == expected
         checked += 1
     end
     # A corpus whose vectors all became unrepresentable would silently stop
@@ -116,49 +128,16 @@ end
         _is_representable(vector) || continue
         expected = _vector_expected_values(vector)
         isnothing(expected) && continue
+        # The store packs a flat vector of values; a forecast's leading axes are
+        # restored by the constructor that writes it, not by the encoder.
         vector["leading_dims"] == 1 || continue
 
-        encoded, element_type = IS._storage_array(expected)
-        # The element type IS tags the array with is the store's own name...
+        encoded, element_type = IS.InfraStore.encode_element_values(expected)
+        # The element type IS's values tag themselves with is the store's own name...
         @test element_type == vector["element_type"]
-        # ...and the bytes it produces are the ones the corpus pins.
+        # ...and the bytes they produce are the ones the corpus pins.
         @test encoded == _vector_storage_array(vector)
         checked += 1
     end
     @test checked >= 5
-end
-
-@testset "element_type names are the store's neutral vocabulary" begin
-    # A regression guard on the names themselves: they are a storage contract
-    # shared with every other binding, not Julia type names.
-    @test IS._storage_array([IS.LinearFunctionData(1.0, 2.0)])[2] == "linear_function"
-    @test IS._storage_array([IS.QuadraticFunctionData(1.0, 2.0, 3.0)])[2] ==
-          "quadratic_function"
-    @test IS._storage_array([IS.PiecewiseLinearData([(0.0, 1.0), (1.0, 3.0)])])[2] ==
-          "piecewise_linear"
-    @test IS._storage_array([IS.PiecewiseStepData([0.0, 1.0], [2.0])])[2] ==
-          "piecewise_step"
-    @test IS._storage_array([(1.0, 2.0, 3.0)])[2] == "tuple(3,f64)"
-    @test IS._storage_array([1.0, 2.0])[2] == "f64"
-    @test IS._storage_array(Int64[1, 2])[2] == "i64"
-    @test IS._storage_array(Bool[true, false])[2] == "bool"
-
-    # An element type IS cannot represent is a loud error, not a silent scalar.
-    @test_throws ErrorException IS._storage_array([1.0 + 2.0im])
-end
-
-@testset "the vendored corpus matches the live one when both are present" begin
-    live = _live_element_type_vectors_path()
-    if isempty(live) || live == VENDORED_ELEMENT_TYPE_VECTORS
-        @test isfile(VENDORED_ELEMENT_TYPE_VECTORS)
-    elseif read(live) != read(VENDORED_ELEMENT_TYPE_VECTORS)
-        # Not a failure: the live checkout may be mid-edit. The testsets above ran
-        # against `live`, so the contract is still asserted — only the pinned copy
-        # is stale, and refreshing it is a deliberate step (see the README).
-        @warn "Vendored conformance corpus differs from the live one; refresh it" live vendored =
-            VENDORED_ELEMENT_TYPE_VECTORS
-        @test_skip false
-    else
-        @test true
-    end
 end

--- a/test/test_element_type_conformance.jl
+++ b/test/test_element_type_conformance.jl
@@ -173,7 +173,8 @@ end
             component,
             IS.SingleTimeSeries(name, initial_time, resolution, values),
         )
-        @test IS.get_element_type(only(IS.list_metadata(sys; name = name))) == tag
+        @test IS.get_element_type(only(IS.list_time_series_metadata(sys; name = name))) ==
+              tag
     end
 end
 

--- a/test/test_openapi_associations.jl
+++ b/test/test_openapi_associations.jl
@@ -80,6 +80,12 @@ end
     @test IS.get_units(static) === nothing
     @test IS.get_percentiles(static) === nothing
     @test eltype(static) === Float64
+    # Including the three IS itself neither writes nor interprets: a row that
+    # dropped them would re-land another client's series stripped of them.
+    @test IS.get_element_shape(static) == ()
+    # IS writes wall clocks, which the store records as a zoneless reference.
+    @test IS.get_time_reference(static) == IS.InfraStore.ZonelessReference()
+    @test IS.get_application_data(static) === nothing
 end
 
 @testset "openapi_time_series_association_rows: SingleTimeSeries carries the grid and the element typing" begin

--- a/test/test_openapi_associations.jl
+++ b/test/test_openapi_associations.jl
@@ -60,12 +60,26 @@ end
     @test length(IS.list_metadata(data; name = "static")) == 1
     @test only(IS.list_metadata(data; name = "static")).name == "static"
     @test isempty(IS.list_metadata(data; name = "nonexistent"))
-    @test length(
-        IS.list_metadata(data; time_series_type = IS.InfraStore.Deterministic),
-    ) == 1
+    # `time_series_type` is an IS type here, exactly as on the owner-scoped
+    # `list_metadata`: the two overloads share a name, so they take one vocabulary.
+    @test length(IS.list_metadata(data; time_series_type = IS.Deterministic)) == 1
+    @test length(IS.list_metadata(data; time_series_type = IS.SingleTimeSeries)) == 1
+    # An abstract family resolves the same way it does on an owner.
+    @test length(IS.list_metadata(data; time_series_type = IS.Forecast)) == 1
+    @test length(IS.list_metadata(data; time_series_type = IS.StaticTimeSeries)) == 1
+    @test length(IS.list_metadata(data; time_series_type = IS.TimeSeriesData)) == 2
     @test length(
         IS.list_metadata(data; owner_category = IS.InfraStore.Component),
     ) == 2
+    # Every column the catalog holds reaches the caller, so a writer restaging
+    # these rows never has to drop to the store's own listing.
+    static = only(IS.list_metadata(data; name = "static"))
+    @test IS.get_element_type(static) == "f64"
+    @test length(IS.get_data_hash(static)) == 64
+    @test IS.get_owner_type(static) == string(nameof(typeof(component)))
+    @test IS.get_units(static) === nothing
+    @test IS.get_percentiles(static) === nothing
+    @test eltype(static) === Float64
 end
 
 @testset "openapi_time_series_association_rows: SingleTimeSeries carries the grid and the element typing" begin

--- a/test/test_openapi_associations.jl
+++ b/test/test_openapi_associations.jl
@@ -26,7 +26,7 @@ function _openapi_row(data, name; kwargs...)
     ).value
 end
 
-@testset "list_time_series_metadata reads every series in one query" begin
+@testset "list_metadata reads every series in one query" begin
     data, component = _openapi_ts_fixture()
     initial = Dates.DateTime(2024, 1, 1)
     resolution = Dates.Hour(1)
@@ -50,21 +50,21 @@ end
         ),
     )
 
-    metadata = IS.list_time_series_metadata(data)
+    metadata = IS.list_metadata(data)
     @test length(metadata) == 2
     @test Set(m.name for m in metadata) == Set(["static", "forecast"])
     # The store handle is reachable directly too, for a writer staging into a scratch store
     # before any SystemData exists.
-    @test length(IS.list_time_series_metadata(data.time_series_manager.data_store)) == 2
+    @test length(IS.list_metadata(data.time_series_manager.data_store)) == 2
     # Filter pushdown to InfraStore.list_time_series.
-    @test length(IS.list_time_series_metadata(data; name = "static")) == 1
-    @test only(IS.list_time_series_metadata(data; name = "static")).name == "static"
-    @test isempty(IS.list_time_series_metadata(data; name = "nonexistent"))
+    @test length(IS.list_metadata(data; name = "static")) == 1
+    @test only(IS.list_metadata(data; name = "static")).name == "static"
+    @test isempty(IS.list_metadata(data; name = "nonexistent"))
     @test length(
-        IS.list_time_series_metadata(data; time_series_type = IS.InfraStore.Deterministic),
+        IS.list_metadata(data; time_series_type = IS.InfraStore.Deterministic),
     ) == 1
     @test length(
-        IS.list_time_series_metadata(data; owner_category = IS.InfraStore.Component),
+        IS.list_metadata(data; owner_category = IS.InfraStore.Component),
     ) == 2
 end
 
@@ -393,7 +393,7 @@ end
         resolution,
     )
     @test_throws DimensionMismatch IS.add_time_series!(data, component, mismatched)
-    @test isempty(IS.list_time_series_metadata(data))
+    @test isempty(IS.list_metadata(data))
 end
 
 @testset "attach_supplemental_attribute!: attaches in memory without writing an association row" begin

--- a/test/test_openapi_associations.jl
+++ b/test/test_openapi_associations.jl
@@ -26,7 +26,7 @@ function _openapi_row(data, name; kwargs...)
     ).value
 end
 
-@testset "list_metadata reads every series in one query" begin
+@testset "list_time_series_metadata reads every series in one query" begin
     data, component = _openapi_ts_fixture()
     initial = Dates.DateTime(2024, 1, 1)
     resolution = Dates.Hour(1)
@@ -50,30 +50,38 @@ end
         ),
     )
 
-    metadata = IS.list_metadata(data)
+    metadata = IS.list_time_series_metadata(data)
     @test length(metadata) == 2
     @test Set(m.name for m in metadata) == Set(["static", "forecast"])
     # The store handle is reachable directly too, for a writer staging into a scratch store
     # before any SystemData exists.
-    @test length(IS.list_metadata(data.time_series_manager.data_store)) == 2
+    @test length(IS.list_time_series_metadata(data.time_series_manager.data_store)) == 2
     # Filter pushdown to InfraStore.list_time_series.
-    @test length(IS.list_metadata(data; name = "static")) == 1
-    @test only(IS.list_metadata(data; name = "static")).name == "static"
-    @test isempty(IS.list_metadata(data; name = "nonexistent"))
+    @test length(IS.list_time_series_metadata(data; name = "static")) == 1
+    @test only(IS.list_time_series_metadata(data; name = "static")).name == "static"
+    @test isempty(IS.list_time_series_metadata(data; name = "nonexistent"))
     # `time_series_type` is an IS type here, exactly as on the owner-scoped
-    # `list_metadata`: the two overloads share a name, so they take one vocabulary.
-    @test length(IS.list_metadata(data; time_series_type = IS.Deterministic)) == 1
-    @test length(IS.list_metadata(data; time_series_type = IS.SingleTimeSeries)) == 1
-    # An abstract family resolves the same way it does on an owner.
-    @test length(IS.list_metadata(data; time_series_type = IS.Forecast)) == 1
-    @test length(IS.list_metadata(data; time_series_type = IS.StaticTimeSeries)) == 1
-    @test length(IS.list_metadata(data; time_series_type = IS.TimeSeriesData)) == 2
+    # `list_time_series_metadata`: the two overloads share a name, so they take one
+    # vocabulary.
+    @test length(IS.list_time_series_metadata(data; time_series_type = IS.Deterministic)) ==
+          1
     @test length(
-        IS.list_metadata(data; owner_category = IS.InfraStore.Component),
+        IS.list_time_series_metadata(data; time_series_type = IS.SingleTimeSeries),
+    ) == 1
+    # An abstract family resolves the same way it does on an owner.
+    @test length(IS.list_time_series_metadata(data; time_series_type = IS.Forecast)) == 1
+    @test length(
+        IS.list_time_series_metadata(data; time_series_type = IS.StaticTimeSeries),
+    ) == 1
+    @test length(
+        IS.list_time_series_metadata(data; time_series_type = IS.TimeSeriesData),
+    ) == 2
+    @test length(
+        IS.list_time_series_metadata(data; owner_category = IS.InfraStore.Component),
     ) == 2
     # Every column the catalog holds reaches the caller, so a writer restaging
     # these rows never has to drop to the store's own listing.
-    static = only(IS.list_metadata(data; name = "static"))
+    static = only(IS.list_time_series_metadata(data; name = "static"))
     @test IS.get_element_type(static) == "f64"
     @test length(IS.get_data_hash(static)) == 64
     @test IS.get_owner_type(static) == string(nameof(typeof(component)))
@@ -413,7 +421,7 @@ end
         resolution,
     )
     @test_throws DimensionMismatch IS.add_time_series!(data, component, mismatched)
-    @test isempty(IS.list_metadata(data))
+    @test isempty(IS.list_time_series_metadata(data))
 end
 
 @testset "attach_supplemental_attribute!: attaches in memory without writing an association row" begin

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -60,6 +60,42 @@ end
     @test occursin("GeographicInfo", text)
 end
 
+@testset "Test show_time_series groups by kind, not by element type" begin
+    sys = create_system_data()
+    component = IS.get_component(IS.TestComponent, sys, "Component1")
+    initial = Dates.DateTime("2020-01-01")
+    resolution = Dates.Hour(1)
+    IS.add_time_series!(
+        sys, component, IS.SingleTimeSeries("floats", initial, resolution, rand(4)),
+    )
+    IS.add_time_series!(
+        sys, component, IS.SingleTimeSeries("ints", initial, resolution, collect(1:4)),
+    )
+    IS.add_time_series!(
+        sys, component,
+        IS.SingleTimeSeries(
+            "steps", initial, resolution,
+            [IS.PiecewiseStepData([1.0, 2.0], [3.0]) for _ in 1:4],
+        ),
+    )
+
+    io = IOBuffer()
+    IS.show_time_series(io, component)
+    text = String(take!(io))
+    # One table for the kind. The row type is parameterized on the value element
+    # type as well, so grouping on it would put each of these three in a table of
+    # its own, all titled the same thing.
+    @test count("SingleTimeSeries", text) == 1
+    @test occursin("floats", text)
+    @test occursin("ints", text)
+    @test occursin("steps", text)
+    # What separates them is a column: the store's own element_type spelling.
+    @test occursin("piecewise_step", text)
+    @test occursin("i64", text)
+    # The content hash is 32 raw bytes and is not one of the columns.
+    @test !occursin("UInt8", text)
+end
+
 @testset "Test show_components units resolution for Vector columns" begin
     sys = create_system_data(; with_time_series = true, time_series_in_memory = true)
     io = IOBuffer()

--- a/test/test_serialization.jl
+++ b/test/test_serialization.jl
@@ -40,12 +40,10 @@ function validate_serialization(sys::IS.SystemData; time_series_read_only = fals
         # There isn't one in IS, so perform the deserialization in the test code. A
         # component's `TimeSeriesKey`s arrive as bare association ids, so the pass runs
         # against the store the system just opened.
-        IS.with_deserialization_store(IS.get_data_store(sys2.time_series_manager)) do
-            for component in data["components"]
-                type = IS.get_type_from_serialization_data(component)
-                comp = IS.deserialize(type, component)
-                IS.add_component!(sys2, comp; allow_existing_time_series = true)
-            end
+        for component in data["components"]
+            type = IS.get_type_from_serialization_data(component)
+            comp = IS.deserialize(type, component)
+            IS.add_component!(sys2, comp; allow_existing_time_series = true)
         end
         return sys2, IS.compare_values(sys, sys2; compare_ids = true)
     finally

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -2599,10 +2599,16 @@ end
           IS.get_time_series_hash(component, key)
 end
 
-# The `owner` argument is not something the id can confirm, so it is checked: a key read
+# The `owner` argument is not something the id can confirm, so it is enforced: a key read
 # or removed against the wrong owner is a caller error, not a request to act on that
-# owner's same-named series. Removal is the case that matters — without the check it would
+# owner's same-named series. Removal is the case that matters — without it the call would
 # delete a series off a component the caller never named.
+#
+# The owner goes INTO the store call (`read_by_id` / `remove_by_ids!` take an `owner`),
+# so the confirming and the acting are one operation. Checking here first would leave a
+# window: an id survives a reassignment, so a row confirmed by one call can belong to
+# someone else by the time the next one deletes it. That race is covered where it can be
+# staged, in InfraStore's own suite.
 @testset "Test key accessors reject a key belonging to another owner" begin
     sys = IS.SystemData()
     component1 = IS.TestComponent("Component1", 5)
@@ -6576,6 +6582,27 @@ end
             ),
         )
     end
+end
+
+@testset "Test a mis-shaped Deterministic read is named, not a BoundsError" begin
+    # A Deterministic's decoded values are the (horizon_count, count) matrix whose
+    # columns are its windows.
+    @test IS._check_deterministic_window_shape(zeros(4, 3), "fine", "f64") === nothing
+
+    # A higher-rank array is a row whose element_type did not decode to the values
+    # it was packed from. Slicing a column off it would raise a bare BoundsError
+    # that says nothing about why.
+    err = try
+        IS._check_deterministic_window_shape(zeros(2, 4, 3), "bad", "piecewise_step")
+        nothing
+    catch e
+        e
+    end
+    @test err isa ArgumentError
+    msg = sprint(showerror, err)
+    @test occursin("bad", msg)
+    @test occursin("3-dimensional", msg)
+    @test occursin("piecewise_step", msg)
 end
 
 @testset "Test removal of SingleTimeSeries attached to a DeterministicSingleTimeSeries" begin

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -2630,6 +2630,7 @@ end
     @test_throws ArgumentError IS.get_time_series_values(component2, key1; len = 3)
     @test_throws ArgumentError IS.get_time_series_array(component2, key1)
     @test_throws ArgumentError IS.get_time_series_hash(component2, key1)
+    @test_throws ArgumentError IS.get_time_series_metadata(component2, key1)
     @test_throws ArgumentError IS.remove_time_series!(sys, component2, key1)
 
     # Both series survive the rejected calls, and each reads from its own owner.
@@ -2655,7 +2656,56 @@ end
     @test_throws ArgumentError IS.get_time_series(component, key)
     @test_throws ArgumentError IS.get_time_series_values(component, key; len = 3)
     @test_throws ArgumentError IS.get_time_series_hash(component, key)
+    @test_throws ArgumentError IS.get_time_series_metadata(component, key)
     @test_throws ArgumentError IS.remove_time_series!(sys, component, key)
+end
+
+# The attributes a key deliberately does not carry are read back off the catalog row the
+# id resolves to, so the row a caller holding only a key gets is the row `list_metadata`
+# would have handed them — and it is current, not a snapshot taken when the key was made.
+@testset "Test get_time_series_metadata by key" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    resolution = Dates.Hour(1)
+    dates = create_dates("2020-01-01T00:00:00", resolution, "2020-01-01T23:00:00")
+    ta = TimeSeries.TimeArray(dates, collect(1.0:24.0), [IS.get_name(component)])
+    features = Dict("scenario" => "high")
+    key = IS.add_time_series!(
+        sys, component, IS.SingleTimeSeries(; name = "val", data = ta);
+        features = features,
+    )
+
+    md = IS.get_time_series_metadata(component, key)
+    @test IS.get_time_series_key(md) == key
+    @test IS.get_time_series_type(md) === IS.SingleTimeSeries{Float64}
+    @test IS.get_name(md) == "val"
+    @test IS.get_resolution(md) == resolution
+    @test IS.get_initial_timestamp(md) == first(dates)
+    @test IS.get_features(md) == features
+    @test IS.get_owner_id(md) == IS.get_id(component)
+    @test IS.get_data_hash(md) == IS.get_time_series_hash(component, key)
+
+    # The same row `list_metadata` reports, reached by id instead of by filter.
+    listed = only(IS.list_metadata(component))
+    @test IS.get_name(md) == IS.get_name(listed)
+    @test IS.get_association_id(md) == IS.get_association_id(listed)
+
+    # A forecast row carries the window columns a static one leaves empty.
+    initial_time = Dates.DateTime("2020-09-01")
+    interval = Dates.Hour(1)
+    fx_data = Dict(
+        initial_time => collect(1.0:24.0),
+        initial_time + interval => collect(25.0:48.0),
+    )
+    fx_key =
+        IS.add_time_series!(sys, component, IS.Deterministic("fx", fx_data, resolution))
+    fx_md = IS.get_time_series_metadata(component, fx_key)
+    @test IS.get_time_series_type(fx_md) === IS.Deterministic{Float64}
+    @test IS.get_horizon(fx_md) == resolution * 24
+    @test IS.get_interval(fx_md) == interval
+    @test IS.get_count(fx_md) == 2
 end
 
 # An id names exactly one catalog row. The attribute-addressed removal it replaced was

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -2506,8 +2506,8 @@ end
     )
 
     doctored = IS.StaticTimeSeriesKey(;
-        # The owner is deliberately NOT doctored: it is the one thing an accessor
-        # checks, because the `owner` argument is not something the id can confirm.
+        # The owner is deliberately NOT doctored: it is the one field an accessor
+        # does read off the key, to confirm the caller named the right owner.
         owner_id = IS.get_owner_id(key),
         owner_category = IS.get_owner_category(key),
         association_id = IS.get_association_id(key),
@@ -2558,8 +2558,8 @@ end
     end
 
     doctored = IS.ForecastKey(;
-        # The owner is deliberately NOT doctored: it is the one thing an accessor
-        # checks, because the `owner` argument is not something the id can confirm.
+        # The owner is deliberately NOT doctored: it is the one field an accessor
+        # does read off the key, to confirm the caller named the right owner.
         owner_id = IS.get_owner_id(key),
         owner_category = IS.get_owner_category(key),
         association_id = IS.get_association_id(key),
@@ -2597,8 +2597,8 @@ end
     )
 
     doctored = IS.NonSequentialTimeSeriesKey(;
-        # The owner is deliberately NOT doctored: it is the one thing an accessor
-        # checks, because the `owner` argument is not something the id can confirm.
+        # The owner is deliberately NOT doctored: it is the one field an accessor
+        # does read off the key, to confirm the caller named the right owner.
         owner_id = IS.get_owner_id(key),
         owner_category = IS.get_owner_category(key),
         association_id = IS.get_association_id(key),

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -2488,6 +2488,227 @@ end
     @test occursin(string(bogus_id), e.msg)
 end
 
+# The key-addressed accessors look the association up by `association_id` and take every
+# lookup attribute off the row it resolves to, so a key whose other fields have been
+# doctored still reads the series the id names. These tests doctor them all to prove it:
+# before, the name / resolution / features were the actual lookup and every one of these
+# reads raised.
+@testset "Test key accessors address a SingleTimeSeries by association_id" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    dates = create_dates("2020-01-01T00:00:00", Dates.Hour(1), "2020-01-01T23:00:00")
+    ta = TimeSeries.TimeArray(dates, collect(1.0:24.0), [IS.get_name(component)])
+    key = IS.add_time_series!(
+        sys, component, IS.SingleTimeSeries(; name = "val", data = ta);
+        features = Dict("scenario" => "high"),
+    )
+
+    doctored = IS.StaticTimeSeriesKey(;
+        # The owner is deliberately NOT doctored: it is the one thing an accessor
+        # checks, because the `owner` argument is not something the id can confirm.
+        owner_id = IS.get_owner_id(key),
+        owner_category = IS.get_owner_category(key),
+        association_id = IS.get_association_id(key),
+        time_series_type = IS.SingleTimeSeries,
+        name = "wrong-name",
+        initial_timestamp = Dates.DateTime("1999-01-01T00:00:00"),
+        resolution = Dates.Minute(5),
+        length = 999,
+        features = Dict{String, Any}("scenario" => "low"),
+    )
+
+    @test IS.get_time_series_values(component, doctored) ==
+          IS.get_time_series_values(component, key)
+    @test IS.get_time_series_timestamps(component, doctored) ==
+          IS.get_time_series_timestamps(component, key)
+    @test IS.get_time_series_array(component, doctored) ==
+          IS.get_time_series_array(component, key)
+    @test IS.get_time_series_hash(component, doctored) ==
+          IS.get_time_series_hash(component, key)
+
+    # Slicing is computed from the resolved row's grid, not the doctored one.
+    start_time = Dates.DateTime("2020-01-01T04:00:00")
+    @test IS.get_time_series_values(
+        component,
+        doctored;
+        start_time = start_time,
+        len = 3,
+    ) ==
+          [5.0, 6.0, 7.0]
+
+    IS.remove_time_series!(sys, component, doctored)
+    @test isempty(IS.get_time_series_keys(component))
+end
+
+@testset "Test key accessors address a Deterministic by association_id" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    initial_time = Dates.DateTime("2020-09-01")
+    resolution = Dates.Hour(1)
+    other_time = initial_time + resolution
+    data = Dict(initial_time => collect(1.0:24.0), other_time => collect(25.0:48.0))
+    key = IS.time_series_transaction(sys; collect_keys = true) do txn
+        IS.add_time_series!(txn, component, IS.Deterministic("fx", data, resolution))
+        IS.flush!(txn)
+        return only(IS.added_keys(txn))
+    end
+
+    doctored = IS.ForecastKey(;
+        # The owner is deliberately NOT doctored: it is the one thing an accessor
+        # checks, because the `owner` argument is not something the id can confirm.
+        owner_id = IS.get_owner_id(key),
+        owner_category = IS.get_owner_category(key),
+        association_id = IS.get_association_id(key),
+        time_series_type = IS.Deterministic,
+        name = "wrong-name",
+        initial_timestamp = Dates.DateTime("1999-01-01T00:00:00"),
+        resolution = Dates.Minute(5),
+        horizon = Dates.Minute(15),
+        interval = Dates.Minute(10),
+        count = 99,
+        features = Dict{String, Any}("scenario" => "low"),
+    )
+
+    @test IS.get_data(IS.get_time_series(component, doctored)) ==
+          IS.get_data(IS.get_time_series(component, key))
+    @test IS.get_time_series_hash(component, doctored) ==
+          IS.get_time_series_hash(component, key)
+    @test IS.get_time_series_values(component, doctored; start_time = other_time) ==
+          collect(25.0:48.0)
+end
+
+@testset "Test key accessors address a NonSequentialTimeSeries by association_id" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    timestamps = [
+        Dates.DateTime("2020-01-01T00:00:00"),
+        Dates.DateTime("2020-01-01T04:00:00"),
+        Dates.DateTime("2020-01-03T00:00:00"),
+    ]
+    values = [10.0, 20.0, 30.0]
+    key = IS.add_time_series!(
+        sys, component, IS.NonSequentialTimeSeries("events", timestamps, values),
+    )
+
+    doctored = IS.NonSequentialTimeSeriesKey(;
+        # The owner is deliberately NOT doctored: it is the one thing an accessor
+        # checks, because the `owner` argument is not something the id can confirm.
+        owner_id = IS.get_owner_id(key),
+        owner_category = IS.get_owner_category(key),
+        association_id = IS.get_association_id(key),
+        time_series_type = IS.NonSequentialTimeSeries,
+        name = "wrong-name",
+        length = 999,
+        features = Dict{String, Any}("scenario" => "low"),
+    )
+
+    @test IS.get_time_series_values(component, doctored) == values
+    @test IS.get_time_series_hash(component, doctored) ==
+          IS.get_time_series_hash(component, key)
+end
+
+# The `owner` argument is not something the id can confirm, so it is checked: a key read
+# or removed against the wrong owner is a caller error, not a request to act on that
+# owner's same-named series. Removal is the case that matters — without the check it would
+# delete a series off a component the caller never named.
+@testset "Test key accessors reject a key belonging to another owner" begin
+    sys = IS.SystemData()
+    component1 = IS.TestComponent("Component1", 5)
+    component2 = IS.TestComponent("Component2", 6)
+    IS.add_component!(sys, component1)
+    IS.add_component!(sys, component2)
+
+    dates = create_dates("2020-01-01T00:00:00", Dates.Hour(1), "2020-01-01T23:00:00")
+    values1 = collect(1.0:24.0)
+    values2 = collect(101.0:124.0)
+    for (component, values) in ((component1, values1), (component2, values2))
+        ta = TimeSeries.TimeArray(dates, values, [IS.get_name(component)])
+        IS.add_time_series!(sys, component, IS.SingleTimeSeries(; name = "val", data = ta))
+    end
+    key1 = only(IS.get_time_series_keys(component1))
+
+    @test_throws ArgumentError IS.get_time_series(component2, key1)
+    @test_throws ArgumentError IS.get_time_series_values(component2, key1)
+    @test_throws ArgumentError IS.get_time_series_values(component2, key1; len = 3)
+    @test_throws ArgumentError IS.get_time_series_array(component2, key1)
+    @test_throws ArgumentError IS.get_time_series_hash(component2, key1)
+    @test_throws ArgumentError IS.remove_time_series!(sys, component2, key1)
+
+    # Both series survive the rejected calls, and each reads from its own owner.
+    @test IS.get_time_series_values(component1, key1) == values1
+    @test IS.get_time_series_values(
+        component2, only(IS.get_time_series_keys(component2)),
+    ) == values2
+end
+
+# A key whose association is gone is not probed for first — the accessors are already
+# committed to acting on it, so the miss surfaces as an error naming the id.
+@testset "Test key accessors on a removed association" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    dates = create_dates("2020-01-01T00:00:00", Dates.Hour(1), "2020-01-01T23:00:00")
+    ta = TimeSeries.TimeArray(dates, collect(1.0:24.0), [IS.get_name(component)])
+    key =
+        IS.add_time_series!(sys, component, IS.SingleTimeSeries(; name = "val", data = ta))
+    IS.remove_time_series!(sys, component, key)
+
+    @test_throws ArgumentError IS.get_time_series(component, key)
+    @test_throws ArgumentError IS.get_time_series_values(component, key; len = 3)
+    @test_throws ArgumentError IS.get_time_series_hash(component, key)
+    @test_throws ArgumentError IS.remove_time_series!(sys, component, key)
+end
+
+# An id names exactly one catalog row. The attribute-addressed removal it replaced was
+# blunter: a `nothing` interval matched *any* interval, so a SingleTimeSeries key could
+# reach the DeterministicSingleTimeSeries derived from it, which shares its name,
+# resolution and features and differs only by carrying one.
+@testset "Test remove_time_series! by key removes exactly one association" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+
+    resolution = Dates.Hour(1)
+    dates = create_dates("2020-01-01T00:00:00", resolution, "2020-01-02T23:00:00")
+    ta = TimeSeries.TimeArray(dates, collect(1.0:length(dates)), ["val"])
+    sts_key = IS.add_time_series!(sys, component, IS.SingleTimeSeries("val", ta))
+    IS.transform_single_time_series!(
+        sys, IS.DeterministicSingleTimeSeries, Dates.Hour(12), Dates.Hour(6),
+    )
+    @test length(IS.get_time_series_keys(component)) == 2
+
+    # The derived forecast holds the SingleTimeSeries down: removing its backing series
+    # would orphan it, and the store refuses rather than removing either.
+    e = try
+        IS.remove_time_series!(sys, component, sts_key)
+        nothing
+    catch err
+        err
+    end
+    @test e isa ArgumentError
+    @test occursin("DeterministicSingleTimeSeries", e.msg)
+    @test length(IS.get_time_series_keys(component)) == 2
+
+    # Removing the forecast by its own key leaves the SingleTimeSeries alone, even
+    # though the two agree on name, resolution and features.
+    dst_key = only(
+        IS.get_time_series_keys(
+            component; time_series_type = IS.DeterministicSingleTimeSeries,
+        ),
+    )
+    IS.remove_time_series!(sys, component, dst_key)
+    @test IS.get_association_id(only(IS.get_time_series_keys(component))) ==
+          IS.get_association_id(sts_key)
+    @test length(IS.get_time_series_values(component, sts_key)) == length(dates)
+end
+
 @testset "Test add_time_series" begin
     sys = IS.SystemData()
     name = "Component1"
@@ -4700,7 +4921,7 @@ end
         e
     end
     @test e isa ArgumentError
-    @test !occursin("stale", e.msg)
+    @test !occursin("association_id", e.msg)
 
     # Replace the series with a shorter one under the same name.
     IS.remove_time_series!(sys, IS.SingleTimeSeries, component, "x")
@@ -4712,7 +4933,7 @@ end
         e
     end
     @test e isa ArgumentError
-    @test occursin("stale", e.msg)
+    @test occursin("association_id", e.msg)
     # Even a window that fits the replacement is rejected by the id, not the shape.
     @test_throws ArgumentError IS.get_time_series_values(
         component, key; start_time = dates[1], len = 5,
@@ -4756,7 +4977,7 @@ end
         e
     end
     @test e isa ArgumentError
-    @test !occursin("stale", e.msg)
+    @test !occursin("association_id", e.msg)
 
     # Replace with the same count but a shorter horizon: the old shape heuristic
     # (start + count) would have passed this and then over-read the window.
@@ -4773,7 +4994,7 @@ end
         e
     end
     @test e isa ArgumentError
-    @test occursin("stale", e.msg)
+    @test occursin("association_id", e.msg)
     @test_throws ArgumentError IS.get_time_series(component, key; len = 3)
 
     IS.remove_time_series!(sys, IS.Deterministic, component, "f")

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -4419,6 +4419,13 @@ end
     @test key2 == key
     @test IS.get_association_id(key2) == IS.get_association_id(key)
     @test IS.get_time_series_type(key2) <: IS.SingleTimeSeries
+
+    # An element type this version cannot name fails here, where the name is in
+    # hand, rather than as a bare key that fails the field it is assigned to.
+    @test_throws ArgumentError IS.deserialize(
+        IS.TimeSeriesKey, merge(serialized, Dict("element_type" => "no_such_type")))
+    @test_throws ArgumentError IS.deserialize(
+        IS.TimeSeriesKey, Dict(k => v for (k, v) in serialized if k != "element_type"))
 end
 
 @testset "Test time series key survives system serialization as its association id" begin
@@ -5179,6 +5186,48 @@ end
         )
     end
     @test length(IS.make_time_array(ts, timestamps[1]; len = 2)) == 2
+end
+
+@testset "Test store-backed accessors reject len/count < 1" begin
+    sys = IS.SystemData()
+    component = IS.TestComponent("Component1", 5)
+    IS.add_component!(sys, component)
+    initial_time = Dates.DateTime("2020-09-01")
+    resolution = Dates.Hour(1)
+    ta = TimeSeries.TimeArray(
+        range(initial_time; length = 12, step = resolution),
+        collect(1.0:12.0),
+    )
+    static_key = IS.add_time_series!(sys, component, IS.SingleTimeSeries("static", ta))
+    interval = Dates.Hour(6)
+    data = SortedDict(
+        initial_time + (i - 1) * interval => collect(1.0:24.0) for i in 1:3
+    )
+    forecast_key = IS.add_time_series!(
+        sys,
+        component,
+        IS.Deterministic(;
+            name = "forecast",
+            data = data,
+            resolution = resolution,
+            interval = interval,
+        ),
+    )
+
+    # `len` and `count` are counts, and the store takes them as unsigned: a
+    # negative one has to raise the accessors' own ArgumentError here rather than
+    # an InexactError out of the ccall marshalling.
+    for bad in (0, -1)
+        @test_throws ArgumentError IS.get_time_series(
+            IS.SingleTimeSeries, component, "static"; len = bad)
+        @test_throws ArgumentError IS.get_time_series(component, static_key; len = bad)
+        @test_throws ArgumentError IS.get_time_series(
+            IS.Deterministic, component, "forecast"; count = bad)
+        @test_throws ArgumentError IS.get_time_series(
+            IS.Deterministic, component, "forecast"; len = bad)
+        @test_throws ArgumentError IS.get_time_series(
+            component, forecast_key; count = bad)
+    end
 end
 
 @testset "Test get_window by index is 1-based" begin

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -21,7 +21,7 @@ _is_deterministic(::Any) = false
     key = IS.add_time_series!(sys, component, forecast)
     @test key isa IS.TimeSeriesKey{<:IS.Forecast}
     # The descriptive columns live on the catalog row, not on the key.
-    md = only(IS.list_metadata(component; name = name))
+    md = only(IS.list_time_series_metadata(component; name = name))
     @test IS.get_time_series_key(md) == key
     @test IS.get_name(md) == name
     @test IS.get_horizon(md) == horizon_count * resolution
@@ -248,7 +248,7 @@ end
     IS.add_time_series!(sys, component, forecast_1h)
     IS.add_time_series!(sys, component, forecast_2h)
 
-    ts_keys = IS.list_metadata(component)
+    ts_keys = IS.list_time_series_metadata(component)
     @test length(ts_keys) == 2
     key_1h = only(filter(k -> IS.get_interval(k) == Dates.Hour(1), ts_keys))
     key_2h = only(filter(k -> IS.get_interval(k) == Dates.Hour(2), ts_keys))
@@ -283,11 +283,11 @@ end
     component2 = IS.TestComponent("Component2", 6)
     IS.add_component!(sys, component2)
     IS.copy_time_series!(component2, component)
-    @test length(IS.list_metadata(component2)) == 2
+    @test length(IS.list_time_series_metadata(component2)) == 2
 
     # A keyed removal removes only the keyed series.
     IS.remove_time_series!(sys, component, key_1h)
-    remaining = IS.list_metadata(component)
+    remaining = IS.list_time_series_metadata(component)
     @test length(remaining) == 1
     @test IS.get_interval(only(remaining)) == Dates.Hour(2)
 end
@@ -322,7 +322,7 @@ end
         features = Dict("scenario" => "a", "model" => "x"),
     )
     # Features live on the catalog row, not on the key.
-    rows = IS.list_metadata(component)
+    rows = IS.list_time_series_metadata(component)
     by_id = Dict(IS.get_association_id(r) => IS.get_features(r) for r in rows)
     @test by_id[IS.get_association_id(key_subset)] == Dict("scenario" => "a")
     @test by_id[IS.get_association_id(key_superset)] ==
@@ -345,7 +345,7 @@ end
 
     # A keyed removal removes exactly the keyed series.
     IS.remove_time_series!(sys, component, key_subset)
-    remaining = IS.list_metadata(component)
+    remaining = IS.list_time_series_metadata(component)
     @test length(remaining) == 1
     @test IS.get_features(only(remaining)) == Dict("scenario" => "a", "model" => "x")
     @test IS.get_time_series_values(component, only(remaining))[1] == 101.0
@@ -359,7 +359,7 @@ end
         features = Dict("scenario" => "a"),
     )
     IS.remove_time_series!(sys, component, key_superset)
-    left = IS.list_metadata(component)
+    left = IS.list_time_series_metadata(component)
     @test length(left) == 1
     @test IS.get_features(only(left)) == Dict("scenario" => "a")
 
@@ -432,7 +432,7 @@ end
             IS.SingleTimeSeries, component, "static"; interval = resolution),
         () -> IS.get_time_series_key(
             IS.SingleTimeSeries, component, "static"; interval = resolution),
-        () -> IS.list_metadata(
+        () -> IS.list_time_series_metadata(
             component; time_series_type = IS.SingleTimeSeries, interval = resolution),
         () -> IS.has_time_series(
             component, IS.SingleTimeSeries, "static"; interval = resolution),
@@ -630,7 +630,8 @@ end
     key1 = IS.add_time_series!(sys, component, forecast1)
     key2 = IS.add_time_series!(sys, component, forecast2)
     # A key is its id; the horizon is a column of the catalog row.
-    horizon_of(name) = IS.get_horizon(only(IS.list_metadata(component; name = name)))
+    horizon_of(name) =
+        IS.get_horizon(only(IS.list_time_series_metadata(component; name = name)))
     @test horizon_of(name1) == horizon_count * resolution1
     @test horizon_of(name2) == horizon_count2 * resolution2
 
@@ -1148,14 +1149,15 @@ end
         ts_name;
         features = Dict("model_year" => "2060", "scenario" => "low"),
     )
-    @test length(IS.list_metadata(component)) == 4
-    @test IS.get_time_series_type(IS.list_metadata(component)[1]) <: IS.SingleTimeSeries
-    @test length(IS.list_metadata(component)) == 4
-    for key in IS.list_metadata(component)
+    @test length(IS.list_time_series_metadata(component)) == 4
+    @test IS.get_time_series_type(IS.list_time_series_metadata(component)[1]) <:
+          IS.SingleTimeSeries
+    @test length(IS.list_time_series_metadata(component)) == 4
+    for key in IS.list_time_series_metadata(component)
         @test IS.get_data(IS.get_time_series(component, key)) == data
     end
     IS.remove_time_series!(sys, IS.SingleTimeSeries)
-    @test isempty(IS.list_metadata(component))
+    @test isempty(IS.list_time_series_metadata(component))
     @test IS.get_num_time_series(sys) == 0
 end
 
@@ -1355,19 +1357,19 @@ end
         ts_name;
         features = Dict("scenario" => "low", "model_year" => "2035"),
     ) isa IS.Deterministic
-    @test length(IS.list_metadata(component)) == 4
+    @test length(IS.list_time_series_metadata(component)) == 4
     @test length(
-        IS.list_metadata(component; time_series_type = IS.Deterministic),
+        IS.list_time_series_metadata(component; time_series_type = IS.Deterministic),
     ) == 4
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
         ),
     ) == 4
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
@@ -1375,21 +1377,22 @@ end
         ),
     ) == 2
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
             features = Dict("scenario" => "low", "model_year" => "2035"),
         ),
     ) == 1
-    @test IS.list_metadata(
+    @test IS.list_time_series_metadata(
         component;
         time_series_type = IS.Deterministic,
         name = ts_name,
         features = Dict("scenario" => "low", "model_year" => "2035"),
     )[1].features["model_year"] == "2035"
-    @test length(IS.list_metadata(component)) == 4
-    @test IS.get_time_series_type(IS.list_metadata(component)[1]) <: IS.Deterministic
+    @test length(IS.list_time_series_metadata(component)) == 4
+    @test IS.get_time_series_type(IS.list_time_series_metadata(component)[1]) <:
+          IS.Deterministic
 
     IS.remove_time_series!(
         sys,
@@ -1399,14 +1402,14 @@ end
         features = Dict("scenario" => "low"),
     )
     @test length(
-        IS.list_metadata(component; time_series_type = IS.Deterministic),
+        IS.list_time_series_metadata(component; time_series_type = IS.Deterministic),
     ) == 2
     for metadata in
-        IS.list_metadata(component; time_series_type = IS.Deterministic)
+        IS.list_time_series_metadata(component; time_series_type = IS.Deterministic)
         @test metadata.features["scenario"] == "high"
     end
     IS.remove_time_series!(sys, IS.Deterministic, component, ts_name)
-    @test isempty(IS.list_metadata(component))
+    @test isempty(IS.list_time_series_metadata(component))
 end
 
 @testset "Test Deterministic with a wrapped SingleTimeSeries" begin
@@ -1772,7 +1775,7 @@ end
 
     # Both sets should coexist.
     all_metadata = collect(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -1812,7 +1815,7 @@ end
     )
 
     all_metadata = collect(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -1889,7 +1892,7 @@ end
     )
 
     all_metadata = collect(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -1906,7 +1909,7 @@ end
     )
 
     all_metadata = collect(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -2417,7 +2420,7 @@ end
     key = IS.add_time_series!(sys, component, ts)
 
     # The owner is a column of the catalog row; the key is the id that finds it.
-    row = only(IS.list_metadata(component))
+    row = only(IS.list_time_series_metadata(component))
     @test IS.get_owner_id(row) == IS.get_id(component)
     @test IS.get_owner_category(row) == IS.get_owner_category(component)
     @test IS.get_association_id(key) == IS.get_association_id(row)
@@ -2445,7 +2448,7 @@ end
     end
 
     # The owner is a column of the catalog row; the key is the id that finds it.
-    row = only(IS.list_metadata(component))
+    row = only(IS.list_time_series_metadata(component))
     @test IS.get_owner_id(row) == IS.get_id(component)
     @test IS.get_owner_category(row) == IS.get_owner_category(component)
     @test IS.get_association_id(key) == IS.get_association_id(row)
@@ -2468,7 +2471,7 @@ end
     key = IS.add_time_series!(sys, component, ts)
 
     # The owner is a column of the catalog row; the key is the id that finds it.
-    row = only(IS.list_metadata(component))
+    row = only(IS.list_time_series_metadata(component))
     @test IS.get_owner_id(row) == IS.get_id(component)
     @test IS.get_owner_category(row) == IS.get_owner_category(component)
     @test IS.get_association_id(key) == IS.get_association_id(row)
@@ -2544,7 +2547,7 @@ end
           [5.0, 6.0, 7.0]
 
     IS.remove_time_series!(sys, component, doctored)
-    @test isempty(IS.list_metadata(component))
+    @test isempty(IS.list_time_series_metadata(component))
 end
 
 @testset "Test key accessors address a Deterministic by association_id" begin
@@ -2623,7 +2626,7 @@ end
         ta = TimeSeries.TimeArray(dates, values, [IS.get_name(component)])
         IS.add_time_series!(sys, component, IS.SingleTimeSeries(; name = "val", data = ta))
     end
-    key1 = only(IS.list_metadata(component1))
+    key1 = only(IS.list_time_series_metadata(component1))
 
     @test_throws ArgumentError IS.get_time_series(component2, key1)
     @test_throws ArgumentError IS.get_time_series_values(component2, key1)
@@ -2636,7 +2639,7 @@ end
     # Both series survive the rejected calls, and each reads from its own owner.
     @test IS.get_time_series_values(component1, key1) == values1
     @test IS.get_time_series_values(
-        component2, only(IS.list_metadata(component2)),
+        component2, only(IS.list_time_series_metadata(component2)),
     ) == values2
 end
 
@@ -2661,8 +2664,9 @@ end
 end
 
 # The attributes a key deliberately does not carry are read back off the catalog row the
-# id resolves to, so the row a caller holding only a key gets is the row `list_metadata`
-# would have handed them — and it is current, not a snapshot taken when the key was made.
+# id resolves to, so the row a caller holding only a key gets is the row
+# `list_time_series_metadata` would have handed them — and it is current, not a snapshot
+# taken when the key was made.
 @testset "Test get_time_series_metadata by key" begin
     sys = IS.SystemData()
     component = IS.TestComponent("Component1", 5)
@@ -2687,8 +2691,8 @@ end
     @test IS.get_owner_id(md) == IS.get_id(component)
     @test IS.get_data_hash(md) == IS.get_time_series_hash(component, key)
 
-    # The same row `list_metadata` reports, reached by id instead of by filter.
-    listed = only(IS.list_metadata(component))
+    # The same row `list_time_series_metadata` reports, reached by id instead of by filter.
+    listed = only(IS.list_time_series_metadata(component))
     @test IS.get_name(md) == IS.get_name(listed)
     @test IS.get_association_id(md) == IS.get_association_id(listed)
 
@@ -2724,7 +2728,7 @@ end
     IS.transform_single_time_series!(
         sys, IS.DeterministicSingleTimeSeries, Dates.Hour(12), Dates.Hour(6),
     )
-    @test length(IS.list_metadata(component)) == 2
+    @test length(IS.list_time_series_metadata(component)) == 2
 
     # The derived forecast holds the SingleTimeSeries down: removing its backing series
     # would orphan it, and the store refuses rather than removing either.
@@ -2736,17 +2740,17 @@ end
     end
     @test e isa ArgumentError
     @test occursin("DeterministicSingleTimeSeries", e.msg)
-    @test length(IS.list_metadata(component)) == 2
+    @test length(IS.list_time_series_metadata(component)) == 2
 
     # Removing the forecast by its own key leaves the SingleTimeSeries alone, even
     # though the two agree on name, resolution and features.
     dst_key = only(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component; time_series_type = IS.DeterministicSingleTimeSeries,
         ),
     )
     IS.remove_time_series!(sys, component, dst_key)
-    @test IS.get_association_id(only(IS.list_metadata(component))) ==
+    @test IS.get_association_id(only(IS.list_time_series_metadata(component))) ==
           IS.get_association_id(sts_key)
     @test length(IS.get_time_series_values(component, sts_key)) == length(dates)
 end
@@ -2805,7 +2809,7 @@ end
     @test length(unique(IS.get_association_id.(keys))) == len
     for (i, key) in enumerate(keys)
         # The owner is on the row the key resolves to, not on the key.
-        row = only(IS.list_metadata(components[i]))
+        row = only(IS.list_time_series_metadata(components[i]))
         @test IS.get_time_series_key(row) == key
         @test IS.get_owner_id(row) == IS.get_id(components[i])
     end
@@ -3173,7 +3177,7 @@ end
         attr1;
         name_mapping = Dict(("not-a-real-label", "x") => "y"),
     )
-    @test isempty(IS.list_metadata(attr3))
+    @test isempty(IS.list_time_series_metadata(attr3))
 end
 
 @testset "Test copy time_series with transformed time series" begin
@@ -3851,7 +3855,7 @@ const IRREGULAR_TIMESTAMPS = [
     )
 
     # A non-sequential series is irregular, so its row carries no resolution.
-    keys = collect(IS.list_metadata(component))
+    keys = collect(IS.list_time_series_metadata(component))
     @test length(keys) == 1
     key = keys[1]
     @test IS.get_time_series_type(key) <: IS.NonSequentialTimeSeries
@@ -3864,7 +3868,7 @@ const IRREGULAR_TIMESTAMPS = [
             IS.NonSequentialTimeSeries, component, name; interval = interval),
         () -> IS.get_time_series_key(
             IS.NonSequentialTimeSeries, component, name; interval = interval),
-        () -> IS.list_metadata(
+        () -> IS.list_time_series_metadata(
             component;
             time_series_type = IS.NonSequentialTimeSeries,
             interval = interval,
@@ -4734,7 +4738,7 @@ end
 
     # Features are a column of the catalog row, so the rows are what carries them
     # here; each row hands back the key that reads it.
-    ts_keys = IS.list_metadata(component)
+    ts_keys = IS.list_time_series_metadata(component)
 
     for key in ts_keys
         timestamps = IS.get_time_series_timestamps(component, key)
@@ -5121,7 +5125,7 @@ end
 
     # The nothing-tolerant accessors keep answering "empty".
     @test !IS.has_time_series(c)
-    @test isempty(IS.list_metadata(c))
+    @test isempty(IS.list_time_series_metadata(c))
     @test isempty(collect(IS.get_time_series_multiple(c)))
 end
 
@@ -5190,7 +5194,7 @@ end
         IS.Deterministic(; name = "f", data = data, resolution = resolution),
     )
     # These are row columns now: a key carries no length, count or horizon.
-    md = only(IS.list_metadata(component; time_series_type = IS.Deterministic))
+    md = only(IS.list_time_series_metadata(component; time_series_type = IS.Deterministic))
     @test IS.get_length(md) == horizon_count
     @test IS.get_length(md) == length(md)
     @test IS.get_count(md) == 3
@@ -5377,7 +5381,7 @@ end
             )
         end
     end
-    ts_keys = IS.list_metadata(component)
+    ts_keys = IS.list_time_series_metadata(component)
     @test length(ts_keys) == 30
     actual_ts_data = Dict(IS.get_name(x) => x for x in ts_keys)
     for i in 1:30
@@ -5424,14 +5428,14 @@ end
             )
         end
     end
-    @test isempty(IS.list_metadata(component))
+    @test isempty(IS.list_time_series_metadata(component))
 
     @test_throws ArgumentError IS.time_series_transaction(sys) do txn
         for _ in 1:3
             IS.add_time_series!(txn, component, forecast)
         end
     end
-    @test isempty(IS.list_metadata(component))
+    @test isempty(IS.list_time_series_metadata(component))
 end
 
 @testset "Test bulk addition of time series with transaction" begin
@@ -5465,7 +5469,7 @@ end
             )
         end
     end
-    ts_keys = IS.list_metadata(component)
+    ts_keys = IS.list_time_series_metadata(component)
     @test length(ts_keys) == 5
     actual_ts_data = Dict(IS.get_name(x) => x for x in ts_keys)
     for i in 1:5
@@ -5526,7 +5530,7 @@ end
             end
         end,
     )
-    ts_keys = IS.list_metadata(component)
+    ts_keys = IS.list_time_series_metadata(component)
     @test length(ts_keys) == 1
     key = ts_keys[1]
     @test IS.get_name(key) == "bystander"
@@ -5808,17 +5812,17 @@ end
         ),
     )
     @test length(
-        IS.list_metadata(component; time_series_type = IS.SingleTimeSeries),
+        IS.list_time_series_metadata(component; time_series_type = IS.SingleTimeSeries),
     ) == 2
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.SingleTimeSeries,
             resolution = resolution1,
         ),
     ) == 1
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.SingleTimeSeries,
             name = ts_name,
@@ -5935,17 +5939,17 @@ end
         ),
     )
     @test length(
-        IS.list_metadata(component; time_series_type = IS.Deterministic),
+        IS.list_time_series_metadata(component; time_series_type = IS.Deterministic),
     ) == 2
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.Deterministic,
             resolution = resolution1,
         ),
     ) == 1
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = f_name,
@@ -6153,19 +6157,19 @@ end
         ),
     )
 
-    # list_metadata with interval
+    # list_time_series_metadata with interval
     @test length(
-        IS.list_metadata(component; time_series_type = IS.Deterministic),
+        IS.list_time_series_metadata(component; time_series_type = IS.Deterministic),
     ) == 2
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.Deterministic,
             interval = interval1,
         ),
     ) == 1
     @test length(
-        IS.list_metadata(
+        IS.list_time_series_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = f_name,
@@ -6658,12 +6662,12 @@ end
         ts_name = "test"
         data = IS.SingleTimeSeries(; data = data, name = ts_name)
         IS.add_time_series!(sys, attr, data)
-        all_metadata = IS.list_metadata(
+        all_metadata = IS.list_time_series_metadata(
             attr;
             time_series_type = IS.SingleTimeSeries,
         )
         @test isempty(
-            IS.list_metadata(
+            IS.list_time_series_metadata(
                 component;
                 time_series_type = IS.SingleTimeSeries,
             ),
@@ -6675,7 +6679,7 @@ end
             IS.remove_time_series!(sys, IS.SingleTimeSeries, attr, ts_name)
         end
         @test isempty(
-            IS.list_metadata(
+            IS.list_time_series_metadata(
                 attr;
                 time_series_type = IS.SingleTimeSeries,
             ),
@@ -6742,7 +6746,7 @@ end
     # so that we can test removing just the SingleTimeSeries from the other component
     IS.remove_time_series!(mgr, IS.DeterministicSingleTimeSeries, component2, ts_name)
 
-    metadata = IS.list_metadata(
+    metadata = IS.list_time_series_metadata(
         component;
         time_series_type = IS.SingleTimeSeries,
         name = ts_name,
@@ -6960,7 +6964,10 @@ end
     IS.transform_single_time_series!(
         sys, IS.DeterministicSingleTimeSeries, Dates.Hour(6), Dates.Hour(6))
     dst_key = only(
-        IS.list_metadata(c1; time_series_type = IS.DeterministicSingleTimeSeries))
+        IS.list_time_series_metadata(
+            c1;
+            time_series_type = IS.DeterministicSingleTimeSeries,
+        ))
     @test IS.get_time_series_hash(c1, dst_key) == h1
 
     # System-wide grouping, default: only the arrays referenced more than once.
@@ -7448,7 +7455,7 @@ end
         IS.remove_time_series!(sys, IS.SingleTimeSeries, component, "keep")
         error("boom")
     end
-    keys = IS.list_metadata(component)
+    keys = IS.list_time_series_metadata(component)
     @test length(keys) == 1
     @test IS.get_name(keys[1]) == "keep"
     # The data came back, not just the catalog row.
@@ -7459,7 +7466,7 @@ end
     IS.time_series_transaction(sys) do txn
         IS.add_time_series!(txn, component, make_ts("added", 100.0))
     end
-    @test length(IS.list_metadata(component)) == 2
+    @test length(IS.list_time_series_metadata(component)) == 2
 end
 
 @testset "Test failed commit rolls back the store transaction" begin
@@ -7492,7 +7499,7 @@ end
         IS.add_time_series!(txn, component, make_ts("after"))
     end
     @test !IS.InfraStore.in_transaction(store)
-    names = Set(IS.get_name(k) for k in IS.list_metadata(component))
+    names = Set(IS.get_name(k) for k in IS.list_time_series_metadata(component))
     @test names == Set(["dup", "after"])
 end
 
@@ -7517,7 +7524,7 @@ end
         # Auto-flushes at 3 and 6 drained all but the seventh entry.
         @test IS.has_staged_data(txn)
     end
-    @test length(IS.list_metadata(component)) == 7
+    @test length(IS.list_time_series_metadata(component)) == 7
 
     # The byte limit flushes long series well before the count limit would.
     # Staged-byte accounting counts the encoded array (for a Float64 series,
@@ -7530,7 +7537,7 @@ end
         # Byte-triggered flushes at 3 and 6 drained all but the seventh entry.
         @test IS.has_staged_data(txn)
     end
-    @test length(IS.list_metadata(component)) == 14
+    @test length(IS.list_time_series_metadata(component)) == 14
 
     # Auto-flushed work still rolls back with the block.
     @test_throws ErrorException IS.time_series_transaction(
@@ -7541,7 +7548,7 @@ end
         end
         error("boom")
     end
-    names = Set(IS.get_name(k) for k in IS.list_metadata(component))
+    names = Set(IS.get_name(k) for k in IS.list_time_series_metadata(component))
     @test names == union(Set("ts_$i" for i in 1:7), Set("bytes_$i" for i in 1:7))
 
     # A composite element type stages as a `length x element_row_width` matrix of
@@ -7606,7 +7613,7 @@ end
 
     # A key is its id; the names are on the rows those ids resolve to.
     stored = Dict(
-        IS.get_association_id(md) => md for md in IS.list_metadata(component)
+        IS.get_association_id(md) => md for md in IS.list_time_series_metadata(component)
     )
     @test [IS.get_name(stored[IS.get_association_id(k)]) for k in keys] ==
           ["collected_$i" for i in 1:5]
@@ -7639,7 +7646,7 @@ end
     end
     # The rollback unwrote the row, so the key naming it is dropped with it.
     @test isempty(IS.added_keys(context))
-    @test isempty(IS.list_metadata(component))
+    @test isempty(IS.list_time_series_metadata(component))
 end
 
 @testset "Test time series context nesting and reuse" begin
@@ -7666,7 +7673,7 @@ end
             error("inner failed")
         end
     end
-    names = Set(IS.get_name(k) for k in IS.list_metadata(component))
+    names = Set(IS.get_name(k) for k in IS.list_time_series_metadata(component))
     @test names == Set(["outer"])
 
     # A transaction is valid only inside its own block.

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -7323,6 +7323,31 @@ end
     end
 end
 
+@testset "Test StaticTimeSeriesReader decodes each element type in its own group" begin
+    sys, comps = _create_reader_system(2)
+    t0, res = READER_T0, READER_RES
+    len = 4
+    # A LinearFunctionData and an NTuple{2, Float64} are each two Float64 slots,
+    # so they agree on dtype and element_shape and are told apart only by their
+    # element_type. The store groups on that too, so these land in two groups —
+    # each decoded whole, under its own tag, into its own cache slot.
+    fds = [IS.LinearFunctionData(1.0 * i, 2.0 * i) for i in 1:len]
+    tups = [(10.0 * i, 20.0 * i) for i in 1:len]
+    fd_key = IS.add_time_series!(sys, comps[1], IS.SingleTimeSeries("v", t0, res, fds))
+    tup_key = IS.add_time_series!(sys, comps[2], IS.SingleTimeSeries("v", t0, res, tups))
+
+    reader = IS.build_static_time_series_reader(sys; resolution = res)
+    entries = IS.get_static_time_series_reader_entries(reader)
+    by_key = Dict(e.key => i for (i, e) in enumerate(entries))
+    fd_i, tup_i = by_key[fd_key], by_key[tup_key]
+    @test IS.get_num_static_time_series_groups(reader) == 2
+    for k in 1:len
+        IS.read_static_time_series_values!(reader, t0 + res * (k - 1))
+        @test IS.get_static_time_series_value(reader, fd_i) == fds[k]
+        @test IS.get_static_time_series_value(reader, tup_i) == tups[k]
+    end
+end
+
 @testset "Test StaticTimeSeriesReader with multidimensional scalar series" begin
     sys, comps = _create_reader_system(1)
     c = only(comps)

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -7197,6 +7197,30 @@ end
     end
 end
 
+@testset "Test StaticTimeSeriesReader with multidimensional scalar series" begin
+    sys, comps = _create_reader_system(1)
+    c = only(comps)
+    t0, res = READER_T0, READER_RES
+    len = 4
+    # A rank-2 scalar series holds a vector per step; a rank-3 one holds a matrix.
+    # Neither is a composite element type, so the slice is the value — there is
+    # nothing to decode, and nothing to collapse to a single element.
+    mat = reshape(collect(1.0:(len * 3)), len, 3)
+    cube = reshape(collect(1.0:(len * 3 * 2)), len, 3, 2)
+    mat_key = IS.add_time_series!(sys, c, IS.SingleTimeSeries("matrix", t0, res, mat))
+    cube_key = IS.add_time_series!(sys, c, IS.SingleTimeSeries("cube", t0, res, cube))
+
+    reader = IS.build_static_time_series_reader(sys; resolution = res)
+    entries = IS.get_static_time_series_reader_entries(reader)
+    by_key = Dict(e.key => i for (i, e) in enumerate(entries))
+    by_name = Dict("matrix" => by_key[mat_key], "cube" => by_key[cube_key])
+    for k in 1:len
+        IS.read_static_time_series_values!(reader, t0 + res * (k - 1))
+        @test IS.get_static_time_series_value(reader, by_name["matrix"]) == mat[k, :]
+        @test IS.get_static_time_series_value(reader, by_name["cube"]) == cube[k, :, :]
+    end
+end
+
 @testset "Test time series context rollback" begin
     sys = IS.SystemData()
     component = IS.TestComponent("Component1", 5)
@@ -7316,6 +7340,21 @@ end
     end
     names = Set(IS.get_name(k) for k in IS.list_metadata(component))
     @test names == union(Set("ts_$i" for i in 1:7), Set("bytes_$i" for i in 1:7))
+
+    # A composite element type stages as a `length x element_row_width` matrix of
+    # Float64 while Julia holds one pointer per value, so `sizeof` under-counts it
+    # by the row width — unbounded for ragged piecewise data.
+    scalars = collect(1.0:8.0)
+    @test IS._staged_nbytes(scalars) == sizeof(scalars)
+    pw = [
+        IS.PiecewiseLinearData([(x = 1.0, y = j), (x = 2.0, y = 2j), (x = 3.0, y = 3j)])
+        for j in 1.0:4.0
+    ]
+    # 3 points => 1 count slot + 2 slots per point.
+    @test IS._staged_nbytes(pw) == length(pw) * 7 * sizeof(Float64)
+    @test IS._staged_nbytes(pw) > sizeof(pw)
+    # A forecast stages an `(horizon, count)` matrix; the width applies just the same.
+    @test IS._staged_nbytes(reduce(hcat, [pw, pw])) == 2 * length(pw) * 7 * sizeof(Float64)
 end
 
 @testset "Test staged additions take their ids from the store" begin

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -19,10 +19,13 @@ _is_deterministic(::Any) = false
 
     forecast = IS.Deterministic(; data = data, name = name, resolution = resolution)
     key = IS.add_time_series!(sys, component, forecast)
-    @test key isa IS.ForecastKey
-    @test key.name == name
-    @test key.horizon == horizon_count * resolution
-    @test key.resolution == resolution
+    @test key isa IS.TimeSeriesKey{<:IS.Forecast}
+    # The descriptive columns live on the catalog row, not on the key.
+    md = only(IS.list_metadata(component; name = name))
+    @test IS.get_time_series_key(md) == key
+    @test IS.get_name(md) == name
+    @test IS.get_horizon(md) == horizon_count * resolution
+    @test IS.get_resolution(md) == resolution
     var1 =
         IS.get_time_series(IS.Deterministic, component, name; start_time = initial_time)
     @test length(var1) == 2
@@ -245,7 +248,7 @@ end
     IS.add_time_series!(sys, component, forecast_1h)
     IS.add_time_series!(sys, component, forecast_2h)
 
-    ts_keys = IS.get_time_series_keys(component)
+    ts_keys = IS.list_metadata(component)
     @test length(ts_keys) == 2
     key_1h = only(filter(k -> IS.get_interval(k) == Dates.Hour(1), ts_keys))
     key_2h = only(filter(k -> IS.get_interval(k) == Dates.Hour(2), ts_keys))
@@ -280,11 +283,11 @@ end
     component2 = IS.TestComponent("Component2", 6)
     IS.add_component!(sys, component2)
     IS.copy_time_series!(component2, component)
-    @test length(IS.get_time_series_keys(component2)) == 2
+    @test length(IS.list_metadata(component2)) == 2
 
     # A keyed removal removes only the keyed series.
     IS.remove_time_series!(sys, component, key_1h)
-    remaining = IS.get_time_series_keys(component)
+    remaining = IS.list_metadata(component)
     @test length(remaining) == 1
     @test IS.get_interval(only(remaining)) == Dates.Hour(2)
 end
@@ -318,8 +321,12 @@ end
         mk(collect(101.0:124.0));
         features = Dict("scenario" => "a", "model" => "x"),
     )
-    @test IS.get_features(key_subset) == Dict("scenario" => "a")
-    @test IS.get_features(key_superset) == Dict("scenario" => "a", "model" => "x")
+    # Features live on the catalog row, not on the key.
+    rows = IS.list_metadata(component)
+    by_id = Dict(IS.get_association_id(r) => IS.get_features(r) for r in rows)
+    @test by_id[IS.get_association_id(key_subset)] == Dict("scenario" => "a")
+    @test by_id[IS.get_association_id(key_superset)] ==
+          Dict("scenario" => "a", "model" => "x")
 
     # Keyed reads resolve exactly instead of throwing an ambiguity error.
     @test IS.get_time_series_values(component, key_subset)[1] == 1.0
@@ -338,7 +345,7 @@ end
 
     # A keyed removal removes exactly the keyed series.
     IS.remove_time_series!(sys, component, key_subset)
-    remaining = IS.get_time_series_keys(component)
+    remaining = IS.list_metadata(component)
     @test length(remaining) == 1
     @test IS.get_features(only(remaining)) == Dict("scenario" => "a", "model" => "x")
     @test IS.get_time_series_values(component, only(remaining))[1] == 101.0
@@ -352,7 +359,7 @@ end
         features = Dict("scenario" => "a"),
     )
     IS.remove_time_series!(sys, component, key_superset)
-    left = IS.get_time_series_keys(component)
+    left = IS.list_metadata(component)
     @test length(left) == 1
     @test IS.get_features(only(left)) == Dict("scenario" => "a")
 
@@ -425,7 +432,7 @@ end
             IS.SingleTimeSeries, component, "static"; interval = resolution),
         () -> IS.get_time_series_key(
             IS.SingleTimeSeries, component, "static"; interval = resolution),
-        () -> IS.get_time_series_keys(
+        () -> IS.list_metadata(
             component; time_series_type = IS.SingleTimeSeries, interval = resolution),
         () -> IS.has_time_series(
             component, IS.SingleTimeSeries, "static"; interval = resolution),
@@ -622,8 +629,10 @@ end
     forecast2 = IS.Deterministic(; data = data2, name = name2, resolution = resolution2)
     key1 = IS.add_time_series!(sys, component, forecast1)
     key2 = IS.add_time_series!(sys, component, forecast2)
-    @test key1.horizon == horizon_count * resolution1
-    @test key2.horizon == horizon_count2 * resolution2
+    # A key is its id; the horizon is a column of the catalog row.
+    horizon_of(name) = IS.get_horizon(only(IS.list_metadata(component; name = name)))
+    @test horizon_of(name1) == horizon_count * resolution1
+    @test horizon_of(name2) == horizon_count2 * resolution2
 
     resolution3 = Dates.Minute(11)
     other_time3 = initial_time + resolution3
@@ -635,7 +644,7 @@ end
     )
     forecast3 = IS.Deterministic(; data = data3, name = name3, resolution = resolution3)
     key3 = IS.add_time_series!(sys, component, forecast3)
-    @test key3.horizon == horizon_count3 * resolution3
+    @test horizon_of(name3) == horizon_count3 * resolution3
 end
 
 @testset "Test add Deterministic Cost Timeseries" begin
@@ -1139,15 +1148,14 @@ end
         ts_name;
         features = Dict("model_year" => "2060", "scenario" => "low"),
     )
-    @test length(IS.get_time_series_keys(component)) == 4
-    @test IS.get_time_series_type(IS.get_time_series_keys(component)[1]) ===
-          IS.SingleTimeSeries
-    @test length(IS.get_time_series_keys(component)) == 4
-    for key in IS.get_time_series_keys(component)
+    @test length(IS.list_metadata(component)) == 4
+    @test IS.get_time_series_type(IS.list_metadata(component)[1]) <: IS.SingleTimeSeries
+    @test length(IS.list_metadata(component)) == 4
+    for key in IS.list_metadata(component)
         @test IS.get_data(IS.get_time_series(component, key)) == data
     end
     IS.remove_time_series!(sys, IS.SingleTimeSeries)
-    @test isempty(IS.get_time_series_keys(component))
+    @test isempty(IS.list_metadata(component))
     @test IS.get_num_time_series(sys) == 0
 end
 
@@ -1347,19 +1355,19 @@ end
         ts_name;
         features = Dict("scenario" => "low", "model_year" => "2035"),
     ) isa IS.Deterministic
-    @test length(IS.get_time_series_keys(component)) == 4
+    @test length(IS.list_metadata(component)) == 4
     @test length(
-        IS.get_time_series_keys(component; time_series_type = IS.Deterministic),
+        IS.list_metadata(component; time_series_type = IS.Deterministic),
     ) == 4
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
         ),
     ) == 4
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
@@ -1367,22 +1375,21 @@ end
         ),
     ) == 2
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = ts_name,
             features = Dict("scenario" => "low", "model_year" => "2035"),
         ),
     ) == 1
-    @test IS.get_time_series_keys(
+    @test IS.list_metadata(
         component;
         time_series_type = IS.Deterministic,
         name = ts_name,
         features = Dict("scenario" => "low", "model_year" => "2035"),
     )[1].features["model_year"] == "2035"
-    @test length(IS.get_time_series_keys(component)) == 4
-    @test IS.get_time_series_type(IS.get_time_series_keys(component)[1]) ===
-          IS.Deterministic
+    @test length(IS.list_metadata(component)) == 4
+    @test IS.get_time_series_type(IS.list_metadata(component)[1]) <: IS.Deterministic
 
     IS.remove_time_series!(
         sys,
@@ -1392,14 +1399,14 @@ end
         features = Dict("scenario" => "low"),
     )
     @test length(
-        IS.get_time_series_keys(component; time_series_type = IS.Deterministic),
+        IS.list_metadata(component; time_series_type = IS.Deterministic),
     ) == 2
     for metadata in
-        IS.get_time_series_keys(component; time_series_type = IS.Deterministic)
+        IS.list_metadata(component; time_series_type = IS.Deterministic)
         @test metadata.features["scenario"] == "high"
     end
     IS.remove_time_series!(sys, IS.Deterministic, component, ts_name)
-    @test isempty(IS.get_time_series_keys(component))
+    @test isempty(IS.list_metadata(component))
 end
 
 @testset "Test Deterministic with a wrapped SingleTimeSeries" begin
@@ -1765,7 +1772,7 @@ end
 
     # Both sets should coexist.
     all_metadata = collect(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -1805,7 +1812,7 @@ end
     )
 
     all_metadata = collect(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -1882,7 +1889,7 @@ end
     )
 
     all_metadata = collect(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -1899,7 +1906,7 @@ end
     )
 
     all_metadata = collect(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.DeterministicSingleTimeSeries,
         ),
@@ -2409,10 +2416,12 @@ end
     ts = IS.SingleTimeSeries(; data = data, name = "val")
     key = IS.add_time_series!(sys, component, ts)
 
-    @test IS.get_owner_id(key) == IS.get_id(component)
-    @test IS.get_owner_category(key) == IS.get_owner_category(component)
-    read_back_key = only(IS.get_time_series_keys(component))
-    @test IS.get_association_id(key) == IS.get_association_id(read_back_key)
+    # The owner is a column of the catalog row; the key is the id that finds it.
+    row = only(IS.list_metadata(component))
+    @test IS.get_owner_id(row) == IS.get_id(component)
+    @test IS.get_owner_category(row) == IS.get_owner_category(component)
+    @test IS.get_association_id(key) == IS.get_association_id(row)
+    @test IS.get_time_series_key(row) == key
 end
 
 @testset "Test add_time_series (Deterministic) key carries owner and association_id" begin
@@ -2435,10 +2444,12 @@ end
         return only(IS.added_keys(txn))
     end
 
-    @test IS.get_owner_id(key) == IS.get_id(component)
-    @test IS.get_owner_category(key) == IS.get_owner_category(component)
-    read_back_key = only(IS.get_time_series_keys(component))
-    @test IS.get_association_id(key) == IS.get_association_id(read_back_key)
+    # The owner is a column of the catalog row; the key is the id that finds it.
+    row = only(IS.list_metadata(component))
+    @test IS.get_owner_id(row) == IS.get_id(component)
+    @test IS.get_owner_category(row) == IS.get_owner_category(component)
+    @test IS.get_association_id(key) == IS.get_association_id(row)
+    @test IS.get_time_series_key(row) == key
 end
 
 @testset "Test add_time_series (NonSequentialTimeSeries) key carries owner and association_id" begin
@@ -2456,10 +2467,12 @@ end
     ts = IS.NonSequentialTimeSeries("events", timestamps, values)
     key = IS.add_time_series!(sys, component, ts)
 
-    @test IS.get_owner_id(key) == IS.get_id(component)
-    @test IS.get_owner_category(key) == IS.get_owner_category(component)
-    read_back_key = only(IS.get_time_series_keys(component))
-    @test IS.get_association_id(key) == IS.get_association_id(read_back_key)
+    # The owner is a column of the catalog row; the key is the id that finds it.
+    row = only(IS.list_metadata(component))
+    @test IS.get_owner_id(row) == IS.get_id(component)
+    @test IS.get_owner_category(row) == IS.get_owner_category(component)
+    @test IS.get_association_id(key) == IS.get_association_id(row)
+    @test IS.get_time_series_key(row) == key
 end
 
 @testset "Test get_time_series_key resolves by association_id" begin
@@ -2505,19 +2518,11 @@ end
         features = Dict("scenario" => "high"),
     )
 
-    doctored = IS.StaticTimeSeriesKey(;
-        # The owner is deliberately NOT doctored: it is the one field an accessor
-        # does read off the key, to confirm the caller named the right owner.
-        owner_id = IS.get_owner_id(key),
-        owner_category = IS.get_owner_category(key),
-        association_id = IS.get_association_id(key),
-        time_series_type = IS.SingleTimeSeries,
-        name = "wrong-name",
-        initial_timestamp = Dates.DateTime("1999-01-01T00:00:00"),
-        resolution = Dates.Minute(5),
-        length = 999,
-        features = Dict{String, Any}("scenario" => "low"),
-    )
+    # There is nothing left to doctor: a key is its association id and the stored
+    # type, and a read resolves everything else from the catalog. Rebuilding one
+    # from the id alone is the strongest form of the property this used to check
+    # by falsifying every other field.
+    doctored = IS.TimeSeriesKey{IS.SingleTimeSeries{Float64}}(IS.get_association_id(key))
 
     @test IS.get_time_series_values(component, doctored) ==
           IS.get_time_series_values(component, key)
@@ -2539,7 +2544,7 @@ end
           [5.0, 6.0, 7.0]
 
     IS.remove_time_series!(sys, component, doctored)
-    @test isempty(IS.get_time_series_keys(component))
+    @test isempty(IS.list_metadata(component))
 end
 
 @testset "Test key accessors address a Deterministic by association_id" begin
@@ -2557,21 +2562,9 @@ end
         return only(IS.added_keys(txn))
     end
 
-    doctored = IS.ForecastKey(;
-        # The owner is deliberately NOT doctored: it is the one field an accessor
-        # does read off the key, to confirm the caller named the right owner.
-        owner_id = IS.get_owner_id(key),
-        owner_category = IS.get_owner_category(key),
-        association_id = IS.get_association_id(key),
-        time_series_type = IS.Deterministic,
-        name = "wrong-name",
-        initial_timestamp = Dates.DateTime("1999-01-01T00:00:00"),
-        resolution = Dates.Minute(5),
-        horizon = Dates.Minute(15),
-        interval = Dates.Minute(10),
-        count = 99,
-        features = Dict{String, Any}("scenario" => "low"),
-    )
+    # A key is its association id and the stored type; nothing else is carried,
+    # so there is no descriptive field left to falsify.
+    doctored = IS.TimeSeriesKey{IS.Deterministic{Float64}}(IS.get_association_id(key))
 
     @test IS.get_data(IS.get_time_series(component, doctored)) ==
           IS.get_data(IS.get_time_series(component, key))
@@ -2596,17 +2589,10 @@ end
         sys, component, IS.NonSequentialTimeSeries("events", timestamps, values),
     )
 
-    doctored = IS.NonSequentialTimeSeriesKey(;
-        # The owner is deliberately NOT doctored: it is the one field an accessor
-        # does read off the key, to confirm the caller named the right owner.
-        owner_id = IS.get_owner_id(key),
-        owner_category = IS.get_owner_category(key),
-        association_id = IS.get_association_id(key),
-        time_series_type = IS.NonSequentialTimeSeries,
-        name = "wrong-name",
-        length = 999,
-        features = Dict{String, Any}("scenario" => "low"),
-    )
+    # A key is its association id and the stored type; nothing else is carried,
+    # so there is no descriptive field left to falsify.
+    doctored =
+        IS.TimeSeriesKey{IS.NonSequentialTimeSeries{Float64}}(IS.get_association_id(key))
 
     @test IS.get_time_series_values(component, doctored) == values
     @test IS.get_time_series_hash(component, doctored) ==
@@ -2631,7 +2617,7 @@ end
         ta = TimeSeries.TimeArray(dates, values, [IS.get_name(component)])
         IS.add_time_series!(sys, component, IS.SingleTimeSeries(; name = "val", data = ta))
     end
-    key1 = only(IS.get_time_series_keys(component1))
+    key1 = only(IS.list_metadata(component1))
 
     @test_throws ArgumentError IS.get_time_series(component2, key1)
     @test_throws ArgumentError IS.get_time_series_values(component2, key1)
@@ -2643,7 +2629,7 @@ end
     # Both series survive the rejected calls, and each reads from its own owner.
     @test IS.get_time_series_values(component1, key1) == values1
     @test IS.get_time_series_values(
-        component2, only(IS.get_time_series_keys(component2)),
+        component2, only(IS.list_metadata(component2)),
     ) == values2
 end
 
@@ -2682,7 +2668,7 @@ end
     IS.transform_single_time_series!(
         sys, IS.DeterministicSingleTimeSeries, Dates.Hour(12), Dates.Hour(6),
     )
-    @test length(IS.get_time_series_keys(component)) == 2
+    @test length(IS.list_metadata(component)) == 2
 
     # The derived forecast holds the SingleTimeSeries down: removing its backing series
     # would orphan it, and the store refuses rather than removing either.
@@ -2694,17 +2680,17 @@ end
     end
     @test e isa ArgumentError
     @test occursin("DeterministicSingleTimeSeries", e.msg)
-    @test length(IS.get_time_series_keys(component)) == 2
+    @test length(IS.list_metadata(component)) == 2
 
     # Removing the forecast by its own key leaves the SingleTimeSeries alone, even
     # though the two agree on name, resolution and features.
     dst_key = only(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component; time_series_type = IS.DeterministicSingleTimeSeries,
         ),
     )
     IS.remove_time_series!(sys, component, dst_key)
-    @test IS.get_association_id(only(IS.get_time_series_keys(component))) ==
+    @test IS.get_association_id(only(IS.list_metadata(component))) ==
           IS.get_association_id(sts_key)
     @test length(IS.get_time_series_values(component, sts_key)) == length(dates)
 end
@@ -2762,7 +2748,10 @@ end
     @test length(keys) == len
     @test length(unique(IS.get_association_id.(keys))) == len
     for (i, key) in enumerate(keys)
-        @test IS.get_owner_id(key) == IS.get_id(components[i])
+        # The owner is on the row the key resolves to, not on the key.
+        row = only(IS.list_metadata(components[i]))
+        @test IS.get_time_series_key(row) == key
+        @test IS.get_owner_id(row) == IS.get_id(components[i])
     end
 
     hash_ta_main = nothing
@@ -3128,7 +3117,7 @@ end
         attr1;
         name_mapping = Dict(("not-a-real-label", "x") => "y"),
     )
-    @test isempty(IS.get_time_series_keys(attr3))
+    @test isempty(IS.list_metadata(attr3))
 end
 
 @testset "Test copy time_series with transformed time series" begin
@@ -3805,11 +3794,11 @@ const IRREGULAR_TIMESTAMPS = [
         IS.NonSequentialTimeSeries(name, timestamps, values),
     )
 
-    # The key is a dedicated NonSequentialTimeSeriesKey (no resolution).
-    keys = collect(IS.get_time_series_keys(component))
+    # A non-sequential series is irregular, so its row carries no resolution.
+    keys = collect(IS.list_metadata(component))
     @test length(keys) == 1
     key = keys[1]
-    @test typeof(key) === IS.NonSequentialTimeSeriesKey
+    @test IS.get_time_series_type(key) <: IS.NonSequentialTimeSeries
     @test IS.get_resolution(key) === nothing
     @test IS.get_name(key) == name
     @test IS.length(key) == 4
@@ -3819,7 +3808,7 @@ const IRREGULAR_TIMESTAMPS = [
             IS.NonSequentialTimeSeries, component, name; interval = interval),
         () -> IS.get_time_series_key(
             IS.NonSequentialTimeSeries, component, name; interval = interval),
-        () -> IS.get_time_series_keys(
+        () -> IS.list_metadata(
             component;
             time_series_type = IS.NonSequentialTimeSeries,
             interval = interval,
@@ -4413,20 +4402,17 @@ end
         features = Dict("scenario" => "high"),
     )
 
-    # The whole key goes on the wire as its association id.
+    # A key goes on the wire as its association id and its stored type — the two
+    # facts the store never rewrites, and between them everything a key is.
     serialized = IS.serialize(key)
-    @test serialized == IS.get_association_id(key)
+    @test serialized["association_id"] == IS.get_association_id(key)
+    @test serialized["time_series_type"] == "SingleTimeSeries"
 
-    key2 = IS.with_deserialization_store(key_store(sys)) do
-        IS.deserialize(IS.StaticTimeSeriesKey, serialized)
-    end
-    @test key2 !== key
-    for field in fieldnames(IS.StaticTimeSeriesKey)
-        @test getproperty(key2, field) == getproperty(key, field)
-    end
-
-    # Without a bound store the id names nothing.
-    @test_throws ArgumentError IS.deserialize(IS.StaticTimeSeriesKey, serialized)
+    # No store needed to rebuild it: nothing on the wire has to be resolved.
+    key2 = IS.deserialize(IS.TimeSeriesKey, serialized)
+    @test key2 == key
+    @test IS.get_association_id(key2) == IS.get_association_id(key)
+    @test IS.get_time_series_type(key2) <: IS.SingleTimeSeries
 end
 
 @testset "Test time series key survives system serialization as its association id" begin
@@ -4459,13 +4445,14 @@ end
     end
 
     holder_json = only(filter(c -> c["name"] == "KeyHolder", raw["components"]))
-    @test holder_json["time_series_key"] == IS.get_association_id(key)
+    @test holder_json["time_series_key"] == IS.serialize(key)
+    @test holder_json["time_series_key"]["association_id"] == IS.get_association_id(key)
 
-    # The field-by-field spelling is gone: nothing but the id crosses the wire, so none
-    # of the key's other fields appear anywhere in the document.
+    # The field-by-field spelling is gone: a key crosses the wire as its id and its
+    # stored type, the two facts the store never rewrites. None of the descriptive
+    # columns it used to carry appear anywhere in the document.
     json_text = read(filename, String)
     @test !occursin("owner_category", json_text)
-    @test !occursin("association_id", json_text)
     @test !occursin("closing_the_circle", json_text)
 
     # Move the JSON and both store halves to a fresh directory, the way a shipped
@@ -4485,12 +4472,11 @@ end
     sys2 = try
         cd(dirname(path))
         restored = IS.deserialize(IS.SystemData, parsed)
-        IS.with_deserialization_store(key_store(restored)) do
-            for component in parsed["components"]
-                type = IS.get_type_from_serialization_data(component)
-                comp = IS.deserialize(type, component)
-                IS.add_component!(restored, comp; allow_existing_time_series = true)
-            end
+        # No store scoping: a key rebuilds itself from the wire.
+        for component in parsed["components"]
+            type = IS.get_type_from_serialization_data(component)
+            comp = IS.deserialize(type, component)
+            IS.add_component!(restored, comp; allow_existing_time_series = true)
         end
         restored
     finally
@@ -4500,9 +4486,8 @@ end
     holder2 = IS.get_component(IS.TimeSeriesKeyTestComponent, sys2, "KeyHolder")
     restored_key = holder2.time_series_key
     @test restored_key == key
-    for field in fieldnames(IS.StaticTimeSeriesKey)
-        @test getproperty(restored_key, field) == getproperty(key, field)
-    end
+    @test typeof(restored_key) === typeof(key)
+    @test IS.get_association_id(restored_key) == IS.get_association_id(key)
 
     owner2 = IS.get_component(IS.TestComponent, sys2, "Component1")
     @test IS.get_time_series_values(owner2, restored_key) == original_values
@@ -4675,17 +4660,18 @@ end
     initial_time = Dates.DateTime("2020-09-01")
     resolution = Dates.Hour(1)
 
-    ts_keys = []
     for scenario in ["high", "low"]
         dates = collect(range(initial_time; length = 24, step = resolution))
         data = scenario == "high" ? collect(1:24) : collect(24:-1:1)
         ta = TimeSeries.TimeArray(dates, data, [IS.get_name(component)])
         ts_name = "power"
         ts = IS.SingleTimeSeries(; data = ta, name = ts_name)
-        key =
-            IS.add_time_series!(sys, component, ts; features = Dict("scenario" => scenario))
-        push!(ts_keys, key)
+        IS.add_time_series!(sys, component, ts; features = Dict("scenario" => scenario))
     end
+
+    # Features are a column of the catalog row, so the rows are what carries them
+    # here; each row hands back the key that reads it.
+    ts_keys = IS.list_metadata(component)
 
     for key in ts_keys
         timestamps = IS.get_time_series_timestamps(component, key)
@@ -5072,7 +5058,7 @@ end
 
     # The nothing-tolerant accessors keep answering "empty".
     @test !IS.has_time_series(c)
-    @test isempty(IS.get_time_series_keys(c))
+    @test isempty(IS.list_metadata(c))
     @test isempty(collect(IS.get_time_series_multiple(c)))
 end
 
@@ -5125,7 +5111,7 @@ end
     @test_throws ArgumentError IS.get_time_series_key(IS.LinearFunctionData(1.0, 2.0))
 end
 
-@testset "Test get_length agrees with Base.length for every key type" begin
+@testset "Test get_length agrees with Base.length on a metadata row" begin
     sys = IS.SystemData()
     component = IS.TestComponent("Component1", 5)
     IS.add_component!(sys, component)
@@ -5140,10 +5126,12 @@ end
         component,
         IS.Deterministic(; name = "f", data = data, resolution = resolution),
     )
-    key = IS.get_time_series_key(IS.Deterministic, component, "f")
-    @test IS.get_length(key) == IS.get_horizon_count(key) == horizon_count
-    @test IS.get_length(key) == length(key)
-    @test IS.get_count(key) == 3
+    # These are row columns now: a key carries no length, count or horizon.
+    md = only(IS.list_metadata(component; time_series_type = IS.Deterministic))
+    @test IS.get_length(md) == horizon_count
+    @test IS.get_length(md) == length(md)
+    @test IS.get_count(md) == 3
+    @test IS.get_horizon(md) == horizon_count * resolution
 end
 
 @testset "Test instance-form forecast accessors reject a non-window start_time" begin
@@ -5284,7 +5272,7 @@ end
             )
         end
     end
-    ts_keys = IS.get_time_series_keys(component)
+    ts_keys = IS.list_metadata(component)
     @test length(ts_keys) == 30
     actual_ts_data = Dict(IS.get_name(x) => x for x in ts_keys)
     for i in 1:30
@@ -5331,14 +5319,14 @@ end
             )
         end
     end
-    @test isempty(IS.get_time_series_keys(component))
+    @test isempty(IS.list_metadata(component))
 
     @test_throws ArgumentError IS.time_series_transaction(sys) do txn
         for _ in 1:3
             IS.add_time_series!(txn, component, forecast)
         end
     end
-    @test isempty(IS.get_time_series_keys(component))
+    @test isempty(IS.list_metadata(component))
 end
 
 @testset "Test bulk addition of time series with transaction" begin
@@ -5372,7 +5360,7 @@ end
             )
         end
     end
-    ts_keys = IS.get_time_series_keys(component)
+    ts_keys = IS.list_metadata(component)
     @test length(ts_keys) == 5
     actual_ts_data = Dict(IS.get_name(x) => x for x in ts_keys)
     for i in 1:5
@@ -5433,7 +5421,7 @@ end
             end
         end,
     )
-    ts_keys = IS.get_time_series_keys(component)
+    ts_keys = IS.list_metadata(component)
     @test length(ts_keys) == 1
     key = ts_keys[1]
     @test IS.get_name(key) == "bystander"
@@ -5715,17 +5703,17 @@ end
         ),
     )
     @test length(
-        IS.get_time_series_keys(component; time_series_type = IS.SingleTimeSeries),
+        IS.list_metadata(component; time_series_type = IS.SingleTimeSeries),
     ) == 2
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.SingleTimeSeries,
             resolution = resolution1,
         ),
     ) == 1
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.SingleTimeSeries,
             name = ts_name,
@@ -5842,17 +5830,17 @@ end
         ),
     )
     @test length(
-        IS.get_time_series_keys(component; time_series_type = IS.Deterministic),
+        IS.list_metadata(component; time_series_type = IS.Deterministic),
     ) == 2
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.Deterministic,
             resolution = resolution1,
         ),
     ) == 1
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = f_name,
@@ -6060,19 +6048,19 @@ end
         ),
     )
 
-    # get_time_series_keys with interval
+    # list_metadata with interval
     @test length(
-        IS.get_time_series_keys(component; time_series_type = IS.Deterministic),
+        IS.list_metadata(component; time_series_type = IS.Deterministic),
     ) == 2
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.Deterministic,
             interval = interval1,
         ),
     ) == 1
     @test length(
-        IS.get_time_series_keys(
+        IS.list_metadata(
             component;
             time_series_type = IS.Deterministic,
             name = f_name,
@@ -6565,12 +6553,12 @@ end
         ts_name = "test"
         data = IS.SingleTimeSeries(; data = data, name = ts_name)
         IS.add_time_series!(sys, attr, data)
-        all_metadata = IS.get_time_series_keys(
+        all_metadata = IS.list_metadata(
             attr;
             time_series_type = IS.SingleTimeSeries,
         )
         @test isempty(
-            IS.get_time_series_keys(
+            IS.list_metadata(
                 component;
                 time_series_type = IS.SingleTimeSeries,
             ),
@@ -6582,7 +6570,7 @@ end
             IS.remove_time_series!(sys, IS.SingleTimeSeries, attr, ts_name)
         end
         @test isempty(
-            IS.get_time_series_keys(
+            IS.list_metadata(
                 attr;
                 time_series_type = IS.SingleTimeSeries,
             ),
@@ -6628,7 +6616,7 @@ end
     # so that we can test removing just the SingleTimeSeries from the other component
     IS.remove_time_series!(mgr, IS.DeterministicSingleTimeSeries, component2, ts_name)
 
-    metadata = IS.get_time_series_keys(
+    metadata = IS.list_metadata(
         component;
         time_series_type = IS.SingleTimeSeries,
         name = ts_name,
@@ -6846,7 +6834,7 @@ end
     IS.transform_single_time_series!(
         sys, IS.DeterministicSingleTimeSeries, Dates.Hour(6), Dates.Hour(6))
     dst_key = only(
-        IS.get_time_series_keys(c1; time_series_type = IS.DeterministicSingleTimeSeries))
+        IS.list_metadata(c1; time_series_type = IS.DeterministicSingleTimeSeries))
     @test IS.get_time_series_hash(c1, dst_key) == h1
 
     # System-wide grouping, default: only the arrays referenced more than once.
@@ -6858,14 +6846,15 @@ end
     @test Set(IS.get_name(o) for (o, _) in groups[h1]) == Set(["c1", "c2"])
     @test length(groups[h1]) == 2
     for (o, k) in groups[h1]
-        @test typeof(k) === IS.StaticTimeSeriesKey
-        @test IS.get_time_series_type(k) === IS.SingleTimeSeries
+        @test k isa IS.TimeSeriesKey{<:IS.SingleTimeSeries}
+        @test IS.get_time_series_type(k) <: IS.SingleTimeSeries
         @test IS.get_time_series_hash(o, k) == h1
     end
 
     # only_shared = false adds the arrays with a single reference.
+    # A key has no name of its own; its association id identifies it.
     ids(pairs) = Set(
-        (IS.get_name(o), IS.get_name(k), IS.get_time_series_type(k))
+        (IS.get_name(o), IS.get_association_id(k), IS.get_time_series_type(k))
         for (o, k) in pairs
     )
     all_groups = IS.get_time_series_array_groups(sys; only_shared = false)
@@ -6874,7 +6863,7 @@ end
     @test Set(IS.get_name(o) for (o, _) in all_groups[h3]) == Set(["c3"])
     @test length(all_groups[h3]) == 1
     @test all(
-        IS.get_time_series_type(k) !== IS.DeterministicSingleTimeSeries
+        !(IS.get_time_series_type(k) <: IS.DeterministicSingleTimeSeries)
         for pairs in values(all_groups) for (_, k) in pairs
     )
 
@@ -7040,7 +7029,7 @@ end
     @test IS.get_num_forecast_slots(reader) == 2
     # Entries are bound to their owner objects.
     @test Set(IS.get_name(e.owner) for e in entries) == Set(["c1", "c2", "c3", "c4"])
-    @test all(typeof(e.key) === IS.ForecastKey for e in entries)
+    @test all(e.key isa IS.TimeSeriesKey{<:IS.Forecast} for e in entries)
 
     # Reading window values requires a prior read.
     @test_throws ArgumentError IS.get_forecast_window(reader, 1)
@@ -7098,7 +7087,7 @@ end
     # so only two physical slots.
     @test length(entries) == 3
     @test all(
-        IS.get_time_series_type(e.key) == IS.DeterministicSingleTimeSeries
+        IS.get_time_series_type(e.key) <: IS.DeterministicSingleTimeSeries
         for e in entries
     )
     @test IS.get_num_forecast_slots(reader) == 2
@@ -7166,7 +7155,7 @@ end
 
     entries = IS.get_static_time_series_reader_entries(reader)
     @test Set(IS.get_name(e.owner) for e in entries) == Set(["c1", "c2", "c3"])
-    @test all(typeof(e.key) === IS.StaticTimeSeriesKey for e in entries)
+    @test all(e.key isa IS.TimeSeriesKey{<:IS.SingleTimeSeries} for e in entries)
     # All three scalar series pack into one columnar group: one read per step.
     @test IS.get_num_static_time_series_groups(reader) == 1
 
@@ -7232,7 +7221,7 @@ end
         IS.remove_time_series!(sys, IS.SingleTimeSeries, component, "keep")
         error("boom")
     end
-    keys = IS.get_time_series_keys(component)
+    keys = IS.list_metadata(component)
     @test length(keys) == 1
     @test IS.get_name(keys[1]) == "keep"
     # The data came back, not just the catalog row.
@@ -7243,7 +7232,7 @@ end
     IS.time_series_transaction(sys) do txn
         IS.add_time_series!(txn, component, make_ts("added", 100.0))
     end
-    @test length(IS.get_time_series_keys(component)) == 2
+    @test length(IS.list_metadata(component)) == 2
 end
 
 @testset "Test failed commit rolls back the store transaction" begin
@@ -7276,7 +7265,7 @@ end
         IS.add_time_series!(txn, component, make_ts("after"))
     end
     @test !IS.InfraStore.in_transaction(store)
-    names = Set(IS.get_name(k) for k in IS.get_time_series_keys(component))
+    names = Set(IS.get_name(k) for k in IS.list_metadata(component))
     @test names == Set(["dup", "after"])
 end
 
@@ -7301,7 +7290,7 @@ end
         # Auto-flushes at 3 and 6 drained all but the seventh entry.
         @test IS.has_staged_data(txn)
     end
-    @test length(IS.get_time_series_keys(component)) == 7
+    @test length(IS.list_metadata(component)) == 7
 
     # The byte limit flushes long series well before the count limit would.
     # Staged-byte accounting counts the encoded array (for a Float64 series,
@@ -7314,7 +7303,7 @@ end
         # Byte-triggered flushes at 3 and 6 drained all but the seventh entry.
         @test IS.has_staged_data(txn)
     end
-    @test length(IS.get_time_series_keys(component)) == 14
+    @test length(IS.list_metadata(component)) == 14
 
     # Auto-flushed work still rolls back with the block.
     @test_throws ErrorException IS.time_series_transaction(
@@ -7325,7 +7314,7 @@ end
         end
         error("boom")
     end
-    names = Set(IS.get_name(k) for k in IS.get_time_series_keys(component))
+    names = Set(IS.get_name(k) for k in IS.list_metadata(component))
     @test names == union(Set("ts_$i" for i in 1:7), Set("bytes_$i" for i in 1:7))
 end
 
@@ -7372,13 +7361,15 @@ end
         return copy(IS.added_keys(txn))
     end
     @test length(keys) == 5
-    @test IS.get_name.(keys) == ["collected_$i" for i in 1:5]
 
+    # A key is its id; the names are on the rows those ids resolve to.
     stored = Dict(
-        IS.get_association_id(k) => k for k in IS.get_time_series_keys(component)
+        IS.get_association_id(md) => md for md in IS.list_metadata(component)
     )
+    @test [IS.get_name(stored[IS.get_association_id(k)]) for k in keys] ==
+          ["collected_$i" for i in 1:5]
     for key in keys
-        @test stored[IS.get_association_id(key)] == key
+        @test IS.get_time_series_key(stored[IS.get_association_id(key)]) == key
     end
 end
 
@@ -7406,7 +7397,7 @@ end
     end
     # The rollback unwrote the row, so the key naming it is dropped with it.
     @test isempty(IS.added_keys(context))
-    @test isempty(IS.get_time_series_keys(component))
+    @test isempty(IS.list_metadata(component))
 end
 
 @testset "Test time series context nesting and reuse" begin
@@ -7433,7 +7424,7 @@ end
             error("inner failed")
         end
     end
-    names = Set(IS.get_name(k) for k in IS.get_time_series_keys(component))
+    names = Set(IS.get_name(k) for k in IS.list_metadata(component))
     @test names == Set(["outer"])
 
     # A transaction is valid only inside its own block.

--- a/test/test_time_series.jl
+++ b/test/test_time_series.jl
@@ -7323,6 +7323,58 @@ end
     end
 end
 
+@testset "Test StaticTimeSeriesReader group accessors" begin
+    sys, comps = _create_reader_system(3)
+    t0, res = READER_T0, READER_RES
+    len = 4
+    # Two element types, so two groups: three scalar series and one of curves.
+    expected = Dict{IS.TimeSeriesKey, Vector}()
+    for (i, c) in enumerate(comps)
+        v = [10.0 * i + j for j in 1:len]
+        expected[IS.add_time_series!(sys, c, IS.SingleTimeSeries("val", t0, res, v))] = v
+    end
+    fds = [IS.LinearFunctionData(1.0 * j, 2.0 * j) for j in 1:len]
+    expected[IS.add_time_series!(
+        sys,
+        comps[1],
+        IS.SingleTimeSeries("cost", t0, res, fds),
+    )] = fds
+
+    reader = IS.build_static_time_series_reader(sys; resolution = res)
+    ngroups = IS.get_num_static_time_series_groups(reader)
+    @test ngroups == 2
+
+    entries = IS.get_static_time_series_reader_entries(reader)
+    grouped = [IS.get_static_time_series_group_entries(reader, g) for g in 1:ngroups]
+    # The group views partition the reader's entries.
+    @test sum(length, grouped) == length(reader)
+    @test Set(e.key for g in grouped for e in g) == Set(e.key for e in entries)
+
+    by_key = Dict(e.key => i for (i, e) in enumerate(entries))
+    for k in 1:len
+        IS.read_static_time_series_values!(reader, t0 + res * (k - 1))
+        for g in 1:ngroups
+            vals = IS.get_static_time_series_group_values(reader, g)
+            ents = grouped[g]
+            # The pairing the accessors promise: value i belongs to entry i.
+            @test length(vals) == length(ents)
+            for (i, e) in enumerate(ents)
+                @test e.group == g
+                @test e.column == i
+                @test vals[i] == expected[e.key][k]
+                # ... and the group path agrees with the per-entry one.
+                @test vals[i] == IS.get_static_time_series_value(reader, by_key[e.key])
+            end
+        end
+    end
+
+    # Reading a group before any read is an error, as it is per entry.
+    fresh = IS.build_static_time_series_reader(sys; resolution = res)
+    @test_throws ArgumentError IS.get_static_time_series_group_values(fresh, 1)
+    # The entry grouping is fixed at build and needs no read.
+    @test length(IS.get_static_time_series_group_entries(fresh, 1)) > 0
+end
+
 @testset "Test StaticTimeSeriesReader decodes each element type in its own group" begin
     sys, comps = _create_reader_system(2)
     t0, res = READER_T0, READER_RES

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -38,8 +38,8 @@ end
     @test_throws ArgumentError IS.copy_time_series!(b, a)
     @test_throws ArgumentError IS.copy_time_series!(a, b)
     # Nothing changed on either side.
-    @test [IS.get_name(k) for k in IS.get_time_series_keys(a)] == ["s"]
-    @test [IS.get_name(k) for k in IS.get_time_series_keys(b)] == ["other"]
+    @test [IS.get_name(k) for k in IS.list_metadata(a)] == ["s"]
+    @test [IS.get_name(k) for k in IS.list_metadata(b)] == ["other"]
     @test IS.get_time_series_values(IS.SingleTimeSeries, b, "other") == fill(100.0, 24)
 
     # An owner that is not attached anywhere is rejected too.
@@ -59,8 +59,8 @@ end
     @test_throws ArgumentError IS.copy_time_series!(attr, component)
     # Nothing changed, and no orphan rows: the system-wide iterators still resolve
     # every owner.
-    @test [IS.get_name(k) for k in IS.get_time_series_keys(component)] == ["comp_series"]
-    @test [IS.get_name(k) for k in IS.get_time_series_keys(attr)] == ["attr_series"]
+    @test [IS.get_name(k) for k in IS.list_metadata(component)] == ["comp_series"]
+    @test [IS.get_name(k) for k in IS.list_metadata(attr)] == ["attr_series"]
     @test length(collect(IS.iterate_components_with_time_series(sys))) == 1
     @test length(collect(IS.iterate_supplemental_attributes_with_time_series(sys))) == 1
 end
@@ -92,11 +92,11 @@ end
         IS.add_time_series!(txn, component, _hourly_sts("v"))
         @test IS.has_staged_data(txn)
         @test !IS.has_time_series(component, IS.SingleTimeSeries, "v")
-        @test isempty(IS.get_time_series_keys(component))
+        @test isempty(IS.list_metadata(component))
         IS.flush!(txn)
         @test !IS.has_staged_data(txn)
         @test IS.has_time_series(component, IS.SingleTimeSeries, "v")
-        @test length(IS.get_time_series_keys(component)) == 1
+        @test length(IS.list_metadata(component)) == 1
         @test IS.get_time_series_values(IS.SingleTimeSeries, component, "v") ==
               collect(1.0:24)
         # Adds keep working after an explicit flush, and the block stays one transaction.
@@ -254,7 +254,7 @@ end
         Dates.Hour(24),
         Dates.Hour(24),
     )
-    key = only(IS.get_time_series_keys(component; time_series_type = IS.Deterministic))
+    key = only(IS.list_metadata(component; time_series_type = IS.Deterministic))
     @test IS.get_interval(key) == Dates.Millisecond(0)
     @test IS.get_count(
         IS.get_time_series(IS.Deterministic, component, "s"; start_time = _T0),
@@ -328,17 +328,17 @@ end
         interval = Dates.Hour(1),
     )
     key = IS.add_time_series!(sys, component, prob)
-    @test IS.get_time_series_type(key) === IS.Probabilistic
-    @test IS.get_time_series_type(key) ===
-          IS.get_time_series_type(only(IS.get_time_series_keys(component)))
+    @test IS.get_time_series_type(key) <: IS.Probabilistic
+    @test IS.get_time_series_type(key) <:
+          IS.get_time_series_type(only(IS.list_metadata(component)))
     @test IS.get_time_series_hash(component, key) ==
-          IS.get_time_series_hash(component, only(IS.get_time_series_keys(component)))
+          IS.get_time_series_hash(component, only(IS.list_metadata(component)))
 
     sts = _hourly_sts("s")
     IS.add_time_series!(sys, component, sts)
     @test IS.has_time_series(component, typeof(sts), "s")
     @test IS.has_time_series(component, typeof(prob), "p")
-    @test length(IS.get_time_series_keys(component; time_series_type = typeof(sts))) == 1
+    @test length(IS.list_metadata(component; time_series_type = typeof(sts))) == 1
     @test IS.get_time_series(typeof(sts), component, "s") isa IS.SingleTimeSeries
     IS.remove_time_series!(sys, typeof(sts), component, "s")
     @test !IS.has_time_series(component, IS.SingleTimeSeries, "s")
@@ -554,16 +554,26 @@ end
 @testset "Test TimeSeriesKey equality and hashing" begin
     sys, component = _sys_with_component()
     key_added = IS.add_time_series!(sys, component, _hourly_sts("s"))
-    key_listed = only(IS.get_time_series_keys(component))
-    @test IS.get_resolution(key_added) == Dates.Hour(1)
-    @test IS.get_resolution(key_listed) == Dates.Millisecond(3_600_000)
+    row = only(IS.list_metadata(component))
+    key_listed = IS.get_time_series_key(row)
+
+    # A write and a listing produce the same key, down to the type parameter.
+    # This used to be a real hazard rather than a tautology: a key carried its
+    # own `resolution`, and the two paths spelled it differently — `Hour(1)` from
+    # the constructor, `Millisecond(3600000)` back from the catalog. With the key
+    # reduced to its id there is nothing left to disagree about, and the period
+    # spelling is a property of the row instead.
+    @test IS.get_resolution(row) == Dates.Millisecond(3_600_000)
+    @test IS.get_resolution(row) == Dates.Hour(1)
     @test key_added == key_listed
+    @test typeof(key_added) === typeof(key_listed)
     @test hash(key_added) == hash(key_listed)
     @test length(Set([key_added, key_listed])) == 1
 
     fkey_added = IS.add_time_series!(sys, component, _hourly_det("d"))
-    fkey_listed =
-        only(IS.get_time_series_keys(component; time_series_type = IS.Deterministic))
+    fkey_listed = IS.get_time_series_key(
+        only(IS.list_metadata(component; time_series_type = IS.Deterministic)),
+    )
     @test fkey_added == fkey_listed
     @test hash(fkey_added) == hash(fkey_listed)
     @test fkey_added != key_added

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -585,6 +585,21 @@ end
     )
 end
 
+@testset "Test TimeSeriesKey display" begin
+    sys, component = _sys_with_component()
+    key = IS.add_time_series!(sys, component, _hourly_sts("s"))
+    id = IS.get_association_id(key)
+
+    # A key is not an `InfrastructureSystemsType` and carries no name or
+    # resolution, so `summary` renders what the key does hold rather than
+    # reaching for accessors the catalog owns.
+    @test sprint(show, key) == "TimeSeriesKey{SingleTimeSeries{Float64}}($id)"
+    @test summary(key) == sprint(show, key)
+
+    fkey = IS.add_time_series!(sys, component, _hourly_det("d"))
+    @test summary(fkey) == sprint(show, fkey)
+end
+
 @testset "Test fast_deepcopy_system rewires every owner" begin
     sys, component = _sys_with_component()
     masked = IS.TestComponent("masked", 5)

--- a/test/test_time_series_consistency.jl
+++ b/test/test_time_series_consistency.jl
@@ -38,8 +38,8 @@ end
     @test_throws ArgumentError IS.copy_time_series!(b, a)
     @test_throws ArgumentError IS.copy_time_series!(a, b)
     # Nothing changed on either side.
-    @test [IS.get_name(k) for k in IS.list_metadata(a)] == ["s"]
-    @test [IS.get_name(k) for k in IS.list_metadata(b)] == ["other"]
+    @test [IS.get_name(k) for k in IS.list_time_series_metadata(a)] == ["s"]
+    @test [IS.get_name(k) for k in IS.list_time_series_metadata(b)] == ["other"]
     @test IS.get_time_series_values(IS.SingleTimeSeries, b, "other") == fill(100.0, 24)
 
     # An owner that is not attached anywhere is rejected too.
@@ -59,8 +59,9 @@ end
     @test_throws ArgumentError IS.copy_time_series!(attr, component)
     # Nothing changed, and no orphan rows: the system-wide iterators still resolve
     # every owner.
-    @test [IS.get_name(k) for k in IS.list_metadata(component)] == ["comp_series"]
-    @test [IS.get_name(k) for k in IS.list_metadata(attr)] == ["attr_series"]
+    @test [IS.get_name(k) for k in IS.list_time_series_metadata(component)] ==
+          ["comp_series"]
+    @test [IS.get_name(k) for k in IS.list_time_series_metadata(attr)] == ["attr_series"]
     @test length(collect(IS.iterate_components_with_time_series(sys))) == 1
     @test length(collect(IS.iterate_supplemental_attributes_with_time_series(sys))) == 1
 end
@@ -92,11 +93,11 @@ end
         IS.add_time_series!(txn, component, _hourly_sts("v"))
         @test IS.has_staged_data(txn)
         @test !IS.has_time_series(component, IS.SingleTimeSeries, "v")
-        @test isempty(IS.list_metadata(component))
+        @test isempty(IS.list_time_series_metadata(component))
         IS.flush!(txn)
         @test !IS.has_staged_data(txn)
         @test IS.has_time_series(component, IS.SingleTimeSeries, "v")
-        @test length(IS.list_metadata(component)) == 1
+        @test length(IS.list_time_series_metadata(component)) == 1
         @test IS.get_time_series_values(IS.SingleTimeSeries, component, "v") ==
               collect(1.0:24)
         # Adds keep working after an explicit flush, and the block stays one transaction.
@@ -254,7 +255,7 @@ end
         Dates.Hour(24),
         Dates.Hour(24),
     )
-    key = only(IS.list_metadata(component; time_series_type = IS.Deterministic))
+    key = only(IS.list_time_series_metadata(component; time_series_type = IS.Deterministic))
     @test IS.get_interval(key) == Dates.Millisecond(0)
     @test IS.get_count(
         IS.get_time_series(IS.Deterministic, component, "s"; start_time = _T0),
@@ -330,15 +331,16 @@ end
     key = IS.add_time_series!(sys, component, prob)
     @test IS.get_time_series_type(key) <: IS.Probabilistic
     @test IS.get_time_series_type(key) <:
-          IS.get_time_series_type(only(IS.list_metadata(component)))
+          IS.get_time_series_type(only(IS.list_time_series_metadata(component)))
     @test IS.get_time_series_hash(component, key) ==
-          IS.get_time_series_hash(component, only(IS.list_metadata(component)))
+          IS.get_time_series_hash(component, only(IS.list_time_series_metadata(component)))
 
     sts = _hourly_sts("s")
     IS.add_time_series!(sys, component, sts)
     @test IS.has_time_series(component, typeof(sts), "s")
     @test IS.has_time_series(component, typeof(prob), "p")
-    @test length(IS.list_metadata(component; time_series_type = typeof(sts))) == 1
+    @test length(IS.list_time_series_metadata(component; time_series_type = typeof(sts))) ==
+          1
     @test IS.get_time_series(typeof(sts), component, "s") isa IS.SingleTimeSeries
     IS.remove_time_series!(sys, typeof(sts), component, "s")
     @test !IS.has_time_series(component, IS.SingleTimeSeries, "s")
@@ -554,7 +556,7 @@ end
 @testset "Test TimeSeriesKey equality and hashing" begin
     sys, component = _sys_with_component()
     key_added = IS.add_time_series!(sys, component, _hourly_sts("s"))
-    row = only(IS.list_metadata(component))
+    row = only(IS.list_time_series_metadata(component))
     key_listed = IS.get_time_series_key(row)
 
     # A write and a listing produce the same key, down to the type parameter.
@@ -572,7 +574,7 @@ end
 
     fkey_added = IS.add_time_series!(sys, component, _hourly_det("d"))
     fkey_listed = IS.get_time_series_key(
-        only(IS.list_metadata(component; time_series_type = IS.Deterministic)),
+        only(IS.list_time_series_metadata(component; time_series_type = IS.Deterministic)),
     )
     @test fkey_added == fkey_listed
     @test hash(fkey_added) == hash(fkey_listed)

--- a/test/test_time_series_function_data.jl
+++ b/test/test_time_series_function_data.jl
@@ -118,7 +118,9 @@
                 # Wrap the key in the corresponding TimeSeriesFunctionData
                 ts_fd = TSType(key)
                 @test IS.is_time_series_backed(ts_fd)
-                @test IS.get_name(only(IS.list_metadata(component; name = name))) == name
+                @test IS.get_name(
+                    only(IS.list_time_series_metadata(component; name = name)),
+                ) == name
                 @test IS.get_time_series_key(ts_fd) == key
 
                 # Retrieve the time series via the key extracted from the wrapper,

--- a/test/test_time_series_function_data.jl
+++ b/test/test_time_series_function_data.jl
@@ -1,17 +1,7 @@
 @testset "TimeSeriesFunctionData" begin
-    forecast_key = IS.ForecastKey(;
-        owner_id = 1,
-        owner_category = IS.InfraStore.Component,
-        association_id = 1,
-        time_series_type = IS.Deterministic,
-        name = "test_forecast",
-        initial_timestamp = Dates.DateTime("2020-01-01"),
-        resolution = Dates.Hour(1),
-        horizon = Dates.Hour(24),
-        interval = Dates.Hour(24),
-        count = 1,
-        features = Dict{String, Any}(),
-    )
+    # A key names one stored series, so its element type is fixed: a
+    # `TimeSeriesFunctionData{T}` can only wrap a key of `T` values.
+    forecast_key(::Type{T}) where {T} = IS.TimeSeriesKey{IS.Deterministic{T}}(1)
 
     ts_types = [
         IS.TimeSeriesLinearFunctionData,
@@ -29,7 +19,9 @@
 
     @testset "is_time_series_backed" begin
         for T in ts_types
-            @test IS.is_time_series_backed(T(forecast_key)) == true
+            @test IS.is_time_series_backed(
+                T(forecast_key(IS.get_underlying_function_data_type(T))),
+            ) == true
         end
         @test IS.is_time_series_backed(IS.LinearFunctionData(1.0, 2.0)) == false
         @test IS.is_time_series_backed(IS.QuadraticFunctionData(1.0, 2.0, 3.0)) == false
@@ -44,31 +36,37 @@
     @testset "get_underlying_function_data_type" begin
         for (T, U) in zip(ts_types, underlying_types)
             @test IS.get_underlying_function_data_type(T) == U
-            @test IS.get_underlying_function_data_type(T(forecast_key)) == U
+            @test IS.get_underlying_function_data_type(
+                T(forecast_key(IS.get_underlying_function_data_type(T))),
+            ) == U
         end
     end
 
     @testset "Serialization round-trip" begin
-        sys, (stored_key,) = create_forecast_key_fixture("test_forecast")
-        store = key_store(sys)
         for T in ts_types
+            # One fixture per wrapper: a key names one stored series, so its
+            # element type has to be the one `T` is bound by.
+            U = IS.get_underlying_function_data_type(T)
+            sys, (stored_key,) =
+                create_forecast_key_fixture("test_forecast"; element_type = U)
             fd = T(stored_key)
             serialized = IS.serialize(fd)
-            # The key is on the wire as its association id and nothing else.
-            @test serialized["time_series_key"] == IS.get_association_id(stored_key)
-            deserialized = IS.with_deserialization_store(store) do
-                IS.deserialize(T, serialized)
-            end
-            @test typeof(deserialized) == T
+            # The key is on the wire as its id, kind and element type — no store
+            # needed to read it back.
+            @test serialized["time_series_key"] == IS.serialize(stored_key)
+            deserialized = IS.deserialize(T, serialized)
+            @test typeof(deserialized) <: T
             @test IS.get_time_series_key(deserialized) == stored_key
         end
     end
 
     @testset "Show" begin
         for (T, U) in zip(ts_types, underlying_types)
-            fd = T(forecast_key)
+            fd = T(forecast_key(IS.get_underlying_function_data_type(T)))
             str = sprint(show, MIME("text/plain"), fd)
-            @test contains(str, "test_forecast")
+            # A key names an association id; the series' name is a catalog column,
+            # and `show` must not reach for the store to render it.
+            @test contains(str, "association_id=1")
             @test contains(str, string(U))
         end
     end
@@ -120,7 +118,8 @@
                 # Wrap the key in the corresponding TimeSeriesFunctionData
                 ts_fd = TSType(key)
                 @test IS.is_time_series_backed(ts_fd)
-                @test IS.get_name(IS.get_time_series_key(ts_fd)) == name
+                @test IS.get_name(only(IS.list_metadata(component; name = name))) == name
+                @test IS.get_time_series_key(ts_fd) == key
 
                 # Retrieve the time series via the key extracted from the wrapper,
                 # exercising the key-based retrieval path rather than by-name.
@@ -237,106 +236,83 @@
 end
 
 @testset "TimeSeriesValueCurve" begin
-    forecast_key = IS.ForecastKey(;
-        owner_id = 1,
-        owner_category = IS.InfraStore.Component,
-        association_id = 1,
-        time_series_type = IS.Deterministic,
-        name = "test_forecast",
-        initial_timestamp = Dates.DateTime("2020-01-01"),
-        resolution = Dates.Hour(1),
-        horizon = Dates.Hour(24),
-        interval = Dates.Hour(24),
-        count = 1,
-        features = Dict{String, Any}(),
-    )
+    # A key names one stored series, so its element type is fixed: a
+    # `TimeSeriesFunctionData{T}` can only wrap a key of `T` values.
+    forecast_key(::Type{T}) where {T} = IS.TimeSeriesKey{IS.Deterministic{T}}(1)
 
-    ii_key = IS.ForecastKey(;
-        owner_id = 1,
-        owner_category = IS.InfraStore.Component,
-        association_id = 1,
-        time_series_type = IS.Deterministic,
-        name = "initial_input",
-        initial_timestamp = Dates.DateTime("2020-01-01"),
-        resolution = Dates.Hour(1),
-        horizon = Dates.Hour(24),
-        interval = Dates.Hour(24),
-        count = 1,
-        features = Dict{String, Any}(),
-    )
-
-    iaz_key = IS.ForecastKey(;
-        owner_id = 1,
-        owner_category = IS.InfraStore.Component,
-        association_id = 1,
-        time_series_type = IS.Deterministic,
-        name = "input_at_zero",
-        initial_timestamp = Dates.DateTime("2020-01-01"),
-        resolution = Dates.Hour(1),
-        horizon = Dates.Hour(24),
-        interval = Dates.Hour(24),
-        count = 1,
-        features = Dict{String, Any}(),
-    )
+    # initial_input / input_at_zero are scalars over time, not function data.
+    ii_key = IS.TimeSeriesKey{IS.Deterministic{Float64}}(2)
+    iaz_key = IS.TimeSeriesKey{IS.Deterministic{Float64}}(3)
 
     @testset "Construction and field access" begin
         # InputOutputCurve with non-default input_at_zero
         io_with_iaz = IS.TimeSeriesInputOutputCurve(
-            IS.TimeSeriesLinearFunctionData(forecast_key), 42.0,
+            IS.TimeSeriesLinearFunctionData(forecast_key(IS.LinearFunctionData)), 42.0,
         )
         @test IS.get_input_at_zero(io_with_iaz) == 42.0
-        @test IS.get_time_series_key(io_with_iaz) === forecast_key
+        @test IS.get_time_series_key(io_with_iaz) == forecast_key(IS.LinearFunctionData)
 
         # IncrementalCurve with initial_input and input_at_zero keys
         inc = IS.TimeSeriesIncrementalCurve(
-            IS.TimeSeriesPiecewiseStepData(forecast_key), ii_key, iaz_key,
+            IS.TimeSeriesPiecewiseStepData(forecast_key(IS.PiecewiseStepData)), ii_key,
+            iaz_key,
         )
         @test IS.get_initial_input(inc) === ii_key
         @test IS.get_input_at_zero(inc) === iaz_key
 
         # AverageRateCurve with nothing initial_input
         ar = IS.TimeSeriesAverageRateCurve(
-            IS.TimeSeriesLinearFunctionData(forecast_key), nothing,
+            IS.TimeSeriesLinearFunctionData(forecast_key(IS.LinearFunctionData)),
+            nothing,
         )
         @test IS.get_initial_input(ar) === nothing
     end
 
     @testset "Cost aliases" begin
         aliases = [
-            IS.TimeSeriesLinearCurve(forecast_key),
-            IS.TimeSeriesQuadraticCurve(forecast_key),
-            IS.TimeSeriesPiecewisePointCurve(forecast_key),
+            IS.TimeSeriesLinearCurve(forecast_key(IS.LinearFunctionData)),
+            IS.TimeSeriesQuadraticCurve(forecast_key(IS.QuadraticFunctionData)),
+            IS.TimeSeriesPiecewisePointCurve(forecast_key(IS.PiecewiseLinearData)),
         ]
         for obj in aliases
             @test IS.is_cost_alias(obj) == true
         end
 
         # Incremental/average aliases propagate initial_input and input_at_zero
-        pic = IS.TimeSeriesPiecewiseIncrementalCurve(forecast_key, ii_key, iaz_key)
+        pic = IS.TimeSeriesPiecewiseIncrementalCurve(
+            forecast_key(IS.PiecewiseStepData),
+            ii_key,
+            iaz_key,
+        )
         @test IS.get_initial_input(pic) === ii_key
         @test IS.get_input_at_zero(pic) === iaz_key
         @test IS.is_cost_alias(pic) == true
 
-        pac = IS.TimeSeriesPiecewiseAverageCurve(forecast_key, ii_key, iaz_key)
+        pac = IS.TimeSeriesPiecewiseAverageCurve(
+            forecast_key(IS.PiecewiseStepData),
+            ii_key,
+            iaz_key,
+        )
         @test IS.get_initial_input(pac) === ii_key
         @test IS.get_input_at_zero(pac) === iaz_key
     end
 
     @testset "Invalid type combinations" begin
         @test_throws MethodError IS.TimeSeriesInputOutputCurve(
-            IS.TimeSeriesPiecewiseStepData(forecast_key),
+            IS.TimeSeriesPiecewiseStepData(forecast_key(IS.PiecewiseStepData)),
         )
         @test_throws MethodError IS.TimeSeriesIncrementalCurve(
-            IS.TimeSeriesQuadraticFunctionData(forecast_key), nothing,
+            IS.TimeSeriesQuadraticFunctionData(forecast_key(IS.QuadraticFunctionData)),
+            nothing,
         )
         @test_throws MethodError IS.TimeSeriesAverageRateCurve(
-            IS.TimeSeriesPiecewiseLinearData(forecast_key), nothing,
+            IS.TimeSeriesPiecewiseLinearData(forecast_key(IS.PiecewiseLinearData)), nothing,
         )
     end
 
     @testset "is_time_series_backed and get_time_series_key propagation" begin
         ts_io = IS.TimeSeriesInputOutputCurve(
-            IS.TimeSeriesLinearFunctionData(forecast_key),
+            IS.TimeSeriesLinearFunctionData(forecast_key(IS.LinearFunctionData)),
         )
         @test IS.is_time_series_backed(ts_io) == true
 
@@ -348,69 +324,74 @@ end
         # Propagation through CostCurve and FuelCurve
         cc = IS.CostCurve(ts_io)
         @test IS.is_time_series_backed(cc) == true
-        @test IS.get_time_series_key(cc) === forecast_key
+        @test IS.get_time_series_key(cc) == forecast_key(IS.LinearFunctionData)
 
         fc = IS.FuelCurve(ts_io, 1.0)
         @test IS.is_time_series_backed(fc) == true
         # get_time_series_key is undefined for FuelCurve — resolve through the value
         # curve (or get_fuel_cost) explicitly.
         @test_throws ArgumentError IS.get_time_series_key(fc)
-        @test IS.get_time_series_key(IS.get_value_curve(fc)) === forecast_key
+        @test IS.get_time_series_key(IS.get_value_curve(fc)) ==
+              forecast_key(IS.LinearFunctionData)
     end
 
     @testset "Serialization round-trip" begin
-        # Real keys: a serialized key is only its association id, so the round trip needs
-        # a store that can resolve it.
-        sys, (stored_key, stored_ii_key) =
-            create_forecast_key_fixture("test_forecast", "initial_input")
-        store = key_store(sys)
+        # Real keys. A key names one stored series, so each wrapper needs one of its
+        # own element type; `initial_input` is a scalar over time, not function data.
+        _, (lin_key,) =
+            create_forecast_key_fixture(
+                "test_forecast";
+                element_type = IS.LinearFunctionData,
+            )
+        _, (step_key,) =
+            create_forecast_key_fixture(
+                "test_forecast";
+                element_type = IS.PiecewiseStepData,
+            )
+        _, (stored_ii_key,) = create_forecast_key_fixture("initial_input")
         ts_curves = [
             (
                 IS.TimeSeriesInputOutputCurve(
-                    IS.TimeSeriesLinearFunctionData(stored_key),
+                    IS.TimeSeriesLinearFunctionData(lin_key),
                 ),
                 IS.TimeSeriesInputOutputCurve,
             ),
             (
                 IS.TimeSeriesInputOutputCurve(
-                    IS.TimeSeriesLinearFunctionData(stored_key), 42.0,
+                    IS.TimeSeriesLinearFunctionData(lin_key), 42.0,
                 ),
                 IS.TimeSeriesInputOutputCurve,
             ),
             (
                 IS.TimeSeriesIncrementalCurve(
-                    IS.TimeSeriesPiecewiseStepData(stored_key), stored_ii_key,
+                    IS.TimeSeriesPiecewiseStepData(step_key), stored_ii_key,
                 ),
                 IS.TimeSeriesIncrementalCurve,
             ),
             (
                 IS.TimeSeriesAverageRateCurve(
-                    IS.TimeSeriesPiecewiseStepData(stored_key), stored_ii_key,
+                    IS.TimeSeriesPiecewiseStepData(step_key), stored_ii_key,
                 ),
                 IS.TimeSeriesAverageRateCurve,
             ),
         ]
 
         for (curve, curve_type) in ts_curves
-            deserialized = IS.with_deserialization_store(store) do
-                IS.deserialize(curve_type, IS.serialize(curve))
-            end
+            deserialized = IS.deserialize(curve_type, IS.serialize(curve))
             @test typeof(deserialized) == typeof(curve)
             @test IS.get_time_series_key(deserialized) == IS.get_time_series_key(curve)
         end
 
         # CostCurve wrapping TS ValueCurve round-trips
-        cc = IS.CostCurve(IS.TimeSeriesLinearCurve(stored_key))
-        cc_deser = IS.with_deserialization_store(store) do
-            IS.deserialize(IS.CostCurve, IS.serialize(cc))
-        end
+        cc = IS.CostCurve(IS.TimeSeriesLinearCurve(lin_key))
+        cc_deser = IS.deserialize(IS.CostCurve, IS.serialize(cc))
         @test IS.is_time_series_backed(cc_deser) == true
-        @test IS.get_time_series_key(cc_deser) == stored_key
+        @test IS.get_time_series_key(cc_deser) == lin_key
     end
 
     @testset "CostCurve and FuelCurve wrapping" begin
         ts_io = IS.TimeSeriesInputOutputCurve(
-            IS.TimeSeriesLinearFunctionData(forecast_key),
+            IS.TimeSeriesLinearFunctionData(forecast_key(IS.LinearFunctionData)),
         )
         # CostCurve preserves value_curve and accepts power_units
         cc = IS.CostCurve(ts_io, IS.SystemBaseUnit())

--- a/test/test_time_series_units.jl
+++ b/test/test_time_series_units.jl
@@ -144,7 +144,7 @@ end
     @test occursin("duplicate attributes", sprint(showerror, err))
 
     # The label appears on no key, so it cannot be filtered or addressed by.
-    key = only(IS.get_time_series_keys(component))
+    key = only(IS.list_metadata(component))
     @test !(:units in fieldnames(typeof(key)))
 end
 

--- a/test/test_time_series_units.jl
+++ b/test/test_time_series_units.jl
@@ -143,9 +143,12 @@ end
     @test typeof(err) === ArgumentError
     @test occursin("duplicate attributes", sprint(showerror, err))
 
-    # The label appears on no key, so it cannot be filtered or addressed by.
-    key = only(IS.list_metadata(component))
-    @test !(:units in fieldnames(typeof(key)))
+    # The label appears on no key, so it cannot be addressed or filtered by: a key
+    # is its association id and nothing else. It does read back on the catalog
+    # row, which describes a series rather than addressing one.
+    @test !(:units in fieldnames(IS.TimeSeriesKey))
+    md = only(IS.list_metadata(component))
+    @test IS.get_units(md) == "MW"
 end
 
 @testset "Test units survives transform_single_time_series!" begin

--- a/test/test_time_series_units.jl
+++ b/test/test_time_series_units.jl
@@ -147,7 +147,7 @@ end
     # is its association id and nothing else. It does read back on the catalog
     # row, which describes a series rather than addressing one.
     @test !(:units in fieldnames(IS.TimeSeriesKey))
-    md = only(IS.list_metadata(component))
+    md = only(IS.list_time_series_metadata(component))
     @test IS.get_units(md) == "MW"
 end
 

--- a/test/test_tuple_valued_time_series.jl
+++ b/test/test_tuple_valued_time_series.jl
@@ -18,7 +18,7 @@
         comp3 = IS.get_component(IS.TestComponent, sys3, "Component1")
         IS.add_time_series!(sys3, comp3, sts3)
 
-        key3 = only(IS.list_metadata(comp3))
+        key3 = only(IS.list_time_series_metadata(comp3))
         s0 = StartUpStages(
             only(
                 IS.get_time_series_values(
@@ -46,7 +46,7 @@
         comp2 = IS.get_component(IS.TestComponent, sys2, "Component1")
         IS.add_time_series!(sys2, comp2, sts2)
 
-        key2 = only(IS.list_metadata(comp2))
+        key2 = only(IS.list_time_series_metadata(comp2))
         mm = MinMax(
             only(
                 IS.get_time_series_values(
@@ -89,7 +89,7 @@
                     sts = IS.SingleTimeSeries(; name = "tuple_ts", data = ta)
                     IS.add_time_series!(sys, comp, sts)
 
-                    key = only(IS.list_metadata(comp))
+                    key = only(IS.list_time_series_metadata(comp))
                     resolve(t) = T(
                         only(
                             IS.get_time_series_values(

--- a/test/test_tuple_valued_time_series.jl
+++ b/test/test_tuple_valued_time_series.jl
@@ -18,7 +18,7 @@
         comp3 = IS.get_component(IS.TestComponent, sys3, "Component1")
         IS.add_time_series!(sys3, comp3, sts3)
 
-        key3 = only(IS.get_time_series_keys(comp3))
+        key3 = only(IS.list_metadata(comp3))
         s0 = StartUpStages(
             only(
                 IS.get_time_series_values(
@@ -46,7 +46,7 @@
         comp2 = IS.get_component(IS.TestComponent, sys2, "Component1")
         IS.add_time_series!(sys2, comp2, sts2)
 
-        key2 = only(IS.get_time_series_keys(comp2))
+        key2 = only(IS.list_metadata(comp2))
         mm = MinMax(
             only(
                 IS.get_time_series_values(
@@ -89,7 +89,7 @@
                     sts = IS.SingleTimeSeries(; name = "tuple_ts", data = ta)
                     IS.add_time_series!(sys, comp, sts)
 
-                    key = only(IS.get_time_series_keys(comp))
+                    key = only(IS.list_metadata(comp))
                     resolve(t) = T(
                         only(
                             IS.get_time_series_values(


### PR DESCRIPTION
Nine commits completing the move to id-addressed time series in IS, ending with the `TimeSeriesKey` collapse and dropping IS's copy of the store's element encodings.

Companion to NatLabRockies/infrastore#64, which this depends on.

## `TimeSeriesKey` is an association id

A key carried a copy of every catalog column it could be filtered by — name, resolution, initial timestamp, horizon, interval, count, owner, features — and a copy can only disagree with the catalog it came from. `rename` and a reassignment both rewrite those columns while preserving the id, so a key held across one went stale where the id could not.

```julia
struct TimeSeriesKey{T <: TimeSeriesData}
    association_id::Int64
end
```

An 8-byte `isbits` value, in place of three structs, their union, eleven accessors, two sets of per-type overrides, and an all-field `==`/`hash` that had to reason about `Hour(1)` and `Millisecond(3600000)` being the same period.

The descriptive columns moved to `TimeSeriesMetadata`, the row `list_metadata` returns — replacing `get_time_series_keys`, and accepted anywhere a key is, so a listing can be acted on without unwrapping. `get_time_series_metadata` is the one-row form.

The type parameter stays because it cannot drift: a stored association's type is part of its identity. It carries the value element type too, which lets `TimeSeriesFunctionData{T, U}` bind `U <: TimeSeriesData{T}` — a key naming `Float64` values can no longer be wrapped as a piecewise curve, which several tests had been doing.

A key now serializes to its id, kind and element type, all three immutable, so it rebuilds itself without the catalog that minted it and `DESERIALIZATION_STORE` goes away.

## The element codec moved to InfraStore.jl

IS carried its own implementation of the store's `element_type` encodings — the ragged piecewise layouts, the fixed-width function rows, the tuple packing — byte-identical to the store's by careful authorship, with only the shared conformance corpus holding the two in step. The encodings are the store's, so InfraStore.jl implements them now and IS supplies the two ends:

- **Encoding** is open dispatch: three methods per `FunctionData` type, and an IS value goes into a store constructor directly.
- **Decoding** is a table, because it starts from a tag string: `read_by_id(store, id; types = _IS_ELEMENT_TYPES)` lands in `LinearFunctionData` and friends with no conversion.

**−423/+172.** Gone: `_storage_array`, `_storage_width`, `_storage_forecast_array`, `_element_type_name`, the `ElementEncoding` hierarchy and its five singletons, `_element_encoding`, `_decode_static_values`, `_decode_stored_values`, `_decode_forecast_window`, `_decode_ntuples`, `_decode_pwl_step_row`, `_decode_element`, `_forecast_window`.

The `FunctionData` types stay in IS. They are stricter than the store — `PiecewiseLinearData` needs two ascending points where the store stores what it is given — so they are not the same types as the store's, and ~1000 lines of convexity work rides on them.

Three parts were not deletions: the `Deterministic` write is `reduce(hcat, windows)` (dict-to-matrix is IS's concern, packing is the store's); `_dense_forecast_array` stays for `Probabilistic`/`Scenarios` minus its tagging; and the reader paths still decode, because the store's readers hand back packing deliberately — but through the store's codec now, caching a tag string rather than an encoding object.

## Breaking

- `get_time_series_keys` → `list_metadata`, which returns rows rather than keys. Most call sites migrate by rename, because the accessors moved to the row.
- Key accessors are gone: read `get_name`, `get_resolution` and the rest off a `TimeSeriesMetadata`.
- `md.time_series_type == X` must become `<: X`.
- A serialized key is now `{association_id, time_series_type, element_type}` rather than a bare integer, and needs no store to deserialize.

**Worth grepping for downstream:** making `TimeSeriesFunctionData{T}` a `UnionAll` broke every place naming it as a concrete type parameter — the five `TimeSeries*Curve` aliases (so `is_cost_alias` returned `false` for real objects), their constructors, `_static_function_data_type`, and the union deserializer. Each needed `<:`.

## Verification

Full `Pkg.test()` green, JuliaFormatter clean.

One note on running the suite: it aborts with `signal 6` unless `INFRASTORE_LIB` points at a local `libinfrastore_ffi` build — the packaged artifact is stale against the dev source. That predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JN9oP7jLfuBf7VbUZ9gnFT