### PR TITLE
Rename the device-base unit marker to component base

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -93,7 +93,7 @@ These wrap `Store::persist_arrays_to` and `Store::open_without_catalog`, which a
 
 ## Units Layer (RelativeUnits)
 
-IS provides unit-system *plumbing* only — SU/DU/NU acquire domain meaning in PowerSystems.jl.
+IS provides unit-system *plumbing* only — SU/CU/NU acquire domain meaning in PowerSystems.jl.
 IS itself performs no domain conversions; only the plumbing and `convert_cost_coefficient`
 math are testable here. IS exports the markers and `RelativeQuantity` only — there is **no
 unit-string vocabulary in IS**; that vocabulary lives in `SiennaSchemas/Core/units.json` for
@@ -101,17 +101,17 @@ the data pipeline.
 
 ```
 RelativeUnits submodule (src/relative_units.jl)
-  AbstractUnitSystem ⊃ {AbstractRelativeUnit ⊃ {DeviceBaseUnit, SystemBaseUnit}, NaturalUnit}
-  const singletons DU, SU, NU
-  RelativeQuantity{T<:Number, U<:AbstractRelativeUnit} <: Number  (built via `0.6 * DU`)
+  AbstractUnitSystem ⊃ {AbstractRelativeUnit ⊃ {ComponentBaseUnit, SystemBaseUnit}, NaturalUnit}
+  const singletons CU, SU, NU
+  RelativeQuantity{T<:Number, U<:AbstractRelativeUnit} <: Number  (built via `0.6 * CU`)
   convert_cost_coefficient + 9-method _cost_coeff_ratio dispatch table (+ erroring catch-all)
   traits: _strip_units (domain packages MUST extend for their quantity types), display_units_arg
 ```
 
 Guard rails (all dispatch-based, erroring `ArgumentError`s):
-- Re-tagging a tagged value (`(0.6DU) * SU`) throws — no silent nesting.
+- Re-tagging a tagged value (`(0.6CU) * SU`) throws — no silent nesting.
 - Cross-unit `+`, `-`, `==`, `<`, `<=`, `isless`, `isapprox` throw — convert explicitly first.
-- Tagged-vs-untagged `==`/`+`/`-` (`0.6DU == 0.5`) throw.
+- Tagged-vs-untagged `==`/`+`/`-` (`0.6CU == 0.5`) throw.
 - `Base.hash` is defined consistently with the cross-payload `==` (Dict/Set safe for same-unit keys).
 - Note: `isequal` falls back to the throwing `==`, so *mixed-unit* Dict keys can throw on
   hash collision — define a non-throwing `isequal` if that's ever needed.
@@ -122,7 +122,7 @@ Guard rails (all dispatch-based, erroring `ArgumentError`s):
 decodes that name back to the singleton. IS4 is a breaking release: the legacy IS3
 `UnitSystem` enum is **no longer accepted** anywhere in the cost-curve API — not as a
 constructor argument, not as a serialized value-name (`"SYSTEM_BASE"`). Downstream packages
-(PowerSystemCaseBuilder, PowerSystems) must pass `SystemBaseUnit()`/`DeviceBaseUnit()`/
+(PowerSystemCaseBuilder, PowerSystems) must pass `SystemBaseUnit()`/`ComponentBaseUnit()`/
 `NaturalUnit()` instances. `zero(c)` preserves the unit parameter; `zero(CostCurve)`
 (type form) defaults to NU.
 
@@ -216,7 +216,7 @@ produces two getter variants and one setter:
 - `set_X!(value, val)` — takes **no** `units` argument. The caller must supply a value that
   already carries its own unit tag (a `RelativeQuantity` or domain quantity); `set_value`
   strips it internally. This asymmetry is intentional: getters need to know the target unit
-  system (e.g. `SU`, `DU`, `MW`) at call time, while setters rely on the value itself to
+  system (e.g. `SU`, `CU`, `MW`) at call time, while setters rely on the value itself to
   carry unit information.
 
 An `exclude_getter` field means the public getter is hand-written elsewhere; the
@@ -318,7 +318,7 @@ label (`"MW"`), read with `get_units`, defaulting to `nothing`. It is distinct f
 - IS neither interprets nor validates it — no units vocabulary in IS. `nothing` is left
   alone; "unknown" vs "dimensionless" is the caller's convention.
 
-Not to be confused with the `RelativeUnits` system markers (`SU`/`DU`/`NU`) — a per-unit
+Not to be confused with the `RelativeUnits` system markers (`SU`/`CU`/`NU`) — a per-unit
 normalization base, not a physical dimension. Note the accessor-side `units::AbstractUnitSystem`
 kwarg documented under "Time series accessors" is **not present on this branch**
 (`default_units` in `src/units.jl` has no callers here); when that line merges, the two
@@ -403,7 +403,7 @@ exists; the arg was never read — renamed to `time_series_transaction`),
 - `ValueCurve` (static and `TimeSeries*` curves)
 - `ProductionVariableCostCurve` (`CostCurve{T,U}`, `FuelCurve{T,U}`)
 - `FunctionData` (`StaticFunctionData`, `TimeSeriesFunctionData`)
-- `RelativeUnits.AbstractUnitSystem` (`DU`, `SU`, `NU` singletons)
+- `RelativeUnits.AbstractUnitSystem` (`CU`, `SU`, `NU` singletons)
 - `ComponentSelector`
 - `Outputs`
 

--- a/docs/src/dev_guide/time_series.md
+++ b/docs/src/dev_guide/time_series.md
@@ -90,7 +90,7 @@ and they filter a query. The label is a description of the values, so:
 
 IS neither interprets nor validates it: there is no units vocabulary in IS, so a consumer
 that converts values on read owns both the vocabulary and the conversion. Do not confuse it
-with the unit *system* concept in `RelativeUnits` (`SU`/`DU`/`NU`), which selects a per-unit
+with the unit *system* concept in `RelativeUnits` (`SU`/`CU`/`NU`), which selects a per-unit
 normalization base rather than naming a physical dimension. The two are independent: a
 series labeled `"MW"` may still be read against any normalization base.
 

--- a/src/InfrastructureSystems.jl
+++ b/src/InfrastructureSystems.jl
@@ -168,11 +168,11 @@ include("relative_units.jl")
 using .RelativeUnits:
     AbstractUnitSystem,
     AbstractRelativeUnit,
-    DeviceBaseUnit,
+    ComponentBaseUnit,
     SystemBaseUnit,
     NaturalUnit,
     RelativeQuantity,
-    DU,
+    CU,
     SU,
     NU,
     display_units_arg,

--- a/src/abstract_time_series.jl
+++ b/src/abstract_time_series.jl
@@ -77,10 +77,10 @@ get_quantity_kind(value::TimeSeriesData) = value.quantity_kind
 
 """
 Return the unit system a time series' values are **already expressed in** — one of the
-[`RelativeUnits`](@ref) markers `NU` (natural units), `DU` (device base), or `SU` (system
+[`RelativeUnits`](@ref) markers `NU` (natural units), `CU` (component base), or `SU` (system
 base) — or `nothing` when the series declares none.
 
-Note the direction: `SU`/`DU`/`NU` are used elsewhere in IS as a *target* to convert
+Note the direction: `SU`/`CU`/`NU` are used elsewhere in IS as a *target* to convert
 **to**, whereas here the marker records the basis the stored values are **in**. It is a
 declaration, not a conversion: IS rescales nothing on the strength of it, and converting
 per-unit values back to natural units needs the base that lives on the owning component
@@ -93,7 +93,7 @@ See [`get_units`](@ref) for the immutability and identity contract the three lab
 
 !!! note
 
-    The backing store represents only `NU` and `DU`. A series declaring `SU` is rejected
+    The backing store represents only `NU` and `CU`. A series declaring `SU` is rejected
     when it is added — see [`get_time_series`](@ref) and the store adapter — rather than
     being silently downgraded.
 """

--- a/src/deterministic.jl
+++ b/src/deterministic.jl
@@ -23,7 +23,7 @@ A deterministic forecast for a particular data field in a Component.
   - `quantity_kind::Union{Nothing, String}`: optional label for the kind of physical
     quantity the values measure (e.g. `"ActivePower"`)
   - `unit_system::Union{Nothing, AbstractUnitSystem}`: optional declaration of the basis
-    the values are already expressed in (`NU`, `DU`, or `SU`)
+    the values are already expressed in (`NU`, `CU`, or `SU`)
   - `internal::InfrastructureSystemsInternal`
 
 See [`get_units`](@ref), [`get_quantity_kind`](@ref), [`get_unit_system`](@ref).
@@ -41,7 +41,7 @@ struct Deterministic{T, N} <: AbstractDeterministic{T}
     units::Union{Nothing, String}
     "kind of physical quantity the values measure (e.g. `\"ActivePower\"`), or `nothing`"
     quantity_kind::Union{Nothing, String}
-    "unit system the values are already expressed in (`NU`/`DU`/`SU`), or `nothing`"
+    "unit system the values are already expressed in (`NU`/`CU`/`SU`), or `nothing`"
     unit_system::Union{Nothing, AbstractUnitSystem}
 
     # Inner constructor validates store-encodability on every construction (including

--- a/src/infrastore.jl
+++ b/src/infrastore.jl
@@ -124,11 +124,11 @@ end
 # Unit system, between IS's `RelativeUnits` markers and the store's two-valued enum.
 _to_store_unit_system(::Nothing) = nothing
 _to_store_unit_system(::NaturalUnit) = InfraStore.NaturalUnits
-_to_store_unit_system(::DeviceBaseUnit) = InfraStore.ComponentBase
+_to_store_unit_system(::ComponentBaseUnit) = InfraStore.ComponentBase
 _to_store_unit_system(::SystemBaseUnit) = throw(
     ArgumentError(
         "the time series store cannot represent SystemBaseUnit (SU): it records only " *
-        "natural units (NU) and the component's own base (DU). Normalize the values to " *
+        "natural units (NU) and the component's own base (CU). Normalize the values to " *
         "one of those before adding the time series.",
     ),
 )
@@ -138,7 +138,7 @@ _to_store_unit_system(::SystemBaseUnit) = throw(
 _from_store_unit_system(::Nothing) = nothing
 function _from_store_unit_system(unit_system::InfraStore.UnitSystem)
     unit_system === InfraStore.NaturalUnits && return NU
-    unit_system === InfraStore.ComponentBase && return DU
+    unit_system === InfraStore.ComponentBase && return CU
     throw(ArgumentError("unrecognized store unit system: $unit_system"))
 end
 

--- a/src/non_sequential_time_series.jl
+++ b/src/non_sequential_time_series.jl
@@ -34,7 +34,7 @@ scalar-per-step case, `N >= 2` is multidimensional per-step values).
   - `quantity_kind::Union{Nothing, String}`: optional label for the kind of physical
     quantity the values measure (e.g. `"ActivePower"`)
   - `unit_system::Union{Nothing, AbstractUnitSystem}`: optional declaration of the basis
-    the values are already expressed in (`NU`, `DU`, or `SU`)
+    the values are already expressed in (`NU`, `CU`, or `SU`)
 
 See [`get_units`](@ref), [`get_quantity_kind`](@ref), [`get_unit_system`](@ref).
 """
@@ -49,7 +49,7 @@ struct NonSequentialTimeSeries{T, N} <: StaticTimeSeries{T}
     units::Union{Nothing, String}
     "kind of physical quantity the values measure (e.g. `\"ActivePower\"`), or `nothing`"
     quantity_kind::Union{Nothing, String}
-    "unit system the values are already expressed in (`NU`/`DU`/`SU`), or `nothing`"
+    "unit system the values are already expressed in (`NU`/`CU`/`SU`), or `nothing`"
     unit_system::Union{Nothing, AbstractUnitSystem}
 
     # An explicit inner constructor (validating the timestamp/value count) suppresses

--- a/src/probabilistic.jl
+++ b/src/probabilistic.jl
@@ -25,7 +25,7 @@ A Probabilistic forecast for a particular data field in a Component.
   - `quantity_kind::Union{Nothing, String}`: optional label for the kind of physical
     quantity the values measure (e.g. `"ActivePower"`)
   - `unit_system::Union{Nothing, AbstractUnitSystem}`: optional declaration of the basis
-    the values are already expressed in (`NU`, `DU`, or `SU`)
+    the values are already expressed in (`NU`, `CU`, or `SU`)
   - `internal::InfrastructureSystemsInternal`
 
 See [`get_units`](@ref), [`get_quantity_kind`](@ref), [`get_unit_system`](@ref).
@@ -45,7 +45,7 @@ struct Probabilistic{T, N} <: Forecast{T}
     units::Union{Nothing, String}
     "kind of physical quantity the values measure (e.g. `\"ActivePower\"`), or `nothing`"
     quantity_kind::Union{Nothing, String}
-    "unit system the values are already expressed in (`NU`/`DU`/`SU`), or `nothing`"
+    "unit system the values are already expressed in (`NU`/`CU`/`SU`), or `nothing`"
     unit_system::Union{Nothing, AbstractUnitSystem}
 end
 

--- a/src/relative_units.jl
+++ b/src/relative_units.jl
@@ -14,16 +14,16 @@
 
 """
 Relative (per-unit) markers and the [`RelativeQuantity`](@ref) wrapper. Domain-agnostic:
-expresses "device base" / "system base" / "natural unit" without assuming any particular
+expresses "component base" / "system base" / "natural unit" without assuming any particular
 physical domain. Downstream packages (e.g. PowerSystems) attach domain-specific meaning
 via categories and conversions.
 """
 module RelativeUnits
 
 export AbstractUnitSystem, AbstractRelativeUnit
-export DeviceBaseUnit, SystemBaseUnit, NaturalUnit
+export ComponentBaseUnit, SystemBaseUnit, NaturalUnit
 export RelativeQuantity
-export DU, SU, NU
+export CU, SU, NU
 export display_units_arg
 export unitful_variant
 export display_string
@@ -41,9 +41,9 @@ Supertype of per-unit (relative) unit markers.
 abstract type AbstractRelativeUnit <: AbstractUnitSystem end
 
 """
-Device base per-unit. Values are normalized to the component's own base.
+Component base per-unit. Values are normalized to the component's own base.
 """
-struct DeviceBaseUnit <: AbstractRelativeUnit end
+struct ComponentBaseUnit <: AbstractRelativeUnit end
 
 """
 System base per-unit. Values are normalized to the system's base.
@@ -59,7 +59,7 @@ Deliberately *not* `<: AbstractRelativeUnit` — "convert to NU" yields a
 """
 struct NaturalUnit <: AbstractUnitSystem end
 
-const DU = DeviceBaseUnit()
+const CU = ComponentBaseUnit()
 const SU = SystemBaseUnit()
 const NU = NaturalUnit()
 
@@ -70,7 +70,7 @@ A quantity tagged with a per-unit marker.
 
 # Examples
 ```julia
-0.6 * DU  # 0.6 per-unit on component base
+0.6 * CU  # 0.6 per-unit on component base
 0.3 * SU  # 0.3 per-unit on system base
 ```
 """
@@ -95,7 +95,7 @@ RelativeQuantity{T, U}(
 RelativeQuantity(value::T, ::U) where {T <: Number, U <: AbstractRelativeUnit} =
     RelativeQuantity{T, U}(value)
 
-"Return the unit marker instance (`DU`/`SU`) of a `RelativeQuantity`."
+"Return the unit marker instance (`CU`/`SU`) of a `RelativeQuantity`."
 unit(::RelativeQuantity{<:Any, U}) where {U} = U()
 
 # Construction via multiplication
@@ -239,27 +239,27 @@ Base.promote_rule(
 ) where {T, S, U} = RelativeQuantity{promote_type(T, S), U}
 
 # Display
-Base.show(io::IO, q::RelativeQuantity{T, DeviceBaseUnit}) where {T} =
-    print(io, q.value, " DU")
+Base.show(io::IO, q::RelativeQuantity{T, ComponentBaseUnit}) where {T} =
+    print(io, q.value, " CU")
 Base.show(io::IO, q::RelativeQuantity{T, SystemBaseUnit}) where {T} =
     print(io, q.value, " SU")
-Base.show(io::IO, ::DeviceBaseUnit) = print(io, "DU")
+Base.show(io::IO, ::ComponentBaseUnit) = print(io, "CU")
 Base.show(io::IO, ::SystemBaseUnit) = print(io, "SU")
 Base.show(io::IO, ::NaturalUnit) = print(io, "NU")
 
-# Unit markers are scalars in a broadcast (`get_rating.(components, DU)`), not
+# Unit markers are scalars in a broadcast (`get_rating.(components, CU)`), not
 # containers to iterate over: without this, Base's `broadcastable` fallback tries
 # to `collect` the marker and fails with a confusing `no method matching
-# length(::DeviceBaseUnit)`. Same treatment Base gives its own parameter-like
+# length(::ComponentBaseUnit)`. Same treatment Base gives its own parameter-like
 # values (`RoundingMode`, `Val`) and Unitful gives its units — which is why
-# broadcasting already worked with `MW` but not with `DU`/`SU`/`NU`.
+# broadcasting already worked with `MW` but not with `CU`/`SU`/`NU`.
 Base.Broadcast.broadcastable(u::AbstractUnitSystem) = Ref(u)
 
 """
     display_string(x) -> String
 
 Render `x` for human-facing display, spelling relative-unit tags out in full
-("0.6 p.u. in component base") where `show` prints the terse "0.6 DU". `DU`/`SU`
+("0.6 p.u. in component base") where `show` prints the terse "0.6 CU". `CU`/`SU`
 are convenient to type but are not standard terminology, so verbose output
 (e.g. a component's `text/plain` display) spells them out; terse contexts such
 as tabular cells keep the short tags.
@@ -277,7 +277,7 @@ display_string(q::RelativeQuantity) =
     string(_per_unit_string(q), " in ", _base_label(unit(q)))
 
 _per_unit_string(q::RelativeQuantity) = string(q.value, " p.u.")
-_base_label(::DeviceBaseUnit) = "component base"
+_base_label(::ComponentBaseUnit) = "component base"
 _base_label(::SystemBaseUnit) = "system base"
 
 function display_string(t::NamedTuple)

--- a/src/scenarios.jl
+++ b/src/scenarios.jl
@@ -25,7 +25,7 @@ A Discrete Scenario Based time series for a particular data field in a Component
   - `quantity_kind::Union{Nothing, String}`: optional label for the kind of physical
     quantity the values measure (e.g. `"ActivePower"`)
   - `unit_system::Union{Nothing, AbstractUnitSystem}`: optional declaration of the basis
-    the values are already expressed in (`NU`, `DU`, or `SU`)
+    the values are already expressed in (`NU`, `CU`, or `SU`)
   - `internal::InfrastructureSystemsInternal`
 
 See [`get_units`](@ref), [`get_quantity_kind`](@ref), [`get_unit_system`](@ref).
@@ -45,7 +45,7 @@ struct Scenarios{T, N} <: Forecast{T}
     units::Union{Nothing, String}
     "kind of physical quantity the values measure (e.g. `\"ActivePower\"`), or `nothing`"
     quantity_kind::Union{Nothing, String}
-    "unit system the values are already expressed in (`NU`/`DU`/`SU`), or `nothing`"
+    "unit system the values are already expressed in (`NU`/`CU`/`SU`), or `nothing`"
     unit_system::Union{Nothing, AbstractUnitSystem}
 end
 

--- a/src/single_time_series.jl
+++ b/src/single_time_series.jl
@@ -35,7 +35,7 @@ scalar-per-step case, `N >= 2` is multidimensional per-step values).
   - `quantity_kind::Union{Nothing, String}`: optional label for the kind of physical
     quantity the values measure (e.g. `"ActivePower"`)
   - `unit_system::Union{Nothing, AbstractUnitSystem}`: optional declaration of the basis
-    the values are already expressed in (`NU`, `DU`, or `SU`)
+    the values are already expressed in (`NU`, `CU`, or `SU`)
 
 See [`get_units`](@ref), [`get_quantity_kind`](@ref), [`get_unit_system`](@ref).
 """
@@ -52,7 +52,7 @@ struct SingleTimeSeries{T, N} <: StaticTimeSeries{T}
     units::Union{Nothing, String}
     "kind of physical quantity the values measure (e.g. `\"ActivePower\"`), or `nothing`"
     quantity_kind::Union{Nothing, String}
-    "unit system the values are already expressed in (`NU`/`DU`/`SU`), or `nothing`"
+    "unit system the values are already expressed in (`NU`/`CU`/`SU`), or `nothing`"
     unit_system::Union{Nothing, AbstractUnitSystem}
 end
 

--- a/src/units.jl
+++ b/src/units.jl
@@ -8,7 +8,7 @@ time_period_conversion(time_periods::Dict{String, <:Dates.Period}) =
 
 The default unit system for `owner`, used by unit-aware accessors when the caller does not
 pass a `units` argument. The IS fallback returns `nothing`, meaning "unspecified"; a domain
-package that gives `SU`/`DU`/`NU` meaning for its own owner types must add a method per
+package that gives `SU`/`CU`/`NU` meaning for its own owner types must add a method per
 type rather than redefine this generic.
 """
 default_units(::Any) = nothing

--- a/src/utils/generate_structs.jl
+++ b/src/utils/generate_structs.jl
@@ -64,9 +64,9 @@ end
 {{/has_null_values}}
 {{#accessors}}
 {{#needs_conversion}}
-{{#create_docstring}}\"\"\"Get [`{{struct_name}}`](@ref) `{{name}}` as a bare number in the requested `units` (e.g. `SU`, `DU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`{{accessor}}_unitful`](@ref).\"\"\"{{/create_docstring}}
+{{#create_docstring}}\"\"\"Get [`{{struct_name}}`](@ref) `{{name}}` as a bare number in the requested `units` (e.g. `SU`, `CU`; domain-provided units such as `MW` are also accepted when the owning domain package has registered a `_strip_units` method for the returned quantity type). Returns a bare number only when such a method is registered; otherwise returns the quantity wrapper. For the unit-bearing value see [`{{accessor}}_unitful`](@ref).\"\"\"{{/create_docstring}}
 {{accessor}}(value::{{struct_name}}, units) = InfrastructureSystems._strip_units(get_value(value, Val(:{{name}}), Val({{conversion_unit}}), units))
-{{#create_docstring}}\"\"\"Get [`{{struct_name}}`](@ref) `{{name}}` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `DU`, `MW`). For a bare number see [`{{accessor}}`](@ref).\"\"\"{{/create_docstring}}
+{{#create_docstring}}\"\"\"Get [`{{struct_name}}`](@ref) `{{name}}` as a unit-bearing quantity in the requested `units` (e.g. `SU`, `CU`, `MW`). For a bare number see [`{{accessor}}`](@ref).\"\"\"{{/create_docstring}}
 {{accessor}}_unitful(value::{{struct_name}}, units) = get_value(value, Val(:{{name}}), Val({{conversion_unit}}), units)
 InfrastructureSystems.display_units_arg(::typeof({{accessor}}), ::{{units_type_sig}}){{#units_bound}} where {T <: {{units_bound}}}{{/units_bound}} = InfrastructureSystems.{{display_units}}
 InfrastructureSystems.display_units_arg(::typeof({{accessor}}_unitful), ::{{units_type_sig}}){{#units_bound}} where {T <: {{units_bound}}}{{/units_bound}} = InfrastructureSystems.{{display_units}}

--- a/src/utils/print_pt.jl
+++ b/src/utils/print_pt.jl
@@ -142,7 +142,7 @@ end
 """
     show_components(io, components, component_type, additional_columns = []; units = nothing, kwargs...)
 
-Vector-form `additional_columns` accepts `units` (e.g. `SU`, `DU`, or a
+Vector-form `additional_columns` accepts `units` (e.g. `SU`, `CU`, or a
 domain-provided unit like `MW`) to force every unit-converted column to
 display in that unit system instead of each column's own `display_units_arg`
 default. To vary the unit by column, pass a mapping from column name to unit

--- a/src/value_curve_with_units.jl
+++ b/src/value_curve_with_units.jl
@@ -20,7 +20,7 @@ get_value_curve(curve::ValueCurveWithUnits) = curve.value_curve
 """
 Get the units marker for the power axes of the curve as an instance of the
 second type parameter (e.g. `NaturalUnit()`, `SystemBaseUnit()`,
-`DeviceBaseUnit()`). Always the units of the x-axis; also the units of the y-axis when
+`ComponentBaseUnit()`). Always the units of the x-axis; also the units of the y-axis when
 [`y_axis_power_dimension`](@ref) is nonzero, as it is for a [`LossCurve`](@ref).
 """
 get_power_units(::ValueCurveWithUnits{T, U}) where {T, U} = U()
@@ -115,7 +115,7 @@ _unit_system_instance(name::AbstractString) = _unit_system_instance(String(name)
 function _unit_system_instance(name::String)
     name == "NaturalUnit" && return NaturalUnit()
     name == "SystemBaseUnit" && return SystemBaseUnit()
-    name == "DeviceBaseUnit" && return DeviceBaseUnit()
+    name == "ComponentBaseUnit" && return ComponentBaseUnit()
     throw(ArgumentError("$name is not a known AbstractUnitSystem"))
 end
 

--- a/test/test_cost_functions.jl
+++ b/test/test_cost_functions.jl
@@ -325,8 +325,8 @@ end
         IS.CostCurve(zero(IS.InputOutputCurve), IS.SystemBaseUnit()),
     ) == IS.SystemBaseUnit()
     @test IS.get_power_units(
-        IS.FuelCurve(zero(IS.InputOutputCurve), IS.DeviceBaseUnit(), 1.0),
-    ) == IS.DeviceBaseUnit()
+        IS.FuelCurve(zero(IS.InputOutputCurve), IS.ComponentBaseUnit(), 1.0),
+    ) == IS.ComponentBaseUnit()
 
     @test IS.get_vom_cost(cc) == IS.LinearCurve(0.0)
     @test IS.get_vom_cost(fc) == IS.LinearCurve(0.0)
@@ -470,7 +470,7 @@ end
 
 @testset "CostCurve/FuelCurve serialize round-trip all unit systems" begin
     vc = IS.InputOutputCurve(IS.QuadraticFunctionData(1.0, 2.0, 3.0))
-    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit())
+    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.ComponentBaseUnit())
         cc = IS.CostCurve(vc, U)
         cc_rt = IS.deserialize(IS.CostCurve, IS.serialize(cc))
         @test cc_rt == cc
@@ -485,7 +485,7 @@ end
 
 @testset "unit-system string decode" begin
     @test IS._unit_system_instance("SystemBaseUnit") == IS.SystemBaseUnit()
-    @test IS._unit_system_instance("DeviceBaseUnit") == IS.DeviceBaseUnit()
+    @test IS._unit_system_instance("ComponentBaseUnit") == IS.ComponentBaseUnit()
     @test IS._unit_system_instance("NaturalUnit") == IS.NaturalUnit()
     @test_throws ArgumentError IS._unit_system_instance("bogus")
     # Legacy IS3 `UnitSystem` enum value-names are no longer accepted.
@@ -496,7 +496,7 @@ end
 @testset "zero preserves unit system (PVC-002)" begin
     vc = IS.InputOutputCurve(IS.LinearFunctionData(1.0, 1.0))
     # Full 6-combo matrix: 3 unit systems × {CostCurve, FuelCurve}
-    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit())
+    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.ComponentBaseUnit())
         c = IS.CostCurve(vc, U)
         @test IS.get_power_units(zero(c)) == U
         f = IS.FuelCurve(vc, U, 3.0)
@@ -513,7 +513,7 @@ end
     # would collide across unit systems
     curves = [
         IS.CostCurve(vc, U)
-        for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit())
+        for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.ComponentBaseUnit())
     ]
     @test length(unique(hash.(curves))) == length(curves)
     # Same unit system still satisfies the isequal => hash contract, including the
@@ -562,14 +562,14 @@ end
     @test_throws Union{MethodError, UndefKeywordError} IS.LossCurve(; value_curve = vc)
     @test_throws MethodError zero(IS.LossCurve)
     # ...but a curve that already has a base can hand it to its own zero
-    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit())
+    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.ComponentBaseUnit())
         @test IS.get_power_units(zero(IS.LossCurve(vc, U))) == U
     end
 end
 
 @testset "LossCurve serialize round-trip all unit systems" begin
     vc = IS.InputOutputCurve(IS.LinearFunctionData(1.5, 0.25))
-    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit())
+    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.ComponentBaseUnit())
         lc = IS.LossCurve(vc, U)
         data = IS.serialize(lc)
         @test data["power_units"] == string(nameof(typeof(U)))
@@ -591,7 +591,7 @@ end
 # = 1, i.e. P already in MW) gives `x_from = (base_to / base_from) * x_to`.
 _x_base(::IS.NaturalUnit, _, _) = 1.0
 _x_base(::IS.SystemBaseUnit, sb, _) = sb
-_x_base(::IS.DeviceBaseUnit, _, db) = db
+_x_base(::IS.ComponentBaseUnit, _, db) = db
 
 _convert(curve, to, sb, db) = IS.convert_power_units(
     curve,
@@ -611,13 +611,13 @@ _convert(curve, to, sb, db) = IS.convert_power_units(
     # only the constant term, which is a bare power, rescales.
     @test IS.get_function_data(su) == IS.LinearFunctionData(0.05, 2.0 / sys_base)
 
-    du = _convert(lc, IS.DeviceBaseUnit(), sys_base, dev_base)
+    du = _convert(lc, IS.ComponentBaseUnit(), sys_base, dev_base)
     @test IS.get_function_data(du) == IS.LinearFunctionData(0.05, 2.0 / dev_base)
 
-    # SU <-> DU directly, and every round trip
-    @test _convert(su, IS.DeviceBaseUnit(), sys_base, dev_base) == du
-    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit()),
-        V in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.DeviceBaseUnit())
+    # SU <-> CU directly, and every round trip
+    @test _convert(su, IS.ComponentBaseUnit(), sys_base, dev_base) == du
+    for U in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.ComponentBaseUnit()),
+        V in (IS.NaturalUnit(), IS.SystemBaseUnit(), IS.ComponentBaseUnit())
 
         start = _convert(lc, U, sys_base, dev_base)
         there = _convert(start, V, sys_base, dev_base)
@@ -789,11 +789,11 @@ end
 @testset "convert_power_units for CostCurve and FuelCurve" begin
     sb, db = 100.0, 50.0
     # The cost of producing a given *physical* quantity must not change with the units
-    # it is expressed in: x_NU MW == x_NU/sb system-base pu == x_NU/db device-base pu.
-    denominators = Dict(IS.NU => 1.0, IS.SU => sb, IS.DU => db)
+    # it is expressed in: x_NU MW == x_NU/sb system-base pu == x_NU/db component-base pu.
+    denominators = Dict(IS.NU => 1.0, IS.SU => sb, IS.CU => db)
 
     cc = IS.CostCurve(IS.QuadraticCurve(2.0, 3.0, 4.0), IS.NU, IS.LinearCurve(7.0, 1.0))
-    for to in (IS.NU, IS.SU, IS.DU)
+    for to in (IS.NU, IS.SU, IS.CU)
         converted = _convert(cc, to, sb, db)
         @test converted isa IS.CostCurve
         @test IS.get_power_units(converted) == to
@@ -805,7 +805,7 @@ end
     end
 
     # Round trips through every intermediate unit system return the original curve
-    for mid in (IS.NU, IS.SU, IS.DU)
+    for mid in (IS.NU, IS.SU, IS.CU)
         there = _convert(cc, mid, sb, db)
         back = _convert(there, IS.NU, sb, db)
         @test fd_approx(IS.get_function_data(back), IS.get_function_data(cc))
@@ -847,7 +847,7 @@ end
     # duration and its y-axis a fuel quantity, so a change of power units must not touch
     # it. Guards against it being swept up with the power-indexed fields.
     @test IS.get_startup_fuel_offtake(fc_su) == IS.get_startup_fuel_offtake(fc)
-    for to in (IS.NU, IS.SU, IS.DU)
+    for to in (IS.NU, IS.SU, IS.CU)
         @test IS.get_startup_fuel_offtake(_convert(fc, to, sb, db)) ==
               IS.get_startup_fuel_offtake(fc)
     end
@@ -882,7 +882,7 @@ end
     @test IS.get_vom_cost(cc) == IS.get_vom_cost(fc)
 
     # The unit system is preserved
-    for units in (IS.NU, IS.SU, IS.DU)
+    for units in (IS.NU, IS.SU, IS.CU)
         @test IS.get_power_units(
             IS.CostCurve(IS.FuelCurve(IS.LinearCurve(5.0), units, 2.0)),
         ) == units

--- a/test/test_openapi_associations.jl
+++ b/test/test_openapi_associations.jl
@@ -258,7 +258,7 @@ end
             ),
         ),
     )
-    for (basis, spelling) in ((IS.NU, "NATURAL_UNITS"), (IS.DU, "COMPONENT_BASE"))
+    for (basis, spelling) in ((IS.NU, "NATURAL_UNITS"), (IS.CU, "COMPONENT_BASE"))
         IS.add_time_series!(
             data, component,
             IS.SingleTimeSeries(

--- a/test/test_printing.jl
+++ b/test/test_printing.jl
@@ -108,9 +108,9 @@ end
     @test occursin("SU", text)
 
     # An explicit `units` override wins over the trait default.
-    IS.show_components(io, sys.components, IS.TestComponent, [:val]; units = IS.DU)
+    IS.show_components(io, sys.components, IS.TestComponent, [:val]; units = IS.CU)
     text = String(take!(io))
-    @test occursin("DU", text)
+    @test occursin("CU", text)
     @test !occursin(r"\bSU\b", text)
 
     # Column order is preserved (not alphabetized) for Vector-form columns,
@@ -129,10 +129,10 @@ end
         sys.components,
         IS.TestComponent,
         [:val, :val2];
-        units = Dict(:val => IS.DU),
+        units = Dict(:val => IS.CU),
     )
     text = String(take!(io))
-    @test occursin("DU", text)
+    @test occursin("CU", text)
     @test !occursin(r"\bSU\b", text)
 
     IS.show_components(
@@ -140,15 +140,15 @@ end
         sys.components,
         IS.TestComponent,
         [:val];
-        units = Dict(:val2 => IS.DU),
+        units = Dict(:val2 => IS.CU),
     )
     text = String(take!(io))
     @test occursin("SU", text)
 
     # NamedTuple mappings work the same way.
-    IS.show_components(io, sys.components, IS.TestComponent, [:val]; units = (val = IS.DU,))
+    IS.show_components(io, sys.components, IS.TestComponent, [:val]; units = (val = IS.CU,))
     text = String(take!(io))
-    @test occursin("DU", text)
+    @test occursin("CU", text)
 
     # `units` is ignored (not an error) for Dict-form additional_columns.
     IS.show_components(
@@ -156,7 +156,7 @@ end
         sys.components,
         IS.TestComponent,
         Dict("val" => x -> x.val * 10);
-        units = IS.DU,
+        units = IS.CU,
     )
     text = String(take!(io))
     @test occursin("val", text)

--- a/test/test_relative_units.jl
+++ b/test/test_relative_units.jl
@@ -1,7 +1,7 @@
 @testset "RelativeQuantity construction and arithmetic" begin
-    a = 0.6 * IS.DU
-    b = 0.4 * IS.DU
-    @test a isa IS.RelativeQuantity{Float64, IS.DeviceBaseUnit}
+    a = 0.6 * IS.CU
+    b = 0.4 * IS.CU
+    @test a isa IS.RelativeQuantity{Float64, IS.ComponentBaseUnit}
     @test IS._strip_units(a + b) ≈ 1.0
     @test IS._strip_units(a - b) ≈ 0.2
     @test IS._strip_units(-a) ≈ -0.6
@@ -12,67 +12,67 @@
 end
 
 @testset "RelativeQuantity comparisons" begin
-    @test 0.6 * IS.DU < 0.7 * IS.DU
-    @test 0.6 * IS.DU <= 0.6 * IS.DU
-    @test isapprox(0.6 * IS.DU, 0.60000001 * IS.DU; atol = 1e-6)
-    @test isless(0.6 * IS.DU, 0.7 * IS.DU)
+    @test 0.6 * IS.CU < 0.7 * IS.CU
+    @test 0.6 * IS.CU <= 0.6 * IS.CU
+    @test isapprox(0.6 * IS.CU, 0.60000001 * IS.CU; atol = 1e-6)
+    @test isless(0.6 * IS.CU, 0.7 * IS.CU)
 end
 
-@testset "DU and SU cannot be mixed" begin
+@testset "CU and SU cannot be mixed" begin
     # Cross-unit operations now throw ArgumentError with a clear message
     # instead of a cryptic ErrorException from Base's promotion path.
-    @test_throws ArgumentError 0.6 * IS.DU + 0.4 * IS.SU
-    @test_throws ArgumentError 0.6 * IS.DU == 0.4 * IS.SU
-    @test_throws ArgumentError 0.6 * IS.DU < 0.4 * IS.SU
+    @test_throws ArgumentError 0.6 * IS.CU + 0.4 * IS.SU
+    @test_throws ArgumentError 0.6 * IS.CU == 0.4 * IS.SU
+    @test_throws ArgumentError 0.6 * IS.CU < 0.4 * IS.SU
     # isapprox lives outside the @eval loop (needs kwargs) — most regression-prone
-    @test_throws ArgumentError isapprox(0.6 * IS.DU, 0.6 * IS.SU)
+    @test_throws ArgumentError isapprox(0.6 * IS.CU, 0.6 * IS.SU)
     # subtraction and isless are inside the @eval loop — verify they also throw
-    @test_throws ArgumentError 0.6 * IS.DU - 0.4 * IS.SU
-    @test_throws ArgumentError isless(0.6 * IS.DU, 0.7 * IS.SU)
+    @test_throws ArgumentError 0.6 * IS.CU - 0.4 * IS.SU
+    @test_throws ArgumentError isless(0.6 * IS.CU, 0.7 * IS.SU)
 end
 
 @testset "tagged-vs-untagged mixing raises ArgumentError" begin
     # RelativeQuantity <: Number but NOT <: Real: the (RQ, Real) and (Real, RQ)
     # erroring methods use Real to avoid any ambiguity with (RQ, RQ) pairs.
-    @test_throws ArgumentError 0.6 * IS.DU == 0.5
-    @test_throws ArgumentError 0.5 + 0.6 * IS.DU
-    @test_throws ArgumentError 0.6 * IS.DU - 0.5
+    @test_throws ArgumentError 0.6 * IS.CU == 0.5
+    @test_throws ArgumentError 0.5 + 0.6 * IS.CU
+    @test_throws ArgumentError 0.6 * IS.CU - 0.5
     # Same-unit comparison must still work (more-specific dispatch is not disrupted)
-    @test (0.6 * IS.DU == 0.6 * IS.DU)
+    @test (0.6 * IS.CU == 0.6 * IS.CU)
 end
 
 @testset "RelativeQuantity zero and one" begin
-    @test zero(IS.RelativeQuantity{Float64, IS.DeviceBaseUnit}) == 0.0 * IS.DU
-    @test one(IS.RelativeQuantity{Float64, IS.DeviceBaseUnit}) == 1.0 * IS.DU
+    @test zero(IS.RelativeQuantity{Float64, IS.ComponentBaseUnit}) == 0.0 * IS.CU
+    @test one(IS.RelativeQuantity{Float64, IS.ComponentBaseUnit}) == 1.0 * IS.CU
 end
 
 @testset "RelativeQuantity display" begin
-    @test sprint(show, 0.6 * IS.DU) == "0.6 DU"
+    @test sprint(show, 0.6 * IS.CU) == "0.6 CU"
     @test sprint(show, 0.3 * IS.SU) == "0.3 SU"
-    @test sprint(show, IS.DU) == "DU"
+    @test sprint(show, IS.CU) == "CU"
     @test sprint(show, IS.SU) == "SU"
     @test sprint(show, IS.NU) == "NU"
 end
 
 @testset "unit markers broadcast as scalars" begin
     # Regression for #629: without `broadcastable`, Base's fallback tries to
-    # `collect` the marker and fails with `no method matching length(::DeviceBaseUnit)`.
+    # `collect` the marker and fails with `no method matching length(::ComponentBaseUnit)`.
     scale(x, ::IS.AbstractUnitSystem) = x
-    for units in (IS.DU, IS.SU, IS.NU)
+    for units in (IS.CU, IS.SU, IS.NU)
         @test scale.([1.0, 2.0, 3.0], units) == [1.0, 2.0, 3.0]
     end
     # an array of markers is still broadcast element-wise
-    @test ([IS.DU, IS.SU] .=== IS.DU) == [true, false]
+    @test ([IS.CU, IS.SU] .=== IS.CU) == [true, false]
 end
 
 @testset "Double-tagging is rejected" begin
-    @test_throws ArgumentError (0.6 * IS.DU) * IS.SU
-    @test_throws ArgumentError IS.SU * (0.6 * IS.DU)
+    @test_throws ArgumentError (0.6 * IS.CU) * IS.SU
+    @test_throws ArgumentError IS.SU * (0.6 * IS.CU)
 end
 
 @testset "RelativeQuantity hash matches ==" begin
-    q1 = 1.0 * IS.DU
-    q2 = 1 * IS.DU
+    q1 = 1.0 * IS.CU
+    q2 = 1 * IS.CU
     @test q1 == q2
     @test hash(q1) == hash(q2)
     d = Dict(q1 => "a")
@@ -81,16 +81,16 @@ end
 end
 
 @testset "RelativeQuantity Number interface completeness" begin
-    q = 0.6 * IS.DU
+    q = 0.6 * IS.CU
 
     @testset "instance zero/one and predicates" begin
-        @test zero(q) == 0.0 * IS.DU
-        @test one(q) == 1.0 * IS.DU
+        @test zero(q) == 0.0 * IS.CU
+        @test one(q) == 1.0 * IS.CU
         @test !iszero(q)
         @test iszero(zero(q))
         @test isfinite(q)
         @test !isnan(q)
-        @test isnan(IS.RelativeQuantity(NaN, IS.DU))
+        @test isnan(IS.RelativeQuantity(NaN, IS.CU))
         @test !isfinite(IS.RelativeQuantity(Inf, IS.SU))
         @test isinf(IS.RelativeQuantity(Inf, IS.SU))
         @test abs(-q) == q
@@ -102,20 +102,20 @@ end
     end
 
     @testset "isequal is total for container semantics" begin
-        @test isequal(0.6 * IS.DU, 0.6 * IS.DU)
-        @test !isequal(0.6 * IS.DU, 0.6 * IS.SU)
+        @test isequal(0.6 * IS.CU, 0.6 * IS.CU)
+        @test !isequal(0.6 * IS.CU, 0.6 * IS.SU)
         @test !isequal(q, 0.6)
         @test !isequal(0.6, q)
-        d = Dict((0.6 * IS.DU) => 1)
+        d = Dict((0.6 * IS.CU) => 1)
         @test !haskey(d, 0.6 * IS.SU)
-        s = Set([0.6 * IS.DU])
+        s = Set([0.6 * IS.CU])
         @test !(0.6 * IS.SU in s)
     end
 
     @testset "products of tagged quantities error clearly" begin
         @test_throws ArgumentError q * q
         @test_throws ArgumentError q^2
-        @test_throws ArgumentError q / (0.5 * IS.DU)
+        @test_throws ArgumentError q / (0.5 * IS.CU)
     end
 end
 
@@ -149,7 +149,7 @@ end
     end
 end
 @testset "display_string spells per-unit tags out" begin
-    @test IS.display_string(0.6 * IS.DU) == "0.6 p.u. in component base"
+    @test IS.display_string(0.6 * IS.CU) == "0.6 p.u. in component base"
     @test IS.display_string(0.3 * IS.SU) == "0.3 p.u. in system base"
     # Untagged values render exactly as `print` would.
     @test IS.display_string(1.5) == "1.5"
@@ -159,7 +159,7 @@ end
     @test IS.display_string((min = 0.0 * IS.SU, max = 2.5 * IS.SU)) ==
           "(min = 0.0 p.u., max = 2.5 p.u.) in system base"
     # Mixed bases have nothing to factor out, so each element is spelled out.
-    @test IS.display_string((min = 0.0 * IS.SU, max = 2.5 * IS.DU)) ==
+    @test IS.display_string((min = 0.0 * IS.SU, max = 2.5 * IS.CU)) ==
           "(min = 0.0 p.u. in system base, max = 2.5 p.u. in component base)"
     # So does a tuple that is not all tagged.
     @test IS.display_string((min = 0.0 * IS.SU, max = 2.5)) ==

--- a/test/test_time_series_units.jl
+++ b/test/test_time_series_units.jl
@@ -188,19 +188,19 @@ end
 
     sts = IS.SingleTimeSeries(
         "sts", initial_time, resolution, rand(24);
-        units = "MW", quantity_kind = "ActivePower", unit_system = IS.DU,
+        units = "MW", quantity_kind = "ActivePower", unit_system = IS.CU,
     )
-    @test descriptors(sts) == ("ActivePower", IS.DU)
+    @test descriptors(sts) == ("ActivePower", IS.CU)
     IS.add_time_series!(sys, component, sts)
     @test descriptors(IS.get_time_series(IS.SingleTimeSeries, component, "sts")) ==
-          ("ActivePower", IS.DU)
+          ("ActivePower", IS.CU)
 
     # A sliced read describes the same values, so it keeps both.
     sliced = IS.get_time_series(
         IS.SingleTimeSeries, component, "sts";
         start_time = initial_time + Dates.Hour(2), len = 4,
     )
-    @test descriptors(sliced) == ("ActivePower", IS.DU)
+    @test descriptors(sliced) == ("ActivePower", IS.CU)
 
     stamps = [initial_time, initial_time + Dates.Hour(1), initial_time + Dates.Hour(4)]
     nts = IS.NonSequentialTimeSeries(
@@ -216,11 +216,11 @@ end
         other_time => rand(horizon_count),
     )
     det = IS.Deterministic(
-        "det", one_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.DU,
+        "det", one_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.CU,
     )
     IS.add_time_series!(sys, component, det)
     @test descriptors(IS.get_time_series(IS.Deterministic, component, "det")) ==
-          ("ActivePower", IS.DU)
+          ("ActivePower", IS.CU)
 
     two_dim = SortedDict(
         initial_time => rand(horizon_count, 3),
@@ -235,11 +235,11 @@ end
           ("ActivePower", IS.NU)
 
     scen = IS.Scenarios(
-        "scen", two_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.DU,
+        "scen", two_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.CU,
     )
     IS.add_time_series!(sys, component, scen)
     @test descriptors(IS.get_time_series(IS.Scenarios, component, "scen")) ==
-          ("ActivePower", IS.DU)
+          ("ActivePower", IS.CU)
 end
 
 @testset "Test unset unit_system stays unspecified rather than NaturalUnit" begin
@@ -275,9 +275,9 @@ end
 
     sts = IS.SingleTimeSeries(
         "sts", initial_time, resolution, rand(24);
-        quantity_kind = "ActivePower", unit_system = IS.DU,
+        quantity_kind = "ActivePower", unit_system = IS.CU,
     )
-    @test descriptors(IS.SingleTimeSeries(sts, "other_name")) == ("ActivePower", IS.DU)
+    @test descriptors(IS.SingleTimeSeries(sts, "other_name")) == ("ActivePower", IS.CU)
 
     stamps = [initial_time, initial_time + Dates.Hour(1), initial_time + Dates.Hour(4)]
     nts = IS.NonSequentialTimeSeries(
@@ -290,10 +290,10 @@ end
         other_time => rand(horizon_count),
     )
     det = IS.Deterministic(
-        "det", one_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.DU,
+        "det", one_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.CU,
     )
-    @test descriptors(IS.Deterministic(det, "other_name")) == ("ActivePower", IS.DU)
-    @test descriptors(IS.Deterministic(det, one_dim)) == ("ActivePower", IS.DU)
+    @test descriptors(IS.Deterministic(det, "other_name")) == ("ActivePower", IS.CU)
+    @test descriptors(IS.Deterministic(det, one_dim)) == ("ActivePower", IS.CU)
 
     two_dim = SortedDict(
         initial_time => rand(horizon_count, 3),
@@ -301,14 +301,14 @@ end
     )
     prob = IS.Probabilistic(
         "prob", two_dim, [0.1, 0.5, 0.9], resolution;
-        quantity_kind = "ActivePower", unit_system = IS.DU,
+        quantity_kind = "ActivePower", unit_system = IS.CU,
     )
-    @test descriptors(IS.Probabilistic(prob, "other_name")) == ("ActivePower", IS.DU)
+    @test descriptors(IS.Probabilistic(prob, "other_name")) == ("ActivePower", IS.CU)
 
     scen = IS.Scenarios(
-        "scen", two_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.DU,
+        "scen", two_dim, resolution; quantity_kind = "ActivePower", unit_system = IS.CU,
     )
-    @test descriptors(IS.Scenarios(scen, "other_name")) == ("ActivePower", IS.DU)
+    @test descriptors(IS.Scenarios(scen, "other_name")) == ("ActivePower", IS.CU)
 end
 
 @testset "Test SystemBaseUnit is rejected by the store rather than downgraded" begin
@@ -319,7 +319,7 @@ end
     resolution = Dates.Hour(1)
 
     # IS names three bases; the store represents two. A system-base series is
-    # refused at the boundary instead of being written as device base or dropped
+    # refused at the boundary instead of being written as component base or dropped
     # to unspecified -- either would misreport the basis of every value to the
     # next reader, unrecoverably.
     ts = IS.SingleTimeSeries(
@@ -329,7 +329,7 @@ end
     @test_throws ArgumentError IS.add_time_series!(sys, component, ts)
 
     # The two the store does represent go through.
-    for (name, marker) in (("du", IS.DU), ("nu", IS.NU))
+    for (name, marker) in (("cu", IS.CU), ("nu", IS.NU))
         ok = IS.SingleTimeSeries(
             name, initial_time, resolution, rand(24); unit_system = marker,
         )


### PR DESCRIPTION
## Summary

`DU`/`DeviceBaseUnit` become `CU`/`ComponentBaseUnit`.

The marker has always meant "normalized to the component's own base": `_base_label` already spelled it out as `"component base"`, and `_to_store_unit_system` already mapped it to `InfraStore.ComponentBase`. "Device" was the odd term out — IS is domain-agnostic and has no notion of a device, and `component` is the word it uses everywhere else.

## What changed

- `DeviceBaseUnit` → `ComponentBaseUnit`, `DU` → `CU` (type, singleton, exports, `show` output).
- `convert_cost_coefficient`'s `device_base_power` argument → `component_base_power`.
- The serialized `power_units` spelling in `ProductionVariableCostCurve`: `"DeviceBaseUnit"` → `"ComponentBaseUnit"`.
- Docstrings, the struct-generator getter templates, and prose throughout.

## Breaking

Yes, deliberately. Downstream call sites (`IS.DU`, `IS.DeviceBaseUnit`) must be updated, and cost curves serialized with the old `power_units` spelling will no longer deserialize. No shims or deserialization aliases, per the psy6-line policy — regenerate old serialized systems instead.

The PowerSystems.jl counterpart is a companion PR.

## Testing

- Full suite: 9747 tests pass.
- Docs build cleanly (only pre-existing warnings).
- Formatter run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M1gJzVgDkhehB9oarwPgD